### PR TITLE
feat: Add settings section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@vitejs/plugin-react": "^4.3.1",
         "classnames": "^2.5.1",
         "cross-env": "7.0.3",
-        "decentraland-ui2": "^0.3.3",
+        "decentraland-ui2": "^0.5.0",
         "electron": "31.1.0",
         "electron-builder": "24.13.3",
         "eslint": "8.57.0",
@@ -1228,9 +1228,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.4.tgz",
-      "integrity": "sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+      "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5171,13 +5171,13 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.15",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.15.tgz",
-      "integrity": "sha512-nbo7yPhtKJkdf9kcVOF8JZHPZTmqXjJ/tI0bdWgHg5tp9AnIN4Y7f7wm9T+0SyGYJk76+GYZ8Q5XaTYAsUHN0Q==",
+      "version": "7.2.16",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.16.tgz",
+      "integrity": "sha512-qI8TV3M7ShITEEc8Ih15A2vLzZGLhD+/UPNwck/hcls2gwg7dyRjNGXcQYHKLB5Q7PuTRfrTkAoPa2VV1s67Ag==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -9382,13 +9382,13 @@
       }
     },
     "node_modules/decentraland-ui2": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-0.3.3.tgz",
-      "integrity": "sha512-4FNDkHRVeXwpyDfZhRsbTyiFV6B2VxxqXHm6xb95cKq9N4yLOi54pQlmEMCAwPYY/ldTNp8twuvynwyWL4weiQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-0.5.0.tgz",
+      "integrity": "sha512-3g/veepVO7v29aPXLR8WU2YETWCI6mGeXPnzZQhp5tzMxebaA94d2u8VDqrF7/gC/8T3Ubcb8XD6hKL+jPV+Lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/schemas": "^11.10.5",
+        "@dcl/schemas": "^13.9.0",
         "@dcl/ui-env": "^1.5.1",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
@@ -9401,6 +9401,19 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-tile-map": "^0.4.1"
+      }
+    },
+    "node_modules/decentraland-ui2/node_modules/@dcl/schemas": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-13.9.0.tgz",
+      "integrity": "sha512-t8t043TfxIpXqzR1mNehD4d6YFfbauq5ICoLL2Y72emSiu8q0bCI3pNCoaN0Ea6s7n+6AVv39Q8TvzWUneRBpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
       }
     },
     "node_modules/decentraland-ui2/node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "classnames": "^2.5.1",
     "cross-env": "7.0.3",
-    "decentraland-ui2": "^0.3.3",
+    "decentraland-ui2": "^0.5.0",
     "electron": "31.1.0",
     "electron-builder": "24.13.3",
     "eslint": "8.57.0",

--- a/packages/main/src/modules/bin.ts
+++ b/packages/main/src/modules/bin.ts
@@ -1,6 +1,5 @@
 import log from 'electron-log/main';
 import fs from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { app, utilityProcess, shell } from 'electron';
 import path from 'path';
 import treeKill from 'tree-kill';
@@ -167,49 +166,6 @@ export async function install() {
   } catch (error: any) {
     log.error('[Install] Failed to install node and npm binaries:', error.message);
     installed.reject(error);
-    throw error;
-  }
-}
-
-export async function npmPackageOutdated(projectPath: string, packageName: string = '') {
-  const normalizedPath = path.normalize(projectPath);
-  const nodeModulesPath = path.join(normalizedPath, 'node_modules');
-
-  if (!existsSync(nodeModulesPath)) {
-    // For projects without node_modules, install dependencies before checking for outdated packages
-    await installNpmPackages(projectPath);
-  }
-
-  log.info(`[PackageOutdated] Verifying if the package ${packageName} is outdated...`);
-
-  try {
-    const _npmPackageOutdated = run('npm', 'npm', {
-      args: ['outdated', packageName, '--depth=0', '--json'],
-      cwd: projectPath,
-    });
-    log.info(`[PackageOutdated] Package ${packageName} is outdated...`);
-    await _npmPackageOutdated.waitFor(new RegExp(packageName), /\{\}/);
-    return true;
-  } catch (_) {
-    log.info(`[PackageOutdated] Package ${packageName} is up to date...${normalizedPath}`);
-    return false;
-  }
-}
-
-export async function installNpmPackages(projectPath: string, packageName?: string) {
-  try {
-    log.info(`[InstallNpmPackages] Installing npm package${packageName ? ` ${packageName}` : 's'}`);
-
-    const npmInstall = run('npm', 'npm', {
-      args: ['install', '--loglevel', 'error', ...(packageName ? ['--save', packageName] : [])],
-      cwd: projectPath,
-    });
-
-    await npmInstall.waitFor(/added \d+ package|up to date|changed \d+ package/);
-
-    log.info('[InstallNpmPackages] Installation complete!');
-  } catch (error: any) {
-    log.error('[InstallNpmPackages] Failed to install npm package:', error.message);
     throw error;
   }
 }

