### PR TITLE
chore: analytics improvements

### DIFF
--- a/packages/main/src/modules/analytics.ts
+++ b/packages/main/src/modules/analytics.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { config } from './config';
 
 let analytics: Analytics | null = null;
-
+const sessionId = randomUUID();
 let _userId: string | null = null;
 
 export function getUserId() {
@@ -45,7 +45,14 @@ export async function track(event: string, properties: Record<string, any> = {})
     const analytics = await getAnalytics();
     if (!analytics) return;
     const anonymousId = await getAnonymousId();
-    const params: TrackParams = { event, properties, anonymousId };
+    const params: TrackParams = {
+      event,
+      properties: {
+        ...properties,
+        sessionId,
+      },
+      anonymousId,
+    };
     const userId = getUserId();
     if (userId) {
       params.userId = userId;

--- a/packages/main/src/modules/ipc.ts
+++ b/packages/main/src/modules/ipc.ts
@@ -27,7 +27,8 @@ export function initIpc() {
 
   // analytics
   handle('analytics.track', (_event, eventName, data) => analytics.track(eventName, data));
-  handle('analytics.getUserId', () => analytics.getUserId());
+  handle('analytics.identify', (_event, userId, traits) => analytics.identify(userId, traits));
+  handle('analytics.getAnonymousId', () => analytics.getAnonymousId());
 
   // npm
   handle('npm.install', (_event, path) => npm.install(path));

--- a/packages/preload/src/modules/analytics.ts
+++ b/packages/preload/src/modules/analytics.ts
@@ -4,6 +4,10 @@ export async function track(event: string, data?: Record<string, any>) {
   await invoke('analytics.track', event, data);
 }
 
-export async function getUserId() {
-  return invoke('analytics.getUserId');
+export async function identify(userId: string, traits?: Record<string, any>) {
+  await invoke('analytics.identify', userId, traits);
+}
+
+export async function getAnonymousId() {
+  return invoke('analytics.getAnonymousId');
 }

--- a/packages/renderer/src/components/AuthProvider/component.tsx
+++ b/packages/renderer/src/components/AuthProvider/component.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from '#store';
 import { AuthContext } from '/@/contexts/AuthContext';
 import Profiles from '/@/lib/profile';
 import { fetchENSList } from '/@/modules/store/ens';
+import { identify } from '/@/modules/store/analytics';
 import type { AuthSignInProps } from './types';
 
 const AUTH_SERVER_URL = 'https://auth-api.decentraland.org';
@@ -95,6 +96,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   useEffect(() => {
     if (wallet && chainId) {
       dispatch(fetchENSList({ address: wallet, chainId }));
+      dispatch(identify({ userId: wallet }));
     }
   }, [wallet, chainId]);
 

--- a/packages/renderer/src/modules/store/analytics/slice.ts
+++ b/packages/renderer/src/modules/store/analytics/slice.ts
@@ -2,17 +2,27 @@ import { analytics } from '#preload';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 // actions
-export const fetchUserId = createAsyncThunk('analytics/fetchUserId', analytics.getUserId);
+export const fetchAnonymousId = createAsyncThunk(
+  'analytics/fetchAnonymousId',
+  analytics.getAnonymousId,
+);
+export const identify = createAsyncThunk(
+  'analytics/identify',
+  async (opts: { userId: string; traits?: Record<string, any> }) =>
+    analytics.identify(opts.userId, opts.traits),
+);
 
 // state
 export type AnalyticsState = {
   loading: boolean;
+  anonymousId: string | null;
   userId: string | null;
   error: string | null;
 };
 
 const initialState: AnalyticsState = {
   loading: false,
+  anonymousId: null,
   userId: null,
   error: null,
 };
@@ -25,17 +35,20 @@ export const slice = createSlice({
   initialState,
   reducers: {},
   extraReducers: builder => {
-    builder.addCase(fetchUserId.pending, state => {
+    builder.addCase(fetchAnonymousId.pending, state => {
       state.loading = true;
     });
-    builder.addCase(fetchUserId.fulfilled, (state, action) => {
+    builder.addCase(fetchAnonymousId.fulfilled, (state, action) => {
       state.loading = false;
-      state.userId = action.payload;
+      state.anonymousId = action.payload;
       state.error = null;
     });
-    builder.addCase(fetchUserId.rejected, (state, action) => {
+    builder.addCase(fetchAnonymousId.rejected, (state, action) => {
       state.loading = false;
       state.error = action.error.message || null;
+    });
+    builder.addCase(identify.pending, (state, action) => {
+      state.userId = action.meta.arg.userId;
     });
   },
 });
@@ -43,7 +56,7 @@ export const slice = createSlice({
 // exports
 export const actions = {
   ...slice.actions,
-  fetchUserId,
+  fetchAnonymousId,
 };
 export const reducer = slice.reducer;
 export const selectors = { ...slice.selectors };

--- a/packages/renderer/src/modules/store/analytics/track.ts
+++ b/packages/renderer/src/modules/store/analytics/track.ts
@@ -24,6 +24,8 @@ trackAction(workspaceActions.saveThumbnail.fulfilled, 'Save Project Success', as
 trackAction(editorActions.runScene.pending, 'Preview Scene', async (_action, getState) => ({
   project_id: getState().editor.project?.id,
 }));
-trackAction(editorActions.publishScene.fulfilled, 'Publish Scene', async (_action, getState) => ({
+trackAction(editorActions.publishScene.fulfilled, 'Publish Scene', async (action, getState) => ({
   project_id: getState().editor.project?.id,
+  target: action.meta.arg.target,
+  targetContent: action.meta.arg.targetContent,
 }));

--- a/packages/renderer/src/modules/store/analytics/track.ts
+++ b/packages/renderer/src/modules/store/analytics/track.ts
@@ -21,5 +21,9 @@ trackAction(workspaceActions.saveThumbnail.fulfilled, 'Save Project Success', as
   project_name: action.payload.title,
 }));
 
-trackAction(editorActions.openPreview.fulfilled, 'Preview Scene');
-trackAction(editorActions.publishScene.fulfilled, 'Publish Scene');
+trackAction(editorActions.runScene.pending, 'Preview Scene', async (_action, getState) => ({
+  project_id: getState().editor.project?.id,
+}));
+trackAction(editorActions.publishScene.fulfilled, 'Publish Scene', async (_action, getState) => ({
+  project_id: getState().editor.project?.id,
+}));

--- a/packages/renderer/src/modules/store/analytics/types.ts
+++ b/packages/renderer/src/modules/store/analytics/types.ts
@@ -1,3 +1,4 @@
+import { type GetState } from '#store';
 import type { Action } from '@reduxjs/toolkit';
 
 export type WindowWithAnalytics = Window & {
@@ -21,4 +22,5 @@ export interface TypedActionCreator<Type extends string> {
 
 export type GetPayload<A extends TypedActionCreator<string>> = (
   action: ReturnType<A>,
+  getState: GetState,
 ) => Promise<Record<string, string | number | undefined | null>>;

--- a/packages/renderer/src/modules/store/analytics/utils.ts
+++ b/packages/renderer/src/modules/store/analytics/utils.ts
@@ -1,5 +1,6 @@
 import type { Action } from '@reduxjs/toolkit';
 import { analytics } from '#preload';
+import { store } from '#store';
 import type {
   AnalyticsAction,
   EventName,
@@ -21,7 +22,7 @@ export async function handleAction(action: Action) {
       event = eventName(action);
     }
 
-    const payload = getPayload ? await getPayload(action) : undefined;
+    const payload = getPayload ? await getPayload(action, store.getState) : undefined;
 
     await analytics.track(event, payload);
   }

--- a/packages/renderer/src/modules/store/editor/slice.ts
+++ b/packages/renderer/src/modules/store/editor/slice.ts
@@ -1,4 +1,4 @@
-import { editor, misc } from '#preload';
+import { editor } from '#preload';
 import { createAsyncThunk, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { type Project } from '/shared/types/projects';
@@ -10,7 +10,6 @@ export const install = createAsyncThunk('editor/install', editor.install);
 export const startInspector = createAsyncThunk('editor/startInspector', editor.startInspector);
 export const runScene = createAsyncThunk('editor/runScene', editor.runScene);
 export const publishScene = createAsyncThunk('editor/publishScene', editor.publishScene);
-export const openPreview = createAsyncThunk('editor/openPreview', misc.openExternal);
 export const openTutorial = createAsyncThunk('editor/openTutorial', editor.openTutorial);
 
 // state
@@ -133,7 +132,6 @@ export const actions = {
   startInspector,
   runScene,
   publishScene,
-  openPreview,
   openTutorial,
 };
 export const reducer = slice.reducer;

--- a/packages/renderer/src/modules/store/index.ts
+++ b/packages/renderer/src/modules/store/index.ts
@@ -53,7 +53,7 @@ async function start() {
     // fetch app version and user id
     await Promise.all([
       store.dispatch(editor.actions.fetchVersion()),
-      store.dispatch(analytics.actions.fetchUserId()),
+      store.dispatch(analytics.actions.fetchAnonymousId()),
     ]);
 
     // install editor dependencies

--- a/packages/shared/types/ipc.ts
+++ b/packages/shared/types/ipc.ts
@@ -14,6 +14,7 @@ export interface Ipc {
   'cli.start': (path: string) => Promise<void>;
   'cli.deploy': (opts: DeployOptions) => Promise<number>;
   'analytics.track': (event: string, data?: Record<string, any>) => void;
-  'analytics.getUserId': () => Promise<string>;
+  'analytics.identify': (userId: string, traits?: Record<string, any>) => void;
+  'analytics.getAnonymousId': () => Promise<string>;
   'npm.install': (path: string) => Promise<void>;
 }


### PR DESCRIPTION
Improved some aspects of analytics as requested:

- Added `project_id` to `PREVIEW` and `PUBLISH` events.
- Switched `userId` for `anonymousId`.
- Added `identify(wallet)` on login. After that, all events will go with `userId` on top of the `anonymousId`.
- Added `target` and `targetContent` to `PUBLISH` to be able to tell if the scene is going to genesis city or a world.
- Added a `sessionId` that lives until the Creator Hub is closed.