### PR TITLE
chore: fix e2e tests

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -50,6 +50,7 @@ test('Main window state', async () => {
 
 test('Main window web content', async () => {
   const page = await electronApp.firstWindow();
+  await page.waitForSelector('#app', { state: 'visible' });
   const element = await page.$('#app', { strict: true });
   expect(element, 'Was unable to find the root element').toBeDefined();
   expect((await element!.innerHTML()).trim(), 'Window content was empty').not.equal('');


### PR DESCRIPTION
Sometimes the E2E tests fails because they try to access an element before it is rendered.

This PR fixes this flakyness