### PR TITLE
fix: duplicate scene

### DIFF
--- a/packages/renderer/src/modules/store/workspace/slice.ts
+++ b/packages/renderer/src/modules/store/workspace/slice.ts
@@ -110,9 +110,7 @@ export const slice = createSlice({
         state.status = 'failed';
         state.error = action.error.message || `Failed to delete project ${action.meta.arg}`;
       })
-      .addCase(duplicateProject.pending, state => {
-        state.status = 'loading';
-      })
+      .addCase(duplicateProject.pending, _state => {})
       .addCase(duplicateProject.fulfilled, (state, action) => {
         return {
           ...state,


### PR DESCRIPTION
Fixes #142

This PR fixes an issue where a duplicated scene could end up with the same name/path as an existing scene. Now it uses the same logic as when creating a new scene to avoid clashing names.