### PR TITLE
fix: create home path if it doesnt exist when getting config

### DIFF
--- a/packages/preload/src/modules/config.ts
+++ b/packages/preload/src/modules/config.ts
@@ -26,6 +26,11 @@ function getDefaultConfig(): Config {
  */
 export async function getConfigPath(): Promise<string> {
   const appHome = await invoke('electron.getAppHome');
+  try {
+    await fs.stat(appHome);
+  } catch (error) {
+    await fs.mkdir(appHome);
+  }
   return path.join(appHome, CONFIG_FILE_NAME);
 }
 


### PR DESCRIPTION
Fixes this issue when opening the CH for the first time and the `.decentraland` directory doesn't exist:

![Screenshot 2024-10-04 at 11 45 16 AM](https://github.com/user-attachments/assets/70e926c3-81dc-43f6-be79-b89387fd44c8)