--- a/packages/main/src/modules/ipc.ts
+++ b/packages/main/src/modules/ipc.ts
@@ -23,6 +23,12 @@ export function initIpc() {
 
   // bin
   handle('bin.install', () => bin.install());
+  handle('bin.installNpmPackages', (_event, projectPath, packageName) =>
+    bin.installNpmPackages(projectPath, packageName),
+  );
+  handle('bin.npmPackageOutdated', (_event, projectPath, packageName) =>
+    bin.npmPackageOutdated(projectPath, packageName),
+  );
   handle('bin.code', (_event, path) => bin.code(path));
 
   // analytics

--- a/packages/main/src/modules/ipc.ts
+++ b/packages/main/src/modules/ipc.ts
@@ -23,12 +23,6 @@ export function initIpc() {
 
   // bin
   handle('bin.install', () => bin.install());
-  handle('bin.installNpmPackages', (_event, projectPath, packageName) =>
-    bin.installNpmPackages(projectPath, packageName),
-  );
-  handle('bin.npmPackageOutdated', (_event, projectPath, packageName) =>
-    bin.npmPackageOutdated(projectPath, packageName),
-  );
   handle('bin.code', (_event, path) => bin.code(path));
 
   // analytics
@@ -37,5 +31,8 @@ export function initIpc() {
   handle('analytics.getAnonymousId', () => analytics.getAnonymousId());
 
   // npm
-  handle('npm.install', (_event, path) => npm.install(path));
+  handle('npm.install', (_event, path, packageName) => npm.install(path, packageName));
+  handle('npm.packageOutdated', (_event, path, packageName) =>
+    npm.packageOutdated(path, packageName),
+  );
 }

--- a/packages/main/src/modules/npm.ts
+++ b/packages/main/src/modules/npm.ts
@@ -21,13 +21,14 @@ export async function packageOutdated(_path: string, packageName: string) {
 
   try {
     const npmOutdated = run('npm', 'npm', {
-      args: ['outdated', packageName, '--depth=0', '--json'],
+      args: ['outdated', packageName, '--depth=0'],
       cwd: _path,
     });
-    // If the npm outdated commands returns "{}", the package is updated otherwise, it returns a JSON object with outdated package versions
-    await npmOutdated.waitFor(new RegExp(packageName), /\{\}/);
-    return true;
-  } catch (_) {
+
+    // If the exit code is 0, the package is up to date, otherwise it's outdated
+    await npmOutdated.wait();
     return false;
+  } catch (_) {
+    return true;
   }
 }

--- a/packages/main/src/modules/npm.ts
+++ b/packages/main/src/modules/npm.ts
@@ -1,6 +1,33 @@
+import path from 'node:path';
+import { existsSync } from 'node:fs';
 import { run } from './bin';
 
-export async function install(path: string) {
-  const installCommand = run('npm', 'npm', { args: ['install', '--loglevel', 'error'], cwd: path });
+export async function install(path: string, packageName?: string) {
+  const installCommand = run('npm', 'npm', {
+    args: ['install', '--loglevel', 'error', ...(packageName ? ['--save', packageName] : [])],
+    cwd: path,
+  });
   await installCommand.wait();
+}
+
+export async function packageOutdated(_path: string, packageName: string) {
+  const normalizedPath = path.normalize(_path);
+  const nodeModulesPath = path.join(normalizedPath, 'node_modules');
+
+  if (!existsSync(nodeModulesPath)) {
+    // For projects without node_modules, install dependencies before checking for outdated packages
+    await install(_path);
+  }
+
+  try {
+    const npmOutdated = run('npm', 'npm', {
+      args: ['outdated', packageName, '--depth=0', '--json'],
+      cwd: _path,
+    });
+    // If the npm outdated commands returns "{}", the package is updated otherwise, it returns a JSON object with outdated package versions
+    await npmOutdated.waitFor(new RegExp(packageName), /\{\}/);
+    return true;
+  } catch (_) {
+    return false;
+  }
 }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -4,3 +4,4 @@ export * as workspace from './modules/workspace';
 export * as fs from './modules/fs';
 export * as analytics from './modules/analytics';
 export * as npm from './modules/npm';
+export * as settings from './modules/settings';

--- a/packages/preload/src/modules/npm.ts
+++ b/packages/preload/src/modules/npm.ts
@@ -6,6 +6,10 @@ import { invoke } from './invoke';
  * @param {string} path - The file system path of the project where dependencies should be installed.
  * @returns {Promise<void>} - A promise that resolves when the installation is complete.
  */
-export async function install(path: string): Promise<void> {
-  await invoke('npm.install', path);
+export async function install(path: string, _package?: string): Promise<void> {
+  await invoke('npm.install', path, _package);
+}
+
+export async function packageOutdated(_path: string, _package: string): Promise<boolean> {
+  return invoke('npm.packageOutdated', _path, _package);
 }

--- a/packages/preload/src/modules/settings.ts
+++ b/packages/preload/src/modules/settings.ts
@@ -33,3 +33,12 @@ export async function getUpdateDependenciesStrategy() {
 export async function setUpdateDependenciesStrategy(strategy: UPDATE_DEPENDENCIES_STRATEGY) {
   await setConfig(config => (config.updateDependenciesStrategy = strategy));
 }
+
+export async function selectSceneFolder(): Promise<string | undefined> {
+  const [projectPath] = await invoke('electron.showOpenDialog', {
+    title: 'Select Scenes Folder',
+    properties: ['openDirectory'],
+  });
+
+  return projectPath;
+}

--- a/packages/preload/src/modules/settings.ts
+++ b/packages/preload/src/modules/settings.ts
@@ -1,0 +1,35 @@
+import { UPDATE_DEPENDENCIES_STRATEGY } from '/shared/types/settings';
+import { invoke } from './invoke';
+import { getConfig, setConfig } from './config';
+
+export async function getScenesPath() {
+  const config = await getConfig();
+  return config.scenesPath ?? (await invoke('electron.getAppHome'));
+}
+
+export async function setScenesPath(path: string) {
+  await setConfig(config => (config.scenesPath = path));
+}
+
+// Helper to check if a value is part of the enum
+function isValidUpdateStrategy(value: string): value is UPDATE_DEPENDENCIES_STRATEGY {
+  return Object.values(UPDATE_DEPENDENCIES_STRATEGY).includes(
+    value as UPDATE_DEPENDENCIES_STRATEGY,
+  );
+}
+
+export async function getUpdateDependenciesStrategy() {
+  const config = await getConfig();
+  if (
+    config.updateDependenciesStrategy &&
+    isValidUpdateStrategy(config.updateDependenciesStrategy)
+  ) {
+    return config.updateDependenciesStrategy;
+  } else {
+    return UPDATE_DEPENDENCIES_STRATEGY.NOTIFY;
+  }
+}
+
+export async function setUpdateDependenciesStrategy(strategy: UPDATE_DEPENDENCIES_STRATEGY) {
+  await setConfig(config => (config.updateDependenciesStrategy = strategy));
+}

--- a/packages/preload/src/modules/workspace.ts
+++ b/packages/preload/src/modules/workspace.ts
@@ -15,6 +15,7 @@ import { hasDependency } from './pkg';
 import { getRowsAndCols, parseCoords } from './scene';
 import { getEditorHome } from './editor';
 import { invoke } from './invoke';
+import { getScenesPath } from './settings';
 
 import { DEFAULT_THUMBNAIL, NEW_SCENE_NAME, EMPTY_SCENE_TEMPLATE_REPO } from './constants';
 
@@ -124,7 +125,7 @@ export async function getProject(_path: string): Promise<Project> {
 }
 
 export async function getPath() {
-  const appHome = await invoke('electron.getAppHome');
+  const appHome = await getScenesPath();
   try {
     await fs.stat(appHome);
   } catch (error) {
@@ -239,6 +240,7 @@ export async function createProject(opts?: { name?: string; repo?: string }): Pr
   await fs.writeFile(sceneJsonPath, JSON.stringify(scene, null, 2));
   const project = await getProject(projectPath);
   await setConfig(config => config.workspace.paths.push(projectPath));
+  await invoke('bin.installNpmPackages', projectPath);
   return project;
 }
 
@@ -400,4 +402,12 @@ export async function openFolder(_path: string) {
   if (error) {
     throw new Error(error);
   }
+}
+
+export async function npmPackageOutdated(_path: string, _package: string): Promise<boolean> {
+  return invoke('bin.npmPackageOutdated', _path, _package);
+}
+
+export async function installNpmPackage(_path: string, _package: string): Promise<void> {
+  return invoke('bin.installNpmPackages', _path, _package);
 }

--- a/packages/preload/src/modules/workspace.ts
+++ b/packages/preload/src/modules/workspace.ts
@@ -240,7 +240,6 @@ export async function createProject(opts?: { name?: string; repo?: string }): Pr
   await fs.writeFile(sceneJsonPath, JSON.stringify(scene, null, 2));
   const project = await getProject(projectPath);
   await setConfig(config => config.workspace.paths.push(projectPath));
-  await invoke('bin.installNpmPackages', projectPath);
   return project;
 }
 
@@ -402,12 +401,4 @@ export async function openFolder(_path: string) {
   if (error) {
     throw new Error(error);
   }
-}
-
-export async function npmPackageOutdated(_path: string, _package: string): Promise<boolean> {
-  return invoke('bin.npmPackageOutdated', _path, _package);
-}
-
-export async function installNpmPackage(_path: string, _package: string): Promise<void> {
-  return invoke('bin.installNpmPackages', _path, _package);
 }

--- a/packages/renderer/src/components/Button/styles.css
+++ b/packages/renderer/src/components/Button/styles.css
@@ -1,6 +1,7 @@
 .Button.MuiButton-root {
   padding: 5px 20px;
-  color: var(--white);
+  /* TODO: Fix this color in decentraland-ui2 */
+  color: var(--white) !important;
   font-weight: 400;
 }
 

--- a/packages/renderer/src/components/EditorPage/component.tsx
+++ b/packages/renderer/src/components/EditorPage/component.tsx
@@ -39,7 +39,7 @@ export function EditorPage() {
     loadingPreview,
     loadingPublish,
   } = useEditor();
-  const { createDependencyNotification } = useSnackbar();
+  const { createCustomNotification } = useSnackbar();
   const userId = useSelector(state => state.analytics.userId);
   const iframeRef = useRef<ReturnType<typeof initRpc>>();
   const [open, setOpen] = useState<ModalType | undefined>();
@@ -73,12 +73,12 @@ export function EditorPage() {
         updateStrategySetting === UPDATE_DEPENDENCIES_STRATEGY.NOTIFY &&
         project?.packageStatus?.[SDK_PACKAGE].isOutdated
       ) {
-        createDependencyNotification('new-dependency-version', project, { duration: 0 });
+        createCustomNotification('new-dependency-version', { duration: 0, project });
       } else if (
         updateStrategySetting === UPDATE_DEPENDENCIES_STRATEGY.AUTO_UPDATE &&
         project?.packageStatus?.[SDK_PACKAGE].showUpdatedNotification
       ) {
-        createDependencyNotification('dependency-updated-automatically', project);
+        createCustomNotification('dependency-updated-automatically', { project });
       }
     };
 

--- a/packages/renderer/src/components/EditorPage/component.tsx
+++ b/packages/renderer/src/components/EditorPage/component.tsx
@@ -76,7 +76,7 @@ export function EditorPage() {
         createDependencyNotification('new-dependency-version', project, { duration: 0 });
       } else if (
         updateStrategySetting === UPDATE_DEPENDENCIES_STRATEGY.AUTO_UPDATE &&
-        project?.packageStatus?.[SDK_PACKAGE].isUpdated
+        project?.packageStatus?.[SDK_PACKAGE].showUpdatedNotification
       ) {
         createDependencyNotification('dependency-updated-automatically', project);
       }

--- a/packages/renderer/src/components/HomePage/component.tsx
+++ b/packages/renderer/src/components/HomePage/component.tsx
@@ -189,6 +189,10 @@ const LearnCard: React.FC = React.memo(() => {
     navigate('/learn');
   }, []);
 
+  const handleLearnItemClick = useCallback((href: string) => {
+    misc.openExternal(href);
+  }, []);
+
   return (
     <Card className="Card LearnCard">
       <CardBanner
@@ -203,6 +207,7 @@ const LearnCard: React.FC = React.memo(() => {
               key={idx}
               title={item.title}
               icon={item.icon}
+              onClick={() => handleLearnItemClick(item.href)}
             />
           ))}
         </div>

--- a/packages/renderer/src/components/Modals/AppSettings/component.tsx
+++ b/packages/renderer/src/components/Modals/AppSettings/component.tsx
@@ -9,9 +9,12 @@ import {
   OutlinedInput,
   Typography,
   FormGroup,
+  InputAdornment,
 } from 'decentraland-ui2';
 import CloseIcon from '@mui/icons-material/Close';
+import FolderIcon from '@mui/icons-material/Folder';
 import { Modal } from 'decentraland-ui2/dist/components/Modal/Modal';
+import { settings as settingsPreload } from '#preload';
 import { UPDATE_DEPENDENCIES_STRATEGY } from '/shared/types/settings';
 import { t } from '/@/modules/store/translation/utils';
 import { useSettings } from '/@/hooks/useSettings';
@@ -61,6 +64,13 @@ export function AppSettings({ open, onClose }: { open: boolean; onClose: () => v
     onClose();
   }, [scenesPath, updateDependenciesStrategy]);
 
+  const handleOpenFolder = useCallback(async () => {
+    const folder = await settingsPreload.selectSceneFolder();
+    if (folder) {
+      setScenesPath(folder);
+    }
+  }, []);
+
   useEffect(() => {
     const path = settings.scenesPath;
     const strategy = settings.updateDependenciesStrategy;
@@ -91,6 +101,16 @@ export function AppSettings({ open, onClose }: { open: boolean; onClose: () => v
               color="secondary"
               value={scenesPath}
               onChange={handleChangeSceneFolder}
+              endAdornment={
+                <InputAdornment position="end">
+                  <IconButton
+                    onClick={handleOpenFolder}
+                    edge="end"
+                  >
+                    <FolderIcon />
+                  </IconButton>
+                </InputAdornment>
+              }
             />
             <Button
               className="ChangeSceneFolderButton"

--- a/packages/renderer/src/components/Modals/AppSettings/component.tsx
+++ b/packages/renderer/src/components/Modals/AppSettings/component.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  IconButton,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  OutlinedInput,
+  Typography,
+  FormGroup,
+} from 'decentraland-ui2';
+import CloseIcon from '@mui/icons-material/Close';
+import { Modal } from 'decentraland-ui2/dist/components/Modal/Modal';
+import { UPDATE_DEPENDENCIES_STRATEGY } from '/shared/types/settings';
+import { t } from '/@/modules/store/translation/utils';
+import { useSettings } from '/@/hooks/useSettings';
+
+import './styles.css';
+
+export function AppSettings({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const settings = useSettings();
+  const [scenesPath, setScenesPath] = useState('');
+  const [updateDependenciesStrategy, setUpdateDependenciesStrategy] =
+    useState<UPDATE_DEPENDENCIES_STRATEGY>(UPDATE_DEPENDENCIES_STRATEGY.NOTIFY);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useEffect(() => {
+    const checkIfDirty = async () => {
+      const scenesPathSetting = settings.scenesPath;
+      const updateStrategySetting = settings.updateDependenciesStrategy;
+
+      setIsDirty(
+        scenesPath !== scenesPathSetting || updateDependenciesStrategy !== updateStrategySetting,
+      );
+    };
+
+    checkIfDirty();
+  }, [scenesPath, updateDependenciesStrategy]);
+
+  const handleChangeSceneFolder = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setScenesPath(event.target.value);
+  }, []);
+
+  const handleClickChangeSceneFolder = useCallback(() => {
+    settings.setScenesPath(scenesPath);
+    onClose();
+  }, [scenesPath]);
+
+  const handleChangeUpdateDependenciesStrategy = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value as UPDATE_DEPENDENCIES_STRATEGY;
+      setUpdateDependenciesStrategy(value);
+    },
+    [],
+  );
+
+  const handleClickApply = useCallback(async () => {
+    await settings.setScenesPath(scenesPath);
+    await settings.setUpdateDependenciesStrategy(updateDependenciesStrategy);
+    onClose();
+  }, [scenesPath, updateDependenciesStrategy]);
+
+  useEffect(() => {
+    const path = settings.scenesPath;
+    const strategy = settings.updateDependenciesStrategy;
+    setScenesPath(path);
+    setUpdateDependenciesStrategy(strategy);
+  }, [settings.scenesPath, settings.updateDependenciesStrategy]);
+
+  return (
+    <Modal
+      open={open}
+      size="small"
+    >
+      <Box className="AppSettingsModal">
+        <Box className="CloseButtonContainer">
+          <IconButton onClick={onClose}>
+            <CloseIcon fontSize="large" />
+          </IconButton>
+        </Box>
+        <Box>
+          <Typography variant="h4">{t('modal.app_settings.title')}</Typography>
+        </Box>
+        <Box className="FormContainer">
+          <FormGroup className="ScenesFolderFormControl">
+            <Typography variant="body1">
+              {t('modal.app_settings.fields.scenes_folder.label')}
+            </Typography>
+            <OutlinedInput
+              color="secondary"
+              value={scenesPath}
+              onChange={handleChangeSceneFolder}
+            />
+            <Button
+              className="ChangeSceneFolderButton"
+              variant="contained"
+              color="secondary"
+              disableRipple
+              onClick={handleClickChangeSceneFolder}
+            >
+              {t('modal.app_settings.fields.scenes_folder.change_button')}
+            </Button>
+          </FormGroup>
+          <FormGroup sx={{ gap: '16px' }}>
+            <Typography variant="body1">
+              {t('modal.app_settings.fields.scene_editor_dependencies.label')}
+            </Typography>
+            <RadioGroup
+              value={updateDependenciesStrategy}
+              onChange={handleChangeUpdateDependenciesStrategy}
+            >
+              <FormControlLabel
+                value={UPDATE_DEPENDENCIES_STRATEGY.AUTO_UPDATE}
+                control={<Radio />}
+                label={t('modal.app_settings.fields.scene_editor_dependencies.options.auto_update')}
+              />
+              <FormControlLabel
+                value={UPDATE_DEPENDENCIES_STRATEGY.NOTIFY}
+                control={<Radio />}
+                label={t('modal.app_settings.fields.scene_editor_dependencies.options.notify')}
+              />
+              <FormControlLabel
+                value={UPDATE_DEPENDENCIES_STRATEGY.DO_NOTHING}
+                control={<Radio />}
+                label={t('modal.app_settings.fields.scene_editor_dependencies.options.do_nothing')}
+              />
+            </RadioGroup>
+          </FormGroup>
+          <Button
+            className="ApplyButton"
+            variant="contained"
+            disabled={!isDirty}
+            onClick={handleClickApply}
+          >
+            {t('modal.app_settings.actions.apply_button')}
+          </Button>
+        </Box>
+      </Box>
+    </Modal>
+  );
+}

--- a/packages/renderer/src/components/Modals/AppSettings/index.ts
+++ b/packages/renderer/src/components/Modals/AppSettings/index.ts
@@ -1,0 +1,2 @@
+import { AppSettings } from './component';
+export { AppSettings };

--- a/packages/renderer/src/components/Modals/AppSettings/styles.css
+++ b/packages/renderer/src/components/Modals/AppSettings/styles.css
@@ -1,0 +1,40 @@
+.AppSettingsModal .MuiPaper-root {
+  background-color: #242129;
+  background-image: none;
+}
+
+.AppSettingsModal .CloseButtonContainer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.AppSettingsModal .FormContainer {
+  display: flex;
+  flex-direction: column;
+  margin-top: 32px;
+  gap: 32px;
+  width: 100%;
+}
+
+.AppSettingsModal .ScenesFolderFormControl {
+  gap: 16px;
+}
+
+.AppSettingsModal
+  .ScenesFolderFormControl
+  .MuiInputBase-root
+  fieldset.MuiOutlinedInput-notchedOutline {
+  /* TODO: Fix styles in the ui2 library */
+  border-color: #ffffff3b;
+}
+
+.AppSettingsModal .ChangeSceneFolderButton {
+  width: 184px;
+  font-weight: 600;
+}
+
+.AppSettingsModal .ApplyButton.Mui-disabled {
+  /* TODO: Fix styles in the ui2 library */
+  background-color: #f8919d;
+  color: #fee9ec;
+}

--- a/packages/renderer/src/components/Navbar/component.tsx
+++ b/packages/renderer/src/components/Navbar/component.tsx
@@ -1,11 +1,16 @@
 import cx from 'classnames';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Box, Button, IconButton } from 'decentraland-ui2';
+import QuestionMarkIcon from '@mui/icons-material/QuestionMark';
+import SettingsIcon from '@mui/icons-material/Settings';
 import { misc } from '#preload';
+import logo from '/assets/images/logo-editor.png';
 import { t } from '/@/modules/store/translation/utils';
 import { Header } from '../Header';
-import logo from '/assets/images/logo-editor.png';
+
 import './styles.css';
-import { Link } from 'react-router-dom';
+import { AppSettings } from '../Modals/AppSettings';
 
 export enum NavbarItem {
   HOME = 'home',
@@ -28,10 +33,21 @@ function MenuItem(props: { item: NavbarItem; active: NavbarItem; disable?: boole
 }
 
 export function Navbar(props: { active: NavbarItem }) {
-  const handleClickFeedback = useCallback(
+  const [openAppSettings, setOpenAppSettings] = useState(false);
+
+  const handleClickReportIssue = useCallback(
     () => misc.openExternal('https://decentraland.canny.io'),
     [],
   );
+
+  const handleClickHelp = useCallback(
+    () => misc.openExternal('https://decentraland.org/help/'),
+    [],
+  );
+
+  const handleClickSettings = useCallback(() => {
+    setOpenAppSettings(true);
+  }, []);
 
   return (
     <Header classNames={cx('Navbar')}>
@@ -74,12 +90,32 @@ export function Navbar(props: { active: NavbarItem }) {
         </div>
       </>
       <>
-        <div
-          className="feedback"
-          onClick={handleClickFeedback}
-        >
-          {t('navbar.feedback')}
-        </div>
+        <Box className="actions">
+          <Button
+            variant="outlined"
+            color="secondary"
+            size="small"
+            onClick={handleClickReportIssue}
+          >
+            {t('navbar.report_an_issue')}
+          </Button>
+          <IconButton
+            aria-label="help"
+            onClick={handleClickHelp}
+          >
+            <QuestionMarkIcon />
+          </IconButton>
+          <IconButton
+            aria-label="settings"
+            onClick={handleClickSettings}
+          >
+            <SettingsIcon />
+          </IconButton>
+        </Box>
+        <AppSettings
+          open={openAppSettings}
+          onClose={() => setOpenAppSettings(false)}
+        />
       </>
     </Header>
   );

--- a/packages/renderer/src/components/Navbar/styles.css
+++ b/packages/renderer/src/components/Navbar/styles.css
@@ -41,3 +41,9 @@
   text-align: center;
   cursor: pointer;
 }
+
+.Navbar .actions {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}

--- a/packages/renderer/src/components/ProjectCard/component.tsx
+++ b/packages/renderer/src/components/ProjectCard/component.tsx
@@ -1,9 +1,10 @@
+import { useCallback } from 'react';
+
 import { Dropdown } from '../Dropdown';
 
 import type { Props } from './types';
 
 import './styles.css';
-import { useCallback } from 'react';
 
 export function ProjectCard({
   title,

--- a/packages/renderer/src/components/Snackbar/DependencyVersion/index.tsx
+++ b/packages/renderer/src/components/Snackbar/DependencyVersion/index.tsx
@@ -54,7 +54,7 @@ export function DependencyUpdatedAutomatically({ onClose }: { onClose: () => voi
         variant="text"
         onClick={onClose}
       >
-        {t('snackbar.dependency_updated_automatically.actions.update')}
+        {t('snackbar.dependency_updated_automatically.actions.ok')}
       </Button>
     ),
     [],

--- a/packages/renderer/src/components/Snackbar/DependencyVersion/index.tsx
+++ b/packages/renderer/src/components/Snackbar/DependencyVersion/index.tsx
@@ -1,0 +1,73 @@
+import { useCallback } from 'react';
+import { Alert, Button, IconButton } from 'decentraland-ui2';
+import NotificationImportantIcon from '@mui/icons-material/NotificationImportant';
+import CloseIcon from '@mui/icons-material/Close';
+
+import { t } from '/@/modules/store/translation/utils';
+import { useEditor } from '/@/hooks/useEditor';
+import { useWorkspace } from '/@/hooks/useWorkspace';
+
+export function NewDependencyVersion({ onClose }: { onClose: () => void }) {
+  const { project } = useEditor();
+  const { updateSdkPackage } = useWorkspace();
+
+  const handleClickUpdate = useCallback(() => {
+    if (project) {
+      updateSdkPackage(project.path);
+    }
+    onClose();
+  }, [project]);
+
+  const renderActions = useCallback(
+    () => (
+      <>
+        <Button
+          variant="text"
+          onClick={handleClickUpdate}
+        >
+          {t('snackbar.new_dependency_version.actions.update')}
+        </Button>
+        <IconButton onClick={onClose}>
+          <CloseIcon color="secondary" />
+        </IconButton>
+      </>
+    ),
+    [],
+  );
+
+  return (
+    <Alert
+      icon={<NotificationImportantIcon color="secondary" />}
+      severity="info"
+      action={renderActions()}
+      sx={{ alignItems: 'center' }}
+    >
+      {t('snackbar.new_dependency_version.title')}
+    </Alert>
+  );
+}
+
+export function DependencyUpdatedAutomatically({ onClose }: { onClose: () => void }) {
+  const renderActions = useCallback(
+    () => (
+      <Button
+        variant="text"
+        onClick={onClose}
+      >
+        {t('snackbar.dependency_updated_automatically.actions.update')}
+      </Button>
+    ),
+    [],
+  );
+
+  return (
+    <Alert
+      icon={<NotificationImportantIcon color="secondary" />}
+      severity="info"
+      action={renderActions()}
+      sx={{ alignItems: 'center' }}
+    >
+      {t('snackbar.dependency_updated_automatically.title')}
+    </Alert>
+  );
+}

--- a/packages/renderer/src/components/Snackbar/component.tsx
+++ b/packages/renderer/src/components/Snackbar/component.tsx
@@ -22,11 +22,9 @@ export function SnackbarComponent() {
       case 'missing-scenes':
         return <MissingScenes onClose={close(notification.id)} />;
       case 'new-dependency-version':
-        return <NewDependencyVersion onClose={close(notification.id, notification.project)} />;
+        return <NewDependencyVersion onClose={close(notification.id)} />;
       case 'dependency-updated-automatically':
-        return (
-          <DependencyUpdatedAutomatically onClose={close(notification.id, notification.project)} />
-        );
+        return <DependencyUpdatedAutomatically onClose={close(notification.id)} />;
       default:
         return null;
     }
@@ -48,11 +46,7 @@ export function SnackbarComponent() {
             key={notification.id}
             open={true}
             autoHideDuration={getDuration(notification)}
-            onClose={dismiss(
-              notification.id,
-              idx,
-              'project' in notification ? notification.project : undefined,
-            )}
+            onClose={dismiss(notification.id, idx)}
             anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
           >
             <div>

--- a/packages/renderer/src/components/Snackbar/component.tsx
+++ b/packages/renderer/src/components/Snackbar/component.tsx
@@ -6,6 +6,7 @@ import { useSnackbar } from '/@/hooks/useSnackbar';
 
 import { MissingScenes } from './MissingScenes';
 import { Generic } from './Generic';
+import { DependencyUpdatedAutomatically, NewDependencyVersion } from './DependencyVersion';
 
 import './styles.css';
 
@@ -20,6 +21,12 @@ export function SnackbarComponent() {
         return <Generic {...notification} />;
       case 'missing-scenes':
         return <MissingScenes onClose={close(notification.id)} />;
+      case 'new-dependency-version':
+        return <NewDependencyVersion onClose={close(notification.id, notification.project)} />;
+      case 'dependency-updated-automatically':
+        return (
+          <DependencyUpdatedAutomatically onClose={close(notification.id, notification.project)} />
+        );
       default:
         return null;
     }
@@ -41,7 +48,11 @@ export function SnackbarComponent() {
             key={notification.id}
             open={true}
             autoHideDuration={getDuration(notification)}
-            onClose={dismiss(notification.id, idx)}
+            onClose={dismiss(
+              notification.id,
+              idx,
+              'project' in notification ? notification.project : undefined,
+            )}
             anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
           >
             <div>

--- a/packages/renderer/src/hooks/useSettings.ts
+++ b/packages/renderer/src/hooks/useSettings.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react';
+import { settings } from '#preload';
+import { UPDATE_DEPENDENCIES_STRATEGY } from '/shared/types/settings';
+
+export const useSettings = () => {
+  const [scenesPath, setScenesPath] = useState('');
+  const [updateDependenciesStrategy, setUpdateDependenciesStrategy] =
+    useState<UPDATE_DEPENDENCIES_STRATEGY>(UPDATE_DEPENDENCIES_STRATEGY.NOTIFY);
+
+  const handleUpdateScenesPath = useCallback(async (path: string) => {
+    await settings.setScenesPath(path);
+    setScenesPath(path);
+  }, []);
+
+  const handleUpdateDependenciesStrategy = useCallback(
+    async (strategy: UPDATE_DEPENDENCIES_STRATEGY) => {
+      await settings.setUpdateDependenciesStrategy(strategy);
+      setUpdateDependenciesStrategy(strategy);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    async function getAppSettings() {
+      const path = await settings.getScenesPath();
+      const strategy = await settings.getUpdateDependenciesStrategy();
+      setScenesPath(path);
+      setUpdateDependenciesStrategy(strategy);
+    }
+
+    getAppSettings();
+  }, []);
+
+  return {
+    scenesPath,
+    updateDependenciesStrategy,
+    setScenesPath: handleUpdateScenesPath,
+    setUpdateDependenciesStrategy: handleUpdateDependenciesStrategy,
+  };
+};

--- a/packages/renderer/src/hooks/useSnackbar.ts
+++ b/packages/renderer/src/hooks/useSnackbar.ts
@@ -3,27 +3,55 @@ import { type SnackbarCloseReason } from 'decentraland-ui2';
 
 import { useDispatch, useSelector } from '#store';
 import { actions } from '/@/modules/store/snackbar';
-import type { Notification } from '/@/modules/store/snackbar/types';
+import type {
+  CustomNotification,
+  DependencyNotification,
+  Notification,
+  Opts,
+  Severity,
+} from '/@/modules/store/snackbar/types';
 
 export function useSnackbar() {
   const dispatch = useDispatch();
   const snackbar = useSelector(state => state.snackbar);
 
   const dismiss = useCallback(
-    (id: Notification['id'], idx: number) =>
+    (id: Notification['id'], idx: number, project?: DependencyNotification['project']) =>
       (_: SyntheticEvent<any> | Event, reason: SnackbarCloseReason) => {
-        if (reason === 'timeout') dispatch(actions.removeSnackbar(id));
+        if (reason === 'timeout') dispatch(actions.removeSnackbar({ id, project }));
         if (reason === 'escapeKeyDown' && idx === 0) {
           const first = snackbar.notifications[0];
-          dispatch(actions.removeSnackbar(first.id));
+          dispatch(actions.removeSnackbar({ id: first.id, project }));
         }
       },
     [snackbar.notifications],
   );
 
   const close = useCallback(
-    (id: Notification['id']) => () => {
-      dispatch(actions.removeSnackbar(id));
+    (id: Notification['id'], project?: DependencyNotification['project']) => () => {
+      dispatch(actions.removeSnackbar({ id, project }));
+    },
+    [],
+  );
+
+  const createGenericNotification = useCallback(
+    (severity: Severity, message: string, opts?: Opts) => {
+      dispatch(actions.createGenericNotification({ severity, message, opts }));
+    },
+    [],
+  );
+
+  const createCustomNotification = useCallback((type: CustomNotification['type'], opts?: Opts) => {
+    dispatch(actions.createCustomNotification({ type, opts }));
+  }, []);
+
+  const createDependencyNotification = useCallback(
+    (
+      type: DependencyNotification['type'],
+      project: DependencyNotification['project'],
+      opts?: Opts,
+    ) => {
+      dispatch(actions.createDependencyNotification({ type, project, opts }));
     },
     [],
   );
@@ -32,5 +60,8 @@ export function useSnackbar() {
     ...snackbar,
     close,
     dismiss,
+    createGenericNotification,
+    createCustomNotification,
+    createDependencyNotification,
   };
 }

--- a/packages/renderer/src/hooks/useSnackbar.ts
+++ b/packages/renderer/src/hooks/useSnackbar.ts
@@ -5,7 +5,6 @@ import { useDispatch, useSelector } from '#store';
 import { actions } from '/@/modules/store/snackbar';
 import type {
   CustomNotification,
-  DependencyNotification,
   Notification,
   Opts,
   Severity,
@@ -16,20 +15,20 @@ export function useSnackbar() {
   const snackbar = useSelector(state => state.snackbar);
 
   const dismiss = useCallback(
-    (id: Notification['id'], idx: number, project?: DependencyNotification['project']) =>
+    (id: Notification['id'], idx: number) =>
       (_: SyntheticEvent<any> | Event, reason: SnackbarCloseReason) => {
-        if (reason === 'timeout') dispatch(actions.removeSnackbar({ id, project }));
+        if (reason === 'timeout') dispatch(actions.removeSnackbar({ id }));
         if (reason === 'escapeKeyDown' && idx === 0) {
           const first = snackbar.notifications[0];
-          dispatch(actions.removeSnackbar({ id: first.id, project }));
+          dispatch(actions.removeSnackbar({ id: first.id }));
         }
       },
     [snackbar.notifications],
   );
 
   const close = useCallback(
-    (id: Notification['id'], project?: DependencyNotification['project']) => () => {
-      dispatch(actions.removeSnackbar({ id, project }));
+    (id: Notification['id']) => () => {
+      dispatch(actions.removeSnackbar({ id }));
     },
     [],
   );
@@ -45,23 +44,11 @@ export function useSnackbar() {
     dispatch(actions.createCustomNotification({ type, opts }));
   }, []);
 
-  const createDependencyNotification = useCallback(
-    (
-      type: DependencyNotification['type'],
-      project: DependencyNotification['project'],
-      opts?: Opts,
-    ) => {
-      dispatch(actions.createDependencyNotification({ type, project, opts }));
-    },
-    [],
-  );
-
   return {
     ...snackbar,
     close,
     dismiss,
     createGenericNotification,
     createCustomNotification,
-    createDependencyNotification,
   };
 }

--- a/packages/renderer/src/hooks/useWorkspace.ts
+++ b/packages/renderer/src/hooks/useWorkspace.ts
@@ -54,6 +54,10 @@ export const useWorkspace = () => {
     dispatch(workspaceActions.openFolder(path));
   }, []);
 
+  const updateSdkPackage = useCallback((path: string) => {
+    dispatch(workspaceActions.updateSdkPackage(path));
+  }, []);
+
   const isLoading = workspace.status === 'loading';
 
   return {
@@ -68,6 +72,7 @@ export const useWorkspace = () => {
     reimportProject,
     unlistProjects,
     openFolder,
+    updateSdkPackage,
     isLoading,
   };
 };

--- a/packages/renderer/src/index.tsx
+++ b/packages/renderer/src/index.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider as StoreProvider } from 'react-redux';
 import { MemoryRouter as Router, Routes, Route } from 'react-router-dom';
-import { ThemeProvider } from '@mui/material/styles';
-import { dark } from 'decentraland-ui2/dist/theme';
+import { dark, ThemeProvider } from 'decentraland-ui2/dist/theme';
 
 import { store } from '#store';
 import { TranslationProvider } from '/@/components/TranslationProvider';

--- a/packages/renderer/src/modules/store/analytics/track.ts
+++ b/packages/renderer/src/modules/store/analytics/track.ts
@@ -10,7 +10,7 @@ trackAction(workspaceActions.createProject.fulfilled, 'Create Project', async ac
   cols: action.payload.layout.cols,
 }));
 
-trackAction(editorActions.setProject, 'Open Project', async action => ({
+trackAction(editorActions.setProject.fulfilled, 'Open Project', async action => ({
   project_id: action.payload.id,
   project_name: action.payload.title,
 }));

--- a/packages/renderer/src/modules/store/editor/slice.ts
+++ b/packages/renderer/src/modules/store/editor/slice.ts
@@ -82,9 +82,12 @@ export const slice = createSlice({
   initialState,
   reducers: {},
   extraReducers: builder => {
+    builder.addCase(setProject.pending, state => {
+      // Clear previous project
+      state.project = undefined;
+    });
     builder.addCase(setProject.fulfilled, (state, action) => {
       state.project = action.payload;
-      state.loadingInspector = false;
     });
     builder.addCase(startInspector.pending, state => {
       state.inspectorPort = 0;

--- a/packages/renderer/src/modules/store/editor/slice.ts
+++ b/packages/renderer/src/modules/store/editor/slice.ts
@@ -1,8 +1,14 @@
-import { editor } from '#preload';
-import { createAsyncThunk, createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import pLimit from 'p-limit';
+import { editor, npm, settings } from '#preload';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 import { type Project } from '/shared/types/projects';
+import { UPDATE_DEPENDENCIES_STRATEGY } from '/shared/types/settings';
+import { SDK_PACKAGE } from '/shared/types/pkg';
+
 import { actions as workspaceActions } from '../workspace';
+
+const limit = pLimit(1);
 
 // actions
 export const fetchVersion = createAsyncThunk('editor/fetchVersion', editor.getVersion);
@@ -11,6 +17,34 @@ export const startInspector = createAsyncThunk('editor/startInspector', editor.s
 export const runScene = createAsyncThunk('editor/runScene', editor.runScene);
 export const publishScene = createAsyncThunk('editor/publishScene', editor.publishScene);
 export const openTutorial = createAsyncThunk('editor/openTutorial', editor.openTutorial);
+export const setProject = createAsyncThunk('editor/setProject', async (project: Project) => {
+  const updateStrategySetting = await settings.getUpdateDependenciesStrategy();
+
+  if (updateStrategySetting === UPDATE_DEPENDENCIES_STRATEGY.DO_NOTHING) {
+    return project;
+  }
+
+  const isOutdated = await limit(() => npm.packageOutdated(project.path, SDK_PACKAGE));
+
+  const updatedPackageStatus: Project['packageStatus'] = {
+    ...project.packageStatus,
+    [SDK_PACKAGE]: { isOutdated },
+  };
+
+  if (updateStrategySetting === UPDATE_DEPENDENCIES_STRATEGY.AUTO_UPDATE && isOutdated) {
+    try {
+      await limit(() => npm.install(project.path, SDK_PACKAGE));
+      updatedPackageStatus[SDK_PACKAGE].showUpdatedNotification = true;
+    } catch (_) {
+      updatedPackageStatus[SDK_PACKAGE].showUpdatedNotification = false;
+    }
+  }
+
+  return {
+    ...project,
+    packageStatus: updatedPackageStatus,
+  };
+});
 
 // state
 export type EditorState = {
@@ -46,12 +80,12 @@ const initialState: EditorState = {
 export const slice = createSlice({
   name: 'editor',
   initialState,
-  reducers: {
-    setProject: (state, { payload: project }: PayloadAction<Project>) => {
-      state.project = project;
-    },
-  },
+  reducers: {},
   extraReducers: builder => {
+    builder.addCase(setProject.fulfilled, (state, action) => {
+      state.project = action.payload;
+      state.loadingInspector = false;
+    });
     builder.addCase(startInspector.pending, state => {
       state.inspectorPort = 0;
       state.loadingInspector = true;
@@ -132,6 +166,7 @@ export const slice = createSlice({
 // exports
 export const actions = {
   ...slice.actions,
+  setProject,
   fetchVersion,
   install,
   startInspector,

--- a/packages/renderer/src/modules/store/snackbar/slice.ts
+++ b/packages/renderer/src/modules/store/snackbar/slice.ts
@@ -4,18 +4,8 @@ import { createSlice } from '@reduxjs/toolkit';
 import { t } from '/@/modules/store/translation/utils';
 
 import { actions as workspaceActions } from '../workspace';
-import {
-  createCustomNotification,
-  createDependencyNotification,
-  createGenericNotification,
-} from './utils';
-import type {
-  CustomNotification,
-  DependencyNotification,
-  Notification,
-  Opts,
-  Severity,
-} from './types';
+import { createCustomNotification, createGenericNotification } from './utils';
+import type { CustomNotification, Notification, Opts, Severity } from './types';
 
 // state
 export type SnackbarState = {
@@ -31,12 +21,7 @@ export const slice = createSlice({
   name: 'snackbar',
   initialState,
   reducers: {
-    removeSnackbar: (
-      state,
-      {
-        payload,
-      }: PayloadAction<{ id: Notification['id']; project?: DependencyNotification['project'] }>,
-    ) => {
+    removeSnackbar: (state, { payload }: PayloadAction<{ id: Notification['id'] }>) => {
       state.notifications = state.notifications.filter($ => $.id !== payload.id);
     },
     createGenericNotification: (
@@ -55,28 +40,14 @@ export const slice = createSlice({
       state,
       action: PayloadAction<{ type: CustomNotification['type']; opts?: Opts }>,
     ) => {
-      state.notifications.push(createCustomNotification(action.payload.type, action.payload.opts));
-    },
-    createDependencyNotification: (
-      state,
-      action: PayloadAction<{
-        type: DependencyNotification['type'];
-        project: DependencyNotification['project'];
-        opts?: Opts;
-      }>,
-    ) => {
       // TODO: Fix showing duplicate notifications for the same type and project
       if (
         !state.notifications.some(
-          $ => $.type === action.payload.type && $.project.id === action.payload.project.id,
+          $ => $.type === action.payload.type && $.project?.id === action.payload.opts?.project?.id,
         )
       ) {
         state.notifications.push(
-          createDependencyNotification(
-            action.payload.type,
-            action.payload.project,
-            action.payload.opts,
-          ),
+          createCustomNotification(action.payload.type, action.payload.opts),
         );
       }
     },

--- a/packages/renderer/src/modules/store/snackbar/slice.ts
+++ b/packages/renderer/src/modules/store/snackbar/slice.ts
@@ -4,8 +4,18 @@ import { createSlice } from '@reduxjs/toolkit';
 import { t } from '/@/modules/store/translation/utils';
 
 import { actions as workspaceActions } from '../workspace';
-import { createCustomNotification, createGenericNotification } from './utils';
-import type { Notification } from './types';
+import {
+  createCustomNotification,
+  createDependencyNotification,
+  createGenericNotification,
+} from './utils';
+import type {
+  CustomNotification,
+  DependencyNotification,
+  Notification,
+  Opts,
+  Severity,
+} from './types';
 
 // state
 export type SnackbarState = {
@@ -21,8 +31,54 @@ export const slice = createSlice({
   name: 'snackbar',
   initialState,
   reducers: {
-    removeSnackbar: (state, { payload: id }: PayloadAction<Notification['id']>) => {
-      state.notifications = state.notifications.filter($ => $.id !== id);
+    removeSnackbar: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{ id: Notification['id']; project?: DependencyNotification['project'] }>,
+    ) => {
+      state.notifications = state.notifications.filter($ => $.id !== payload.id);
+    },
+    createGenericNotification: (
+      state,
+      action: PayloadAction<{ severity: Severity; message: string; opts?: Opts }>,
+    ) => {
+      state.notifications.push(
+        createGenericNotification(
+          action.payload.severity,
+          action.payload.message,
+          action.payload.opts,
+        ),
+      );
+    },
+    createCustomNotification: (
+      state,
+      action: PayloadAction<{ type: CustomNotification['type']; opts?: Opts }>,
+    ) => {
+      state.notifications.push(createCustomNotification(action.payload.type, action.payload.opts));
+    },
+    createDependencyNotification: (
+      state,
+      action: PayloadAction<{
+        type: DependencyNotification['type'];
+        project: DependencyNotification['project'];
+        opts?: Opts;
+      }>,
+    ) => {
+      // TODO: Fix showing duplicate notifications for the same type and project
+      if (
+        !state.notifications.some(
+          $ => $.type === action.payload.type && $.project.id === action.payload.project.id,
+        )
+      ) {
+        state.notifications.push(
+          createDependencyNotification(
+            action.payload.type,
+            action.payload.project,
+            action.payload.opts,
+          ),
+        );
+      }
     },
   },
   extraReducers: builder => {

--- a/packages/renderer/src/modules/store/snackbar/types.ts
+++ b/packages/renderer/src/modules/store/snackbar/types.ts
@@ -1,8 +1,10 @@
 import type { AlertColor } from 'decentraland-ui2';
+import type { Project } from '/shared/types/projects';
 
 export type Severity = AlertColor | 'loading';
 export type NotificationId = string;
 type CustomNotificationType = 'missing-scenes';
+type DependencyNotificationType = 'new-dependency-version' | 'dependency-updated-automatically';
 
 export type Opts = {
   requestId?: string;
@@ -19,5 +21,8 @@ export type GenericNotification = CommonNotificationProps<'generic'> & {
   severity: Severity;
   message: string;
 };
+export type DependencyNotification = CommonNotificationProps<DependencyNotificationType> & {
+  project: Project;
+};
 
-export type Notification = CustomNotification | GenericNotification;
+export type Notification = CustomNotification | GenericNotification | DependencyNotification;

--- a/packages/renderer/src/modules/store/snackbar/types.ts
+++ b/packages/renderer/src/modules/store/snackbar/types.ts
@@ -3,12 +3,15 @@ import type { Project } from '/shared/types/projects';
 
 export type Severity = AlertColor | 'loading';
 export type NotificationId = string;
-type CustomNotificationType = 'missing-scenes';
-type DependencyNotificationType = 'new-dependency-version' | 'dependency-updated-automatically';
+type CustomNotificationType =
+  | 'missing-scenes'
+  | 'new-dependency-version'
+  | 'dependency-updated-automatically';
 
 export type Opts = {
   requestId?: string;
   duration?: number;
+  project?: Project;
 };
 
 type CommonNotificationProps<T extends string> = {
@@ -21,8 +24,5 @@ export type GenericNotification = CommonNotificationProps<'generic'> & {
   severity: Severity;
   message: string;
 };
-export type DependencyNotification = CommonNotificationProps<DependencyNotificationType> & {
-  project: Project;
-};
 
-export type Notification = CustomNotification | GenericNotification | DependencyNotification;
+export type Notification = CustomNotification | GenericNotification;

--- a/packages/renderer/src/modules/store/snackbar/utils.ts
+++ b/packages/renderer/src/modules/store/snackbar/utils.ts
@@ -4,7 +4,6 @@ import type {
   NotificationId,
   Severity,
   Opts,
-  DependencyNotification,
 } from './types';
 
 let incrementalId = 0;
@@ -26,12 +25,4 @@ export function createGenericNotification(
   opts?: Opts,
 ): GenericNotification {
   return { ...opts, id: opts?.requestId || getId('generic'), type: 'generic', severity, message };
-}
-
-export function createDependencyNotification(
-  type: DependencyNotification['type'],
-  project: DependencyNotification['project'],
-  opts?: Opts,
-): DependencyNotification {
-  return { ...opts, id: opts?.requestId || getId(type), type, project };
 }

--- a/packages/renderer/src/modules/store/snackbar/utils.ts
+++ b/packages/renderer/src/modules/store/snackbar/utils.ts
@@ -4,6 +4,7 @@ import type {
   NotificationId,
   Severity,
   Opts,
+  DependencyNotification,
 } from './types';
 
 let incrementalId = 0;
@@ -25,4 +26,12 @@ export function createGenericNotification(
   opts?: Opts,
 ): GenericNotification {
   return { ...opts, id: opts?.requestId || getId('generic'), type: 'generic', severity, message };
+}
+
+export function createDependencyNotification(
+  type: DependencyNotification['type'],
+  project: DependencyNotification['project'],
+  opts?: Opts,
+): DependencyNotification {
+  return { ...opts, id: opts?.requestId || getId(type), type, project };
 }

--- a/packages/renderer/src/modules/store/translation/locales/en.json
+++ b/packages/renderer/src/modules/store/translation/locales/en.json
@@ -73,6 +73,7 @@
       "more": "More"
     },
     "feedback": "Submit feedback",
+    "report_an_issue": "Report an Issue",
     "user_menu": {
       "sign_in": "Sign In",
       "sign_out": "Sign Out"
@@ -141,6 +142,26 @@
           "url": "Invalid URL"
         }
       }
+    },
+    "app_settings": {
+      "title": "App Settings",
+      "fields": {
+        "scenes_folder": {
+          "label": "Scenes Folder",
+          "change_button": "Change Folder"
+        },
+        "scene_editor_dependencies": {
+          "label": "Scene Editor Dependencies",
+          "options": {
+            "auto_update": "Auto-update all my scenes",
+            "notify": "Notify me of new version updates",
+            "do_nothing": "Do nothing"
+          }
+        }
+      },
+      "actions": {
+        "apply_button": "Apply"
+      }
     }
   },
   "snackbar": {
@@ -157,6 +178,18 @@
       "actions": {
         "view": "View",
         "discard_all": "Discard all"
+      }
+    },
+    "new_dependency_version": {
+      "title": "New dependencies version detected",
+      "actions": {
+        "update": "Update"
+      }
+    },
+    "dependency_updated_automatically": {
+      "title": "Scene dependencies were updated",
+      "actions": {
+        "ok": "Ok"
       }
     }
   },

--- a/packages/renderer/src/modules/store/translation/locales/es.json
+++ b/packages/renderer/src/modules/store/translation/locales/es.json
@@ -140,6 +140,26 @@
           "url": "URL inválida"
         }
       }
+    },
+    "app_settings": {
+      "title": "Configuración de la aplicación",
+      "fields": {
+        "scenes_folder": {
+          "label": "Carpeta de escenas",
+          "change_button": "Cambiar carpeta"
+        },
+        "scene_editor_dependencies": {
+          "label": "Dependencias del editor de escenas",
+          "options": {
+            "auto_update": "Actualizar automáticamente las dependencias",
+            "notify": "Notificarme cuando exista una nueva version",
+            "do_nothing": "No hacer nada"
+          }
+        }
+      },
+      "actions": {
+        "apply_button": "Guardar"
+      }
     }
   },
   "snackbar": {
@@ -156,6 +176,18 @@
       "actions": {
         "view": "Ver",
         "discard_all": "Descartar todas"
+      }
+    },
+    "new_dependency_version": {
+      "title": "Se detectó una nueva versión de dependencias",
+      "actions": {
+        "update": "Actualizar"
+      }
+    },
+    "dependency_updated_automatically": {
+      "title": "Las dependencias de la escena fueron actualizadas",
+      "actions": {
+        "ok": "Ok"
       }
     }
   },

--- a/packages/renderer/src/modules/store/translation/locales/zh.json
+++ b/packages/renderer/src/modules/store/translation/locales/zh.json
@@ -140,6 +140,26 @@
           "url": "无效的网址"
         }
       }
+    },
+    "app_settings": {
+      "title": "應用程式設定",
+      "fields": {
+        "scenes_folder": {
+          "label": "場景資料夾",
+          "change_button": "更改資料夾"
+        },
+        "scene_editor_dependencies": {
+          "label": "場景編輯器依賴項",
+          "options": {
+            "auto_update": "自動更新我的所有場景",
+            "notify": "有新版本更新時通知我",
+            "do_nothing": "什麼也不做"
+          }
+        }
+      },
+      "actions": {
+        "apply_button": "申請"
+      }
     }
   },
   "snackbar": {
@@ -156,6 +176,18 @@
       "actions": {
         "view": "版本",
         "discard_all": "全部丢弃"
+      }
+    },
+    "new_dependency_version": {
+      "title": "偵測到新的依賴項版本",
+      "actions": {
+        "update": "更新"
+      }
+    },
+    "dependency_updated_automatically": {
+      "title": "場景相依性已更新",
+      "actions": {
+        "ok": "好的"
       }
     }
   },

--- a/packages/renderer/src/modules/store/workspace/slice.ts
+++ b/packages/renderer/src/modules/store/workspace/slice.ts
@@ -6,7 +6,6 @@ import { type ThunkAction } from '#store';
 import type { Workspace } from '/shared/types/workspace';
 import { SortBy } from '/shared/types/projects';
 import { SDK_PACKAGE } from '/shared/types/pkg';
-import { actions as snackbarActions } from '../snackbar';
 import type { Async } from '/@/modules/async';
 
 // actions
@@ -205,26 +204,6 @@ export const slice = createSlice({
         state.status = 'failed';
         state.error =
           action.error.message || `Failed to update the SDK package for project ${action.meta.arg}`;
-      })
-      .addCase(snackbarActions.removeSnackbar, (state, action) => {
-        if (
-          action.payload.id.startsWith('dependency-updated-automatically') &&
-          action.payload.project
-        ) {
-          const projectIdx = state.projects.findIndex($ => $.id === action.payload.project!.id);
-          if (projectIdx !== -1) {
-            state.projects[projectIdx] = {
-              ...action.payload.project,
-              packageStatus: {
-                ...action.payload.project.packageStatus,
-                [SDK_PACKAGE]: {
-                  ...action.payload.project.packageStatus![SDK_PACKAGE],
-                  showUpdatedNotification: undefined,
-                },
-              },
-            };
-          }
-        }
       });
   },
 });

--- a/packages/renderer/src/themes/theme.css
+++ b/packages/renderer/src/themes/theme.css
@@ -79,6 +79,8 @@ body {
   padding: 0px;
   margin: 0px;
   height: 100%;
+  /* The lib decentraland-ui2 adds a default background-color to the body */
+  background-color: unset !important;
 }
 
 a {

--- a/packages/renderer/src/themes/theme.css
+++ b/packages/renderer/src/themes/theme.css
@@ -61,6 +61,7 @@
   --mui-shape-borderRadius: 6px;
   /* --mui-palette-primary-main: #ff2d55; */
   --mui-palette-action-disabled: #f8919d;
+  --mui-palette-secondary-contrast: #ffffff;
 }
 
 html {

--- a/packages/shared/types/config.ts
+++ b/packages/shared/types/config.ts
@@ -1,6 +1,13 @@
+import { type UPDATE_DEPENDENCIES_STRATEGY } from './settings';
+
 export type Config = {
   version: number;
   workspace: {
     paths: string[];
   };
+} & AppSettings;
+
+export type AppSettings = {
+  scenesPath?: string;
+  updateDependenciesStrategy?: UPDATE_DEPENDENCIES_STRATEGY;
 };

--- a/packages/shared/types/ipc.ts
+++ b/packages/shared/types/ipc.ts
@@ -9,8 +9,6 @@ export interface Ipc {
   'electron.openExternal': (url: string) => Promise<void>;
   'inspector.start': () => Promise<number>;
   'bin.install': () => Promise<void>;
-  'bin.installNpmPackages': (projectPath: string, packageName?: string) => Promise<void>;
-  'bin.npmPackageOutdated': (projectPath: string, packageName: string) => Promise<boolean>;
   'bin.code': (path: string) => Promise<void>;
   'cli.init': (path: string, repo?: string) => Promise<void>;
   'cli.start': (path: string) => Promise<void>;
@@ -18,5 +16,6 @@ export interface Ipc {
   'analytics.track': (event: string, data?: Record<string, any>) => void;
   'analytics.identify': (userId: string, traits?: Record<string, any>) => void;
   'analytics.getAnonymousId': () => Promise<string>;
-  'npm.install': (path: string) => Promise<void>;
+  'npm.install': (path: string, packageName?: string) => Promise<void>;
+  'npm.packageOutdated': (path: string, packageName: string) => Promise<boolean>;
 }

--- a/packages/shared/types/ipc.ts
+++ b/packages/shared/types/ipc.ts
@@ -9,6 +9,8 @@ export interface Ipc {
   'electron.openExternal': (url: string) => Promise<void>;
   'inspector.start': () => Promise<number>;
   'bin.install': () => Promise<void>;
+  'bin.installNpmPackages': (projectPath: string, packageName?: string) => Promise<void>;
+  'bin.npmPackageOutdated': (projectPath: string, packageName: string) => Promise<boolean>;
   'bin.code': (path: string) => Promise<void>;
   'cli.init': (path: string, repo?: string) => Promise<void>;
   'cli.start': (path: string) => Promise<void>;

--- a/packages/shared/types/pkg.ts
+++ b/packages/shared/types/pkg.ts
@@ -7,3 +7,5 @@ export type PackageJson = {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
 };
+
+export const SDK_PACKAGE = '@dcl/sdk';

--- a/packages/shared/types/projects.ts
+++ b/packages/shared/types/projects.ts
@@ -26,4 +26,10 @@ export type Project = {
   updatedAt: number;
   size: number;
   worldConfiguration?: WorldConfiguration;
+  packageStatus?: {
+    [packageName: string]: {
+      isOutdated: boolean;
+      isUpdated?: boolean;
+    };
+  };
 };

--- a/packages/shared/types/projects.ts
+++ b/packages/shared/types/projects.ts
@@ -29,7 +29,7 @@ export type Project = {
   packageStatus?: {
     [packageName: string]: {
       isOutdated: boolean;
-      isUpdated?: boolean;
+      showUpdatedNotification?: boolean;
     };
   };
 };

--- a/packages/shared/types/settings.ts
+++ b/packages/shared/types/settings.ts
@@ -1,0 +1,5 @@
+export enum UPDATE_DEPENDENCIES_STRATEGY {
+  AUTO_UPDATE = 'auto_update',
+  NOTIFY = 'notify',
+  DO_NOTHING = 'do_nothing',
+}


### PR DESCRIPTION
This PR adds the settings modal, allowing the user to update the default scenes folder and manage the update behavior for the SDK package.

Also, the PR verifies the status(`outdated|updated`) of the `@dcl/sdk` package in the background when the app is started up.

<img width="871" alt="image" src="https://github.com/user-attachments/assets/00399e12-7476-4699-b7af-bc2a49fce9f8">
