### PR TITLE
chore: remove version from artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
           # The following are the parameters required by the esigner-codesign action to work, we must explicitly pass in even the optional ones since we're not using the action directly, but from the checked out repo
           CODE_SIGN_SCRIPT_PATH: "${{ github.workspace }}\\esigner-codesign\\dist\\index.js"
           INPUT_COMMAND: "sign"
-          INPUT_FILE_PATH: "${{ github.workspace }}\\dist\\Decentraland Creator Hub-${{ steps.version.outputs.version }}-win-x64.exe"
+          INPUT_FILE_PATH: "${{ github.workspace }}\\dist\\Decentraland Creator Hub-win-x64.exe"
           INPUT_OVERRIDE: "true"
           INPUT_MALWARE_BLOCK: "false"
           INPUT_CLEAN_LOGS: "false"

--- a/electron-builder.cjs
+++ b/electron-builder.cjs
@@ -11,7 +11,7 @@ const config = {
     target: 'deb',
   },
   productName: 'Decentraland Creator Hub',
-  artifactName: '${productName}-${version}-${os}-${arch}.${ext}',
+  artifactName: '${productName}-${os}-${arch}.${ext}',
   win: {
     publisherName: 'Decentraland Foundation',
     appId: 'Decentraland.CreatorsHub',
@@ -86,9 +86,9 @@ if (process.env.CODE_SIGN_SCRIPT_PATH) {
   config.win.sign = configuration => {
     console.log('Requested signing for ', configuration.path);
 
-    // Only proceed if the versioned .exe file is in the configuration path - skip signing everything else
-    if (!/Decentraland Creator Hub-(\d+)\.(\d+)\.(\d+)-win-x64.exe$/.test(configuration.path)) {
-      console.log('This is not the versioned .exe, skip signing');
+    // Only proceed if the installer .exe file is in the configuration path - skip signing everything else
+    if (!/Decentraland Creator Hub-win-x64.exe$/.test(configuration.path)) {
+      console.log('This is not the installer .exe, skip signing');
       return true;
     }
 


### PR DESCRIPTION
Remove the `-{version}` part of the artifacts generated on each release.

This is so we can always point to download the latest version using static links like this: 

```
https://github.com/decentraland/creator-hub/releases/latest/download/Decentraland-Creator-Hub-{os}-{arch}.{ext}
```

### Examples:
- macOS ARM: `https://github.com/decentraland/creator-hub/releases/latest/download/Decentraland-Creator-Hub-mac-arm64.dmg`
- macOS x64: `https://github.com/decentraland/creator-hub/releases/latest/download/Decentraland-Creator-Hub-mac-x64.dmg`
- Windows: `https://github.com/decentraland/creator-hub/releases/latest/download/Decentraland-Creator-Hub-win-x64.exe`