### PR TITLE
Rework dependency update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16433,7 +16433,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.1.0.tgz",
       "integrity": "sha512-H0jc0q1vOzlEk0TqAKXKZxdl7kX3OFUzCnNVUnq5Pc3DGo0kpeaMuPqxQn235HibwBEb0/pm9dgKTjXy66fBkg==",
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.1.1"
       },

--- a/packages/main/src/modules/ipc.ts
+++ b/packages/main/src/modules/ipc.ts
@@ -31,8 +31,6 @@ export function initIpc() {
   handle('analytics.getAnonymousId', () => analytics.getAnonymousId());
 
   // npm
-  handle('npm.install', (_event, path, packageName) => npm.install(path, packageName));
-  handle('npm.packageOutdated', (_event, path, packageName) =>
-    npm.packageOutdated(path, packageName),
-  );
+  handle('npm.install', (_event, path, packages) => npm.install(path, packages));
+  handle('npm.getOutdatedDeps', (_event, path, packages) => npm.getOutdatedDeps(path, packages));
 }

--- a/packages/main/src/modules/npm.ts
+++ b/packages/main/src/modules/npm.ts
@@ -1,34 +1,67 @@
-import path from 'node:path';
-import { existsSync } from 'node:fs';
-import { run } from './bin';
+import type { Outdated } from '/shared/types/npm';
 
-export async function install(path: string, packageName?: string) {
+import { run, StreamError } from './bin';
+
+export async function install(path: string, packages: string[] = []) {
   const installCommand = run('npm', 'npm', {
-    args: ['install', '--loglevel', 'error', ...(packageName ? ['--save', packageName] : [])],
+    args: ['install', '--loglevel', 'error', ...packages.flatMap(dep => ['--save', dep])],
     cwd: path,
   });
   await installCommand.wait();
 }
 
-export async function packageOutdated(_path: string, packageName: string) {
-  const normalizedPath = path.normalize(_path);
-  const nodeModulesPath = path.join(normalizedPath, 'node_modules');
-
-  if (!existsSync(nodeModulesPath)) {
-    // For projects without node_modules, install dependencies before checking for outdated packages
-    await install(_path);
-  }
-
+/**
+ * Fetches information about outdated dependencies for a given project directory.
+ * It runs the `npm outdated` command and parses the output to return a list of outdated packages.
+ *
+ * @param _path - The directory path where the npm command should be executed.
+ * @param packages - An optional array of specific package names to check for outdated versions.
+ * @returns A Promise that resolves to an object containing details about outdated packages.
+ *          If no outdated packages are found or an error occurs, an empty object is returned.
+ */
+export async function getOutdatedDeps(_path: string, packages: string[] = []): Promise<Outdated> {
   try {
     const npmOutdated = run('npm', 'npm', {
-      args: ['outdated', packageName, '--depth=0'],
+      args: ['outdated', '--depth=0', '--json', ...packages],
       cwd: _path,
     });
 
-    // If the exit code is 0, the package is up to date, otherwise it's outdated
     await npmOutdated.wait();
-    return false;
+    return {};
+  } catch (e) {
+    if (e instanceof StreamError) return parseOutdated(e.stdout);
+    return {};
+  }
+}
+
+/**
+ * Parses the result of `npm outdated --depth=0 --json` to match the `Outdated` structure.
+ * Handles cases where the package info may be an array or an object.
+ *
+ * @param buffer - The Buffer output from the `npm outdated` command.
+ * @returns An object matching the `Outdated` type, containing package names with their current and latest versions.
+ */
+export function parseOutdated(buffer: Buffer): Outdated {
+  try {
+    const parsed = JSON.parse(buffer.toString('utf8'));
+
+    const result: Outdated = {};
+    for (const [pkg, info] of Object.entries(parsed)) {
+      if (Array.isArray(info) && info.length > 0) {
+        result[pkg] = {
+          current: info[0].current,
+          latest: info[0].latest,
+        };
+      } else if (info && typeof info === 'object' && 'current' in info && 'latest' in info) {
+        result[pkg] = {
+          current: info.current as string,
+          latest: info.latest as string,
+        };
+      }
+    }
+
+    return result;
   } catch (_) {
-    return true;
+    return {};
   }
 }

--- a/packages/preload/src/modules/editor.ts
+++ b/packages/preload/src/modules/editor.ts
@@ -1,16 +1,13 @@
-import fs from 'node:fs/promises';
 import path from 'path';
 
 import type { DeployOptions } from '/shared/types/ipc';
+
 import { invoke } from './invoke';
+import * as fs from './fs';
 
 export async function getEditorHome(_path: string) {
   const editorHomePath = path.join(_path, '.editor');
-  try {
-    await fs.stat(editorHomePath);
-  } catch (_) {
-    await fs.mkdir(editorHomePath);
-  }
+  if (!(await fs.exists(editorHomePath))) await fs.mkdir(editorHomePath);
   return editorHomePath;
 }
 

--- a/packages/preload/src/modules/fs.ts
+++ b/packages/preload/src/modules/fs.ts
@@ -37,3 +37,7 @@ export async function readdir(path: string) {
 export async function isDirectory(path: string) {
   return (await fs.stat(path)).isDirectory();
 }
+
+export async function mkdir(path: string) {
+  await fs.mkdir(path);
+}

--- a/packages/preload/src/modules/npm.ts
+++ b/packages/preload/src/modules/npm.ts
@@ -1,3 +1,5 @@
+import type { Outdated } from '/shared/types/npm';
+
 import { invoke } from './invoke';
 
 /**
@@ -6,10 +8,10 @@ import { invoke } from './invoke';
  * @param {string} path - The file system path of the project where dependencies should be installed.
  * @returns {Promise<void>} - A promise that resolves when the installation is complete.
  */
-export async function install(path: string, _package?: string): Promise<void> {
-  await invoke('npm.install', path, _package);
+export async function install(path: string, packages: string[] = []): Promise<void> {
+  await invoke('npm.install', path, packages);
 }
 
-export async function packageOutdated(_path: string, _package: string): Promise<boolean> {
-  return invoke('npm.packageOutdated', _path, _package);
+export async function getOudatedDeps(path: string, packages: string[] = []): Promise<Outdated> {
+  return invoke('npm.getOutdatedDeps', path, packages);
 }

--- a/packages/preload/src/modules/settings.ts
+++ b/packages/preload/src/modules/settings.ts
@@ -2,31 +2,33 @@ import {
   DEPENDENCY_UPDATE_STRATEGY,
   DEFAULT_DEPENDENCY_UPDATE_STRATEGY,
 } from '/shared/types/settings';
+import type { AppSettings } from '/shared/types/settings';
+
 import { invoke } from './invoke';
 import { getConfig, setConfig } from './config';
 
+export function getDefaultScenesPath() {
+  return invoke('electron.getAppHome');
+}
+
 export async function getScenesPath() {
   const config = await getConfig();
-  return config.scenesPath ?? (await invoke('electron.getAppHome'));
+  return config.settings.scenesPath ?? (await getDefaultScenesPath());
 }
 
-export async function setScenesPath(path: string) {
-  await setConfig(config => (config.scenesPath = path));
-}
-
-// Helper to check if a value is part of the enum
-function isValidUpdateStrategy(value?: string): value is DEPENDENCY_UPDATE_STRATEGY {
+export function isValidUpdateStrategy(value?: string): value is DEPENDENCY_UPDATE_STRATEGY {
   return Object.values(DEPENDENCY_UPDATE_STRATEGY).includes(value as DEPENDENCY_UPDATE_STRATEGY);
 }
 
 export async function getUpdateDependenciesStrategy() {
-  const { updateDependenciesStrategy } = await getConfig();
-  if (isValidUpdateStrategy(updateDependenciesStrategy)) return updateDependenciesStrategy;
+  const { dependencyUpdateStrategy } = (await getConfig()).settings;
+  if (isValidUpdateStrategy(dependencyUpdateStrategy)) return dependencyUpdateStrategy;
   return DEFAULT_DEPENDENCY_UPDATE_STRATEGY;
 }
 
-export async function setUpdateDependenciesStrategy(strategy: DEPENDENCY_UPDATE_STRATEGY) {
-  await setConfig(config => (config.updateDependenciesStrategy = strategy));
+export async function updateAppSettings(settings: AppSettings) {
+  // update app settings on config file
+  await setConfig(config => (config.settings = settings));
 }
 
 export async function selectSceneFolder(): Promise<string | undefined> {

--- a/packages/preload/src/modules/settings.ts
+++ b/packages/preload/src/modules/settings.ts
@@ -1,4 +1,7 @@
-import { UPDATE_DEPENDENCIES_STRATEGY } from '/shared/types/settings';
+import {
+  DEPENDENCY_UPDATE_STRATEGY,
+  DEFAULT_DEPENDENCY_UPDATE_STRATEGY,
+} from '/shared/types/settings';
 import { invoke } from './invoke';
 import { getConfig, setConfig } from './config';
 
@@ -12,25 +15,17 @@ export async function setScenesPath(path: string) {
 }
 
 // Helper to check if a value is part of the enum
-function isValidUpdateStrategy(value: string): value is UPDATE_DEPENDENCIES_STRATEGY {
-  return Object.values(UPDATE_DEPENDENCIES_STRATEGY).includes(
-    value as UPDATE_DEPENDENCIES_STRATEGY,
-  );
+function isValidUpdateStrategy(value?: string): value is DEPENDENCY_UPDATE_STRATEGY {
+  return Object.values(DEPENDENCY_UPDATE_STRATEGY).includes(value as DEPENDENCY_UPDATE_STRATEGY);
 }
 
 export async function getUpdateDependenciesStrategy() {
-  const config = await getConfig();
-  if (
-    config.updateDependenciesStrategy &&
-    isValidUpdateStrategy(config.updateDependenciesStrategy)
-  ) {
-    return config.updateDependenciesStrategy;
-  } else {
-    return UPDATE_DEPENDENCIES_STRATEGY.NOTIFY;
-  }
+  const { updateDependenciesStrategy } = await getConfig();
+  if (isValidUpdateStrategy(updateDependenciesStrategy)) return updateDependenciesStrategy;
+  return DEFAULT_DEPENDENCY_UPDATE_STRATEGY;
 }
 
-export async function setUpdateDependenciesStrategy(strategy: UPDATE_DEPENDENCIES_STRATEGY) {
+export async function setUpdateDependenciesStrategy(strategy: DEPENDENCY_UPDATE_STRATEGY) {
   await setConfig(config => (config.updateDependenciesStrategy = strategy));
 }
 

--- a/packages/renderer/src/components/HomePage/component.tsx
+++ b/packages/renderer/src/components/HomePage/component.tsx
@@ -110,7 +110,7 @@ const SignInCard: React.FC<SignInCardProps> = React.memo(({ onClickSignIn }) => 
 
 const ScenesCard: React.FC = React.memo(() => {
   const navigate = useNavigate();
-  const { projects, isLoading, selectProject } = useWorkspace();
+  const { projects, isLoading, runProject } = useWorkspace();
   const emptyProjects = projects.length === 0;
 
   const handleStartBuildingClick = useCallback(() => {
@@ -122,7 +122,7 @@ const ScenesCard: React.FC = React.memo(() => {
   }, []);
 
   const handleProjectClick = useCallback((project: Project) => {
-    selectProject(project);
+    runProject(project);
   }, []);
 
   return (

--- a/packages/renderer/src/components/Modals/AppSettings/component.tsx
+++ b/packages/renderer/src/components/Modals/AppSettings/component.tsx
@@ -15,7 +15,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import FolderIcon from '@mui/icons-material/Folder';
 import { Modal } from 'decentraland-ui2/dist/components/Modal/Modal';
 import { settings as settingsPreload } from '#preload';
-import { UPDATE_DEPENDENCIES_STRATEGY } from '/shared/types/settings';
+import { DEPENDENCY_UPDATE_STRATEGY } from '/shared/types/settings';
 import { t } from '/@/modules/store/translation/utils';
 import { useSettings } from '/@/hooks/useSettings';
 
@@ -25,7 +25,7 @@ export function AppSettings({ open, onClose }: { open: boolean; onClose: () => v
   const settings = useSettings();
   const [scenesPath, setScenesPath] = useState('');
   const [updateDependenciesStrategy, setUpdateDependenciesStrategy] =
-    useState<UPDATE_DEPENDENCIES_STRATEGY>(UPDATE_DEPENDENCIES_STRATEGY.NOTIFY);
+    useState<DEPENDENCY_UPDATE_STRATEGY>(DEPENDENCY_UPDATE_STRATEGY.NOTIFY);
   const [isDirty, setIsDirty] = useState(false);
 
   useEffect(() => {
@@ -52,7 +52,7 @@ export function AppSettings({ open, onClose }: { open: boolean; onClose: () => v
 
   const handleChangeUpdateDependenciesStrategy = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value as UPDATE_DEPENDENCIES_STRATEGY;
+      const value = event.target.value as DEPENDENCY_UPDATE_STRATEGY;
       setUpdateDependenciesStrategy(value);
     },
     [],
@@ -131,17 +131,17 @@ export function AppSettings({ open, onClose }: { open: boolean; onClose: () => v
               onChange={handleChangeUpdateDependenciesStrategy}
             >
               <FormControlLabel
-                value={UPDATE_DEPENDENCIES_STRATEGY.AUTO_UPDATE}
+                value={DEPENDENCY_UPDATE_STRATEGY.AUTO_UPDATE}
                 control={<Radio />}
                 label={t('modal.app_settings.fields.scene_editor_dependencies.options.auto_update')}
               />
               <FormControlLabel
-                value={UPDATE_DEPENDENCIES_STRATEGY.NOTIFY}
+                value={DEPENDENCY_UPDATE_STRATEGY.NOTIFY}
                 control={<Radio />}
                 label={t('modal.app_settings.fields.scene_editor_dependencies.options.notify')}
               />
               <FormControlLabel
-                value={UPDATE_DEPENDENCIES_STRATEGY.DO_NOTHING}
+                value={DEPENDENCY_UPDATE_STRATEGY.DO_NOTHING}
                 control={<Radio />}
                 label={t('modal.app_settings.fields.scene_editor_dependencies.options.do_nothing')}
               />

--- a/packages/renderer/src/components/Modals/AppSettings/component.tsx
+++ b/packages/renderer/src/components/Modals/AppSettings/component.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
@@ -14,69 +14,53 @@ import {
 import CloseIcon from '@mui/icons-material/Close';
 import FolderIcon from '@mui/icons-material/Folder';
 import { Modal } from 'decentraland-ui2/dist/components/Modal/Modal';
+import equal from 'fast-deep-equal';
+
 import { settings as settingsPreload } from '#preload';
+
 import { DEPENDENCY_UPDATE_STRATEGY } from '/shared/types/settings';
+
 import { t } from '/@/modules/store/translation/utils';
 import { useSettings } from '/@/hooks/useSettings';
 
 import './styles.css';
 
 export function AppSettings({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const settings = useSettings();
-  const [scenesPath, setScenesPath] = useState('');
-  const [updateDependenciesStrategy, setUpdateDependenciesStrategy] =
-    useState<DEPENDENCY_UPDATE_STRATEGY>(DEPENDENCY_UPDATE_STRATEGY.NOTIFY);
-  const [isDirty, setIsDirty] = useState(false);
+  const { settings: _settings, updateAppSettings } = useSettings();
+  const [settings, setSettings] = useState(_settings);
 
   useEffect(() => {
-    const checkIfDirty = async () => {
-      const scenesPathSetting = settings.scenesPath;
-      const updateStrategySetting = settings.updateDependenciesStrategy;
+    if (!equal(_settings, settings)) setSettings(_settings);
+  }, [_settings]);
 
-      setIsDirty(
-        scenesPath !== scenesPathSetting || updateDependenciesStrategy !== updateStrategySetting,
-      );
-    };
-
-    checkIfDirty();
-  }, [scenesPath, updateDependenciesStrategy]);
-
-  const handleChangeSceneFolder = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    setScenesPath(event.target.value);
-  }, []);
-
-  const handleClickChangeSceneFolder = useCallback(() => {
-    settings.setScenesPath(scenesPath);
-    onClose();
-  }, [scenesPath]);
+  const handleChangeSceneFolder = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setSettings({ ...settings, scenesPath: event.target.value });
+    },
+    [settings],
+  );
 
   const handleChangeUpdateDependenciesStrategy = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value as DEPENDENCY_UPDATE_STRATEGY;
-      setUpdateDependenciesStrategy(value);
+      setSettings({
+        ...settings,
+        dependencyUpdateStrategy: event.target.value as DEPENDENCY_UPDATE_STRATEGY,
+      });
     },
-    [],
+    [settings],
   );
 
-  const handleClickApply = useCallback(async () => {
-    await settings.setScenesPath(scenesPath);
-    await settings.setUpdateDependenciesStrategy(updateDependenciesStrategy);
+  const handleClickApply = useCallback(() => {
+    updateAppSettings(settings);
     onClose();
-  }, [scenesPath, updateDependenciesStrategy]);
+  }, [settings, updateAppSettings]);
 
   const handleOpenFolder = useCallback(async () => {
     const folder = await settingsPreload.selectSceneFolder();
-    if (folder) {
-      setScenesPath(folder);
-    }
-  }, []);
+    if (folder) setSettings({ ...settings, scenesPath: folder });
+  }, [settings]);
 
-  useEffect(() => {
-    const path = settings.scenesPath;
-    const strategy = settings.updateDependenciesStrategy;
-    setScenesPath(path);
-    setUpdateDependenciesStrategy(strategy);
-  }, [settings.scenesPath, settings.updateDependenciesStrategy]);
+  const isDirty = useMemo(() => !equal(_settings, settings), [settings, _settings]);
 
   return (
     <Modal
@@ -99,7 +83,7 @@ export function AppSettings({ open, onClose }: { open: boolean; onClose: () => v
             </Typography>
             <OutlinedInput
               color="secondary"
-              value={scenesPath}
+              value={settings.scenesPath}
               onChange={handleChangeSceneFolder}
               endAdornment={
                 <InputAdornment position="end">
@@ -112,22 +96,13 @@ export function AppSettings({ open, onClose }: { open: boolean; onClose: () => v
                 </InputAdornment>
               }
             />
-            <Button
-              className="ChangeSceneFolderButton"
-              variant="contained"
-              color="secondary"
-              disableRipple
-              onClick={handleClickChangeSceneFolder}
-            >
-              {t('modal.app_settings.fields.scenes_folder.change_button')}
-            </Button>
           </FormGroup>
           <FormGroup sx={{ gap: '16px' }}>
             <Typography variant="body1">
               {t('modal.app_settings.fields.scene_editor_dependencies.label')}
             </Typography>
             <RadioGroup
-              value={updateDependenciesStrategy}
+              value={settings.dependencyUpdateStrategy}
               onChange={handleChangeUpdateDependenciesStrategy}
             >
               <FormControlLabel

--- a/packages/renderer/src/components/SceneList/Projects/component.tsx
+++ b/packages/renderer/src/components/SceneList/Projects/component.tsx
@@ -27,26 +27,24 @@ export function Projects({ projects }: Props) {
         onClick={() => navigate('/templates')}
       ></div>
       {projects.map(project => (
-        <>
-          <Project
-            key={project.path}
-            project={project}
-          />
-        </>
+        <Project
+          key={project.path}
+          project={project}
+        />
       ))}
     </>
   );
 }
 
 function Project({ project }: { project: Project }) {
-  const { selectProject, duplicateProject, deleteProject, openFolder } = useWorkspace();
+  const { runProject, duplicateProject, deleteProject, openFolder } = useWorkspace();
   const [open, setOpen] = useState(false);
 
   const parcels = project.layout.cols * project.layout.rows;
 
   const handleClick = useCallback(() => {
-    selectProject(project);
-  }, [project, selectProject]);
+    runProject(project);
+  }, [project, runProject]);
 
   const handleDuplicateProject = useCallback(() => {
     duplicateProject(project);

--- a/packages/renderer/src/components/Snackbar/DependencyVersion/index.tsx
+++ b/packages/renderer/src/components/Snackbar/DependencyVersion/index.tsx
@@ -9,11 +9,11 @@ import { useWorkspace } from '/@/hooks/useWorkspace';
 
 export function NewDependencyVersion({ onClose }: { onClose: () => void }) {
   const { project } = useEditor();
-  const { updateSdkPackage } = useWorkspace();
+  const { updatePackages } = useWorkspace();
 
   const handleClickUpdate = useCallback(() => {
     if (project) {
-      updateSdkPackage(project.path);
+      updatePackages(project);
     }
     onClose();
   }, [project]);
@@ -32,7 +32,7 @@ export function NewDependencyVersion({ onClose }: { onClose: () => void }) {
         </IconButton>
       </>
     ),
-    [],
+    [project],
   );
 
   return (
@@ -43,31 +43,6 @@ export function NewDependencyVersion({ onClose }: { onClose: () => void }) {
       sx={{ alignItems: 'center' }}
     >
       {t('snackbar.new_dependency_version.title')}
-    </Alert>
-  );
-}
-
-export function DependencyUpdatedAutomatically({ onClose }: { onClose: () => void }) {
-  const renderActions = useCallback(
-    () => (
-      <Button
-        variant="text"
-        onClick={onClose}
-      >
-        {t('snackbar.dependency_updated_automatically.actions.ok')}
-      </Button>
-    ),
-    [],
-  );
-
-  return (
-    <Alert
-      icon={<NotificationImportantIcon color="secondary" />}
-      severity="info"
-      action={renderActions()}
-      sx={{ alignItems: 'center' }}
-    >
-      {t('snackbar.dependency_updated_automatically.title')}
     </Alert>
   );
 }

--- a/packages/renderer/src/components/Snackbar/component.tsx
+++ b/packages/renderer/src/components/Snackbar/component.tsx
@@ -6,7 +6,7 @@ import { useSnackbar } from '/@/hooks/useSnackbar';
 
 import { MissingScenes } from './MissingScenes';
 import { Generic } from './Generic';
-import { DependencyUpdatedAutomatically, NewDependencyVersion } from './DependencyVersion';
+import { NewDependencyVersion } from './DependencyVersion';
 
 import './styles.css';
 
@@ -23,8 +23,6 @@ export function SnackbarComponent() {
         return <MissingScenes onClose={close(notification.id)} />;
       case 'new-dependency-version':
         return <NewDependencyVersion onClose={close(notification.id)} />;
-      case 'dependency-updated-automatically':
-        return <DependencyUpdatedAutomatically onClose={close(notification.id)} />;
       default:
         return null;
     }

--- a/packages/renderer/src/hooks/useEditor.ts
+++ b/packages/renderer/src/hooks/useEditor.ts
@@ -79,7 +79,6 @@ export const useEditor = () => {
 
   return {
     ...editor,
-    project,
     startInspector,
     runScene,
     publishScene,

--- a/packages/renderer/src/hooks/useEditor.ts
+++ b/packages/renderer/src/hooks/useEditor.ts
@@ -71,7 +71,6 @@ export const useEditor = () => {
   const updateProject = useCallback(
     (updatedProject: Project) => {
       if (!project || !updatedProject || project.path !== updatedProject.path) return;
-
       dispatch(workspaceActions.updateProject(updatedProject));
     },
     [workspaceActions.updateProject, project],

--- a/packages/renderer/src/hooks/useSettings.ts
+++ b/packages/renderer/src/hooks/useSettings.ts
@@ -1,40 +1,21 @@
-import { useCallback, useEffect, useState } from 'react';
-import { settings } from '#preload';
-import { DEPENDENCY_UPDATE_STRATEGY } from '/shared/types/settings';
+import { useCallback } from 'react';
+
+import { useDispatch, useSelector } from '#store';
+
+import { type AppSettings } from '/shared/types/settings';
+
+import { actions as workspaceActions } from '/@/modules/store/workspace';
 
 export const useSettings = () => {
-  const [scenesPath, setScenesPath] = useState('');
-  const [updateDependenciesStrategy, setUpdateDependenciesStrategy] =
-    useState<DEPENDENCY_UPDATE_STRATEGY>(DEPENDENCY_UPDATE_STRATEGY.NOTIFY);
+  const dispatch = useDispatch();
+  const { settings } = useSelector(state => state.workspace);
 
-  const handleUpdateScenesPath = useCallback(async (path: string) => {
-    await settings.setScenesPath(path);
-    setScenesPath(path);
-  }, []);
-
-  const handleUpdateDependenciesStrategy = useCallback(
-    async (strategy: DEPENDENCY_UPDATE_STRATEGY) => {
-      await settings.setUpdateDependenciesStrategy(strategy);
-      setUpdateDependenciesStrategy(strategy);
-    },
-    [],
-  );
-
-  useEffect(() => {
-    async function getAppSettings() {
-      const path = await settings.getScenesPath();
-      const strategy = await settings.getUpdateDependenciesStrategy();
-      setScenesPath(path);
-      setUpdateDependenciesStrategy(strategy);
-    }
-
-    getAppSettings();
+  const updateAppSettings = useCallback((settings: AppSettings) => {
+    dispatch(workspaceActions.updateSettings(settings));
   }, []);
 
   return {
-    scenesPath,
-    updateDependenciesStrategy,
-    setScenesPath: handleUpdateScenesPath,
-    setUpdateDependenciesStrategy: handleUpdateDependenciesStrategy,
+    settings,
+    updateAppSettings,
   };
 };

--- a/packages/renderer/src/hooks/useSettings.ts
+++ b/packages/renderer/src/hooks/useSettings.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import { settings } from '#preload';
-import { UPDATE_DEPENDENCIES_STRATEGY } from '/shared/types/settings';
+import { DEPENDENCY_UPDATE_STRATEGY } from '/shared/types/settings';
 
 export const useSettings = () => {
   const [scenesPath, setScenesPath] = useState('');
   const [updateDependenciesStrategy, setUpdateDependenciesStrategy] =
-    useState<UPDATE_DEPENDENCIES_STRATEGY>(UPDATE_DEPENDENCIES_STRATEGY.NOTIFY);
+    useState<DEPENDENCY_UPDATE_STRATEGY>(DEPENDENCY_UPDATE_STRATEGY.NOTIFY);
 
   const handleUpdateScenesPath = useCallback(async (path: string) => {
     await settings.setScenesPath(path);
@@ -13,7 +13,7 @@ export const useSettings = () => {
   }, []);
 
   const handleUpdateDependenciesStrategy = useCallback(
-    async (strategy: UPDATE_DEPENDENCIES_STRATEGY) => {
+    async (strategy: DEPENDENCY_UPDATE_STRATEGY) => {
       await settings.setUpdateDependenciesStrategy(strategy);
       setUpdateDependenciesStrategy(strategy);
     },

--- a/packages/renderer/src/hooks/useSnackbar.ts
+++ b/packages/renderer/src/hooks/useSnackbar.ts
@@ -3,12 +3,7 @@ import { type SnackbarCloseReason } from 'decentraland-ui2';
 
 import { useDispatch, useSelector } from '#store';
 import { actions } from '/@/modules/store/snackbar';
-import type {
-  CustomNotification,
-  Notification,
-  Opts,
-  Severity,
-} from '/@/modules/store/snackbar/types';
+import type { Notification } from '/@/modules/store/snackbar/types';
 
 export function useSnackbar() {
   const dispatch = useDispatch();
@@ -17,10 +12,10 @@ export function useSnackbar() {
   const dismiss = useCallback(
     (id: Notification['id'], idx: number) =>
       (_: SyntheticEvent<any> | Event, reason: SnackbarCloseReason) => {
-        if (reason === 'timeout') dispatch(actions.removeSnackbar({ id }));
+        if (reason === 'timeout') dispatch(actions.removeSnackbar(id));
         if (reason === 'escapeKeyDown' && idx === 0) {
           const first = snackbar.notifications[0];
-          dispatch(actions.removeSnackbar({ id: first.id }));
+          dispatch(actions.removeSnackbar(first.id));
         }
       },
     [snackbar.notifications],
@@ -28,27 +23,14 @@ export function useSnackbar() {
 
   const close = useCallback(
     (id: Notification['id']) => () => {
-      dispatch(actions.removeSnackbar({ id }));
+      dispatch(actions.removeSnackbar(id));
     },
     [],
   );
-
-  const createGenericNotification = useCallback(
-    (severity: Severity, message: string, opts?: Opts) => {
-      dispatch(actions.createGenericNotification({ severity, message, opts }));
-    },
-    [],
-  );
-
-  const createCustomNotification = useCallback((type: CustomNotification['type'], opts?: Opts) => {
-    dispatch(actions.createCustomNotification({ type, opts }));
-  }, []);
 
   return {
     ...snackbar,
     close,
     dismiss,
-    createGenericNotification,
-    createCustomNotification,
   };
 }

--- a/packages/renderer/src/hooks/useWorkspace.ts
+++ b/packages/renderer/src/hooks/useWorkspace.ts
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { useDispatch, useSelector } from '#store';
 
 import { type Project, type SortBy } from '/shared/types/projects';
 
 import { actions as workspaceActions } from '/@/modules/store/workspace';
-import { useNavigate } from 'react-router-dom';
 
 export const useWorkspace = () => {
   const dispatch = useDispatch();
@@ -20,13 +20,9 @@ export const useWorkspace = () => {
     dispatch(workspaceActions.setSortBy(type));
   }, []);
 
-  const selectProject = useCallback(async (project: Project) => {
-    try {
-      await dispatch(workspaceActions.selectProject(project)).unwrap();
-      navigate('/editor');
-    } catch (e) {
-      dispatch(workspaceActions.moveProjectToMissing(project));
-    }
+  const runProject = useCallback(async (project: Project) => {
+    dispatch(workspaceActions.runProject(project));
+    navigate('/editor');
   }, []);
 
   const createProject = useCallback((opts?: { name?: string; repo?: string }) => {
@@ -58,8 +54,8 @@ export const useWorkspace = () => {
     dispatch(workspaceActions.openFolder(path));
   }, []);
 
-  const updateSdkPackage = useCallback((path: string) => {
-    dispatch(workspaceActions.updateSdkPackage(path));
+  const updatePackages = useCallback((project: Project) => {
+    dispatch(workspaceActions.updatePackages(project));
   }, []);
 
   const isLoading = workspace.status === 'loading';
@@ -68,7 +64,7 @@ export const useWorkspace = () => {
     ...workspace,
     getWorkspace,
     setSortBy,
-    selectProject,
+    runProject,
     createProject,
     deleteProject,
     duplicateProject,
@@ -76,7 +72,7 @@ export const useWorkspace = () => {
     reimportProject,
     unlistProjects,
     openFolder,
-    updateSdkPackage,
+    updatePackages,
     isLoading,
   };
 };

--- a/packages/renderer/src/modules/rpc/index.ts
+++ b/packages/renderer/src/modules/rpc/index.ts
@@ -3,7 +3,9 @@ import { MessageTransport } from '@dcl/mini-rpc';
 import { CameraRPC } from './camera';
 
 import { fs } from '#preload';
+
 import { type Project } from '/shared/types/projects';
+
 import { UiRPC } from './ui';
 import { type Method, type Params, type Result, StorageRPC } from './storage';
 

--- a/packages/renderer/src/modules/store/analytics/slice.ts
+++ b/packages/renderer/src/modules/store/analytics/slice.ts
@@ -1,5 +1,6 @@
-import { analytics } from '#preload';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+import { analytics } from '#preload';
 
 // actions
 export const fetchAnonymousId = createAsyncThunk(

--- a/packages/renderer/src/modules/store/analytics/track.ts
+++ b/packages/renderer/src/modules/store/analytics/track.ts
@@ -10,7 +10,7 @@ trackAction(workspaceActions.createProject.fulfilled, 'Create Project', async ac
   cols: action.payload.layout.cols,
 }));
 
-trackAction(editorActions.setProject.fulfilled, 'Open Project', async action => ({
+trackAction(workspaceActions.runProject.fulfilled, 'Open Project', async action => ({
   project_id: action.payload.id,
   project_name: action.payload.title,
 }));

--- a/packages/renderer/src/modules/store/index.ts
+++ b/packages/renderer/src/modules/store/index.ts
@@ -5,6 +5,7 @@ import {
   useDispatch as formerUseDispuseDispatch,
 } from 'react-redux';
 import logger from 'redux-logger';
+
 import { createAnalyticsMiddleware } from './analytics/middleware';
 import * as editor from './editor';
 import * as snackbar from './snackbar';

--- a/packages/renderer/src/modules/store/snackbar/types.ts
+++ b/packages/renderer/src/modules/store/snackbar/types.ts
@@ -3,24 +3,22 @@ import type { Project } from '/shared/types/projects';
 
 export type Severity = AlertColor | 'loading';
 export type NotificationId = string;
-type CustomNotificationType =
-  | 'missing-scenes'
-  | 'new-dependency-version'
-  | 'dependency-updated-automatically';
+export type CustomNotificationType =
+  | { type: 'missing-scenes' }
+  | { type: 'new-dependency-version'; project: Project };
 
 export type Opts = {
   requestId?: string;
   duration?: number;
-  project?: Project;
 };
 
-type CommonNotificationProps<T extends string> = {
+type CommonNotificationProps<T extends { type: string }> = {
   id: NotificationId;
-  type: T;
-} & Opts;
+} & T &
+  Opts;
 
 export type CustomNotification = CommonNotificationProps<CustomNotificationType>;
-export type GenericNotification = CommonNotificationProps<'generic'> & {
+export type GenericNotification = CommonNotificationProps<{ type: 'generic' }> & {
   severity: Severity;
   message: string;
 };

--- a/packages/renderer/src/modules/store/snackbar/utils.ts
+++ b/packages/renderer/src/modules/store/snackbar/utils.ts
@@ -1,4 +1,5 @@
 import type {
+  CustomNotificationType,
   CustomNotification,
   GenericNotification,
   NotificationId,
@@ -13,10 +14,10 @@ function getId(type: string): NotificationId {
 }
 
 export function createCustomNotification(
-  type: CustomNotification['type'],
+  notification: CustomNotificationType,
   opts?: Opts,
 ): CustomNotification {
-  return { ...opts, id: opts?.requestId || getId(type), type };
+  return { ...notification, ...opts, id: opts?.requestId || getId(notification.type) };
 }
 
 export function createGenericNotification(

--- a/packages/renderer/src/modules/store/thunk.ts
+++ b/packages/renderer/src/modules/store/thunk.ts
@@ -1,0 +1,16 @@
+// IMPORTANT!
+// TLDR: This intermediate file is needed to avoid circular dependencies between the reducers and the store...
+
+// Reason: Since using ".withTypes" requires the store state, this function will be defined after
+// the store is resolved. But the store file calls all the reducers to create the store and also calls
+// all the reducers files. The reducers files define thunks using "createAsyncThunk", so they require the
+// store to be defined, thus the circular dependency error. Using an intermediate file solves this problem.
+
+import { createAsyncThunk as formerCreateAsyncThunk } from '@reduxjs/toolkit';
+
+import type { AppDispatch, AppState } from '.';
+
+export const createAsyncThunk = formerCreateAsyncThunk.withTypes<{
+  state: AppState;
+  dispatch: AppDispatch;
+}>();

--- a/packages/renderer/src/modules/store/translation/locales/en.json
+++ b/packages/renderer/src/modules/store/translation/locales/en.json
@@ -171,7 +171,8 @@
       "duplicate_scene": "Duplicating scene...",
       "duplicate_scene_failed": "Failed duplicating scene",
       "delete_scene": "Deleting scene...",
-      "delete_scene_failed": "Failed deleting scene"
+      "delete_scene_failed": "Failed deleting scene",
+      "dependencies_updated": "Scene dependencies were updated"
     },
     "missing_projects": {
       "title": "{scenes} {scenes, plural, one {scene} other {scenes}} could not be loaded due to missing files",
@@ -184,12 +185,6 @@
       "title": "New dependencies version detected",
       "actions": {
         "update": "Update"
-      }
-    },
-    "dependency_updated_automatically": {
-      "title": "Scene dependencies were updated",
-      "actions": {
-        "ok": "Ok"
       }
     }
   },

--- a/packages/renderer/src/modules/store/translation/locales/es.json
+++ b/packages/renderer/src/modules/store/translation/locales/es.json
@@ -169,7 +169,8 @@
       "duplicate_scene": "Duplicando escena...",
       "duplicate_scene_failed": "Error al duplicar escena",
       "delete_scene": "Borrando escena...",
-      "delete_scene_failed": "Error al borrar escena"
+      "delete_scene_failed": "Error al borrar escena",
+      "dependencies_updated": "Las dependencias de la escena fueron actualizadas"
     },
     "missing_projects": {
       "title": "{scenes} {scenes, plural, one {escena} other {escenas}} {scenes, plural, one {faltante} other {faltantes}}",
@@ -182,12 +183,6 @@
       "title": "Se detectó una nueva versión de dependencias",
       "actions": {
         "update": "Actualizar"
-      }
-    },
-    "dependency_updated_automatically": {
-      "title": "Las dependencias de la escena fueron actualizadas",
-      "actions": {
-        "ok": "Ok"
       }
     }
   },

--- a/packages/renderer/src/modules/store/translation/locales/zh.json
+++ b/packages/renderer/src/modules/store/translation/locales/zh.json
@@ -169,7 +169,8 @@
       "duplicate_scene": "复制场景...",
       "duplicate_scene_failed": "复制场景失败",
       "delete_scene": "删除场景...",
-      "delete_scene_failed": "删除场景失败"
+      "delete_scene_failed": "删除场景失败",
+      "dependencies_updated": "場景相依性已更新"
     },
     "missing_projects": {
       "title": "{scenes} 丢失的 {scenes, plural, one {场景} other {场景}} 成立",
@@ -182,12 +183,6 @@
       "title": "偵測到新的依賴項版本",
       "actions": {
         "update": "更新"
-      }
-    },
-    "dependency_updated_automatically": {
-      "title": "場景相依性已更新",
-      "actions": {
-        "ok": "好的"
       }
     }
   },

--- a/packages/renderer/src/modules/store/workspace/slice.ts
+++ b/packages/renderer/src/modules/store/workspace/slice.ts
@@ -1,7 +1,7 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { type Project, SortBy } from '/shared/types/projects';
-import { DEPENDENCY_UPDATE_STRATEGY } from '/shared/types/settings';
+import { DEFAULT_DEPENDENCY_UPDATE_STRATEGY } from '/shared/types/settings';
 import { type Workspace } from '/shared/types/workspace';
 
 import type { Async } from '/@/modules/async';
@@ -14,7 +14,8 @@ const initialState: Async<Workspace> = {
   missing: [],
   templates: [],
   settings: {
-    dependencyUpdateStrategy: DEPENDENCY_UPDATE_STRATEGY.NOTIFY,
+    scenesPath: '',
+    dependencyUpdateStrategy: DEFAULT_DEPENDENCY_UPDATE_STRATEGY,
   },
   status: 'idle',
   error: null,
@@ -164,7 +165,10 @@ export const slice = createSlice({
             state.projects[projectIdx] = project;
           }
         },
-      );
+      )
+      .addCase(thunks.updateSettings.fulfilled, (state, { meta }) => {
+        state.settings = meta.arg;
+      });
   },
 });
 

--- a/packages/renderer/src/modules/store/workspace/thunks.ts
+++ b/packages/renderer/src/modules/store/workspace/thunks.ts
@@ -1,9 +1,9 @@
-import { fs, npm, workspace } from '#preload';
+import { fs, npm, settings, workspace } from '#preload';
 
 import { createAsyncThunk } from '/@/modules/store/thunk';
 
 import { type Project } from '/shared/types/projects';
-import { type DEPENDENCY_UPDATE_STRATEGY } from '/shared/types/settings';
+import type { DEPENDENCY_UPDATE_STRATEGY } from '/shared/types/settings';
 import { WorkspaceError } from '/shared/types/workspace';
 
 import { actions } from './index';
@@ -99,3 +99,4 @@ export const runProject = createAsyncThunk(
     return updatedProject;
   },
 );
+export const updateSettings = createAsyncThunk('config/updateSettings', settings.updateAppSettings);

--- a/packages/renderer/src/modules/store/workspace/thunks.ts
+++ b/packages/renderer/src/modules/store/workspace/thunks.ts
@@ -1,0 +1,101 @@
+import { fs, npm, workspace } from '#preload';
+
+import { createAsyncThunk } from '/@/modules/store/thunk';
+
+import { type Project } from '/shared/types/projects';
+import { type DEPENDENCY_UPDATE_STRATEGY } from '/shared/types/settings';
+import { WorkspaceError } from '/shared/types/workspace';
+
+import { actions } from './index';
+
+import { installAndGetOutdatedPackages, shouldUpdateDependencies } from './utils';
+
+export const getWorkspace = createAsyncThunk('workspace/getWorkspace', workspace.getWorkspace);
+export const createProject = createAsyncThunk('workspace/createProject', workspace.createProject);
+export const updateProject = createAsyncThunk('workspace/updateProject', workspace.updateProject);
+export const deleteProject = createAsyncThunk('workspace/deleteProject', workspace.deleteProject);
+export const duplicateProject = createAsyncThunk(
+  'workspace/duplicateProject',
+  workspace.duplicateProject,
+);
+export const importProject = createAsyncThunk('workspace/importProject', workspace.importProject);
+export const reimportProject = createAsyncThunk(
+  'workspace/reimportProject',
+  workspace.reimportProject,
+);
+export const unlistProjects = createAsyncThunk(
+  'workspace/unlistProjects',
+  workspace.unlistProjects,
+);
+export const openFolder = createAsyncThunk('workspace/openFolder', workspace.openFolder);
+export const installProject = createAsyncThunk('npm/install', async (path: string) =>
+  npm.install(path),
+);
+export const saveThumbnail = createAsyncThunk(
+  'workspace/saveThumbnail',
+  async ({ path, thumbnail }: Parameters<typeof workspace.saveThumbnail>[0]) => {
+    await workspace.saveThumbnail({ path, thumbnail });
+    const project = await workspace.getProject(path); // TODO: remove this and create a getThumbnail method...
+    return project;
+  },
+);
+export const createProjectAndInstall = createAsyncThunk(
+  'workspace/createProjectAndInstall',
+  async (opts: Parameters<typeof workspace.createProject>[0], { dispatch }) => {
+    const { path } = await dispatch(createProject(opts)).unwrap();
+    dispatch(installProject(path));
+  },
+);
+export const updatePackages = createAsyncThunk(
+  'workspace/updatePackages',
+  async (project: Project) => {
+    const latestPackages = Object.entries(project.dependencyAvailableUpdates).map(
+      ([pkg, { latest }]) => `${pkg}@${latest}`,
+    );
+    await npm.install(project.path, latestPackages);
+  },
+);
+export const updateAvailableDependencyUpdates = createAsyncThunk(
+  'workspace/updateAvailableDependencyUpdates',
+  (
+    { project, updates }: { project: Project; updates: Project['dependencyAvailableUpdates'] },
+    { getState },
+  ): { project: Project; strategy: DEPENDENCY_UPDATE_STRATEGY } => {
+    return {
+      project: { ...project, dependencyAvailableUpdates: updates },
+      strategy: getState().workspace.settings.dependencyUpdateStrategy,
+    };
+  },
+);
+export const runProject = createAsyncThunk(
+  'workspace/runProject',
+  async (project: Project, { dispatch, getState }): Promise<Project> => {
+    const { workspace: _workspace } = getState();
+    const strategy = _workspace.settings.dependencyUpdateStrategy;
+
+    if (!(await fs.exists(project.path))) {
+      // if project is on the project's list but directory doesn't exist, then it was removed while app was running...
+      dispatch(actions.moveProjectToMissing(project));
+      throw new WorkspaceError('PROJECT_NOT_FOUND');
+    }
+
+    // It's possible for "node_modules" to not exist because it was never installed before
+    // or because the user deleted it while the app was running.
+    // In any case, we have to "npm install" & "npm outdated"
+    const hasNodeModules = await workspace.hasNodeModules(project.path);
+    const dependencyAvailableUpdates = hasNodeModules
+      ? await workspace.getOutdatedPackages(project.path)
+      : await installAndGetOutdatedPackages(project.path);
+
+    if (shouldUpdateDependencies(strategy, dependencyAvailableUpdates)) {
+      await dispatch(updatePackages({ ...project, dependencyAvailableUpdates })).unwrap();
+      return { ...project, dependencyAvailableUpdates: {} };
+    }
+
+    const { project: updatedProject } = await dispatch(
+      updateAvailableDependencyUpdates({ project, updates: dependencyAvailableUpdates }),
+    ).unwrap();
+
+    return updatedProject;
+  },
+);

--- a/packages/renderer/src/modules/store/workspace/utils.ts
+++ b/packages/renderer/src/modules/store/workspace/utils.ts
@@ -1,0 +1,27 @@
+import { npm, workspace } from '#preload';
+
+import { DEPENDENCY_UPDATE_STRATEGY } from '/shared/types/settings';
+import { type DependencyState } from '/shared/types/projects';
+
+export const hasOutdatedDependencies = (deps: DependencyState) => {
+  return !!Object.keys(deps).length;
+};
+
+export const shouldUpdateDependencies = (
+  strategy: DEPENDENCY_UPDATE_STRATEGY,
+  deps: DependencyState,
+) => {
+  return strategy === DEPENDENCY_UPDATE_STRATEGY.AUTO_UPDATE && hasOutdatedDependencies(deps);
+};
+
+export const shouldNotifyUpdates = (
+  strategy: DEPENDENCY_UPDATE_STRATEGY,
+  deps: DependencyState,
+) => {
+  return strategy === DEPENDENCY_UPDATE_STRATEGY.NOTIFY && hasOutdatedDependencies(deps);
+};
+
+export const installAndGetOutdatedPackages = async (path: string) => {
+  await npm.install(path);
+  return workspace.getOutdatedPackages(path);
+};

--- a/packages/shared/types/config.ts
+++ b/packages/shared/types/config.ts
@@ -1,4 +1,4 @@
-import { type UPDATE_DEPENDENCIES_STRATEGY } from './settings';
+import { type DEPENDENCY_UPDATE_STRATEGY } from './settings';
 
 export type Config = {
   version: number;
@@ -9,5 +9,5 @@ export type Config = {
 
 export type AppSettings = {
   scenesPath?: string;
-  updateDependenciesStrategy?: UPDATE_DEPENDENCIES_STRATEGY;
+  updateDependenciesStrategy?: DEPENDENCY_UPDATE_STRATEGY;
 };

--- a/packages/shared/types/config.ts
+++ b/packages/shared/types/config.ts
@@ -1,13 +1,9 @@
-import { type DEPENDENCY_UPDATE_STRATEGY } from './settings';
+import { type AppSettings } from './settings';
 
 export type Config = {
   version: number;
   workspace: {
     paths: string[];
   };
-} & AppSettings;
-
-export type AppSettings = {
-  scenesPath?: string;
-  updateDependenciesStrategy?: DEPENDENCY_UPDATE_STRATEGY;
+  settings: AppSettings;
 };

--- a/packages/shared/types/error.ts
+++ b/packages/shared/types/error.ts
@@ -1,0 +1,9 @@
+export class ErrorBase<T extends string> extends Error {
+  constructor(
+    public name: T,
+    public message: string = '',
+    public cause?: any,
+  ) {
+    super();
+  }
+}

--- a/packages/shared/types/ipc.ts
+++ b/packages/shared/types/ipc.ts
@@ -1,5 +1,7 @@
 import { type OpenDialogOptions } from 'electron';
 
+import type { Outdated } from '/shared/types/npm';
+
 export type DeployOptions = { path: string; target?: string; targetContent?: string };
 
 export interface Ipc {
@@ -16,6 +18,6 @@ export interface Ipc {
   'analytics.track': (event: string, data?: Record<string, any>) => void;
   'analytics.identify': (userId: string, traits?: Record<string, any>) => void;
   'analytics.getAnonymousId': () => Promise<string>;
-  'npm.install': (path: string, packageName?: string) => Promise<void>;
-  'npm.packageOutdated': (path: string, packageName: string) => Promise<boolean>;
+  'npm.install': (path: string, packages?: string[]) => Promise<void>;
+  'npm.getOutdatedDeps': (path: string, packages?: string[]) => Promise<Outdated>;
 }

--- a/packages/shared/types/npm.ts
+++ b/packages/shared/types/npm.ts
@@ -1,0 +1,6 @@
+export type Outdated = {
+  [key: string]: {
+    current: string;
+    latest: string;
+  };
+};

--- a/packages/shared/types/pkg.ts
+++ b/packages/shared/types/pkg.ts
@@ -8,4 +8,8 @@ export type PackageJson = {
   devDependencies?: Record<string, string>;
 };
 
-export const SDK_PACKAGE = '@dcl/sdk';
+export enum PACKAGES {
+  SDK_PACKAGE = '@dcl/sdk',
+}
+
+export const PACKAGES_LIST = Object.values(PACKAGES);

--- a/packages/shared/types/projects.ts
+++ b/packages/shared/types/projects.ts
@@ -1,5 +1,8 @@
 import type { WorldConfiguration } from '@dcl/schemas';
 
+import type { Outdated } from './npm';
+import type { PACKAGES } from './pkg';
+
 export type Layout = {
   rows: number;
   cols: number;
@@ -15,6 +18,8 @@ export type ProjectInfo = {
   id: string;
 };
 
+export type DependencyState = { [k in PACKAGES]?: Outdated[keyof Outdated] };
+
 export type Project = {
   id: string;
   path: string;
@@ -26,10 +31,5 @@ export type Project = {
   updatedAt: number;
   size: number;
   worldConfiguration?: WorldConfiguration;
-  packageStatus?: {
-    [packageName: string]: {
-      isOutdated: boolean;
-      showUpdatedNotification?: boolean;
-    };
-  };
+  dependencyAvailableUpdates: DependencyState;
 };

--- a/packages/shared/types/settings.ts
+++ b/packages/shared/types/settings.ts
@@ -1,5 +1,11 @@
-export enum UPDATE_DEPENDENCIES_STRATEGY {
+export enum DEPENDENCY_UPDATE_STRATEGY {
   AUTO_UPDATE = 'auto_update',
   NOTIFY = 'notify',
   DO_NOTHING = 'do_nothing',
 }
+
+export const DEFAULT_DEPENDENCY_UPDATE_STRATEGY = DEPENDENCY_UPDATE_STRATEGY.NOTIFY;
+
+export type Settings = {
+  dependencyUpdateStrategy: DEPENDENCY_UPDATE_STRATEGY;
+};

--- a/packages/shared/types/settings.ts
+++ b/packages/shared/types/settings.ts
@@ -6,6 +6,7 @@ export enum DEPENDENCY_UPDATE_STRATEGY {
 
 export const DEFAULT_DEPENDENCY_UPDATE_STRATEGY = DEPENDENCY_UPDATE_STRATEGY.NOTIFY;
 
-export type Settings = {
+export type AppSettings = {
+  scenesPath: string;
   dependencyUpdateStrategy: DEPENDENCY_UPDATE_STRATEGY;
 };

--- a/packages/shared/types/workspace.ts
+++ b/packages/shared/types/workspace.ts
@@ -1,10 +1,13 @@
+import { ErrorBase } from './error';
 import type { Project, SortBy } from './projects';
+import type { Settings } from './settings';
 
 export type Workspace = {
   sortBy: SortBy;
   projects: Project[];
   missing: string[];
   templates: Template[];
+  settings: Settings;
 };
 
 export type Template = {
@@ -23,3 +26,10 @@ export type Template = {
   date_created: string;
   resource_type: string;
 };
+
+export type Error = 'PROJECT_NOT_FOUND';
+
+export class WorkspaceError extends ErrorBase<Error> {}
+
+export const isWorkspaceError = (error: unknown, type: Error): error is WorkspaceError =>
+  error instanceof WorkspaceError && error.name === type;

--- a/packages/shared/types/workspace.ts
+++ b/packages/shared/types/workspace.ts
@@ -1,13 +1,13 @@
 import { ErrorBase } from './error';
 import type { Project, SortBy } from './projects';
-import type { Settings } from './settings';
+import type { AppSettings } from './settings';
 
 export type Workspace = {
   sortBy: SortBy;
   projects: Project[];
   missing: string[];
   templates: Template[];
-  settings: Settings;
+  settings: AppSettings;
 };
 
 export type Template = {


### PR DESCRIPTION
closes https://github.com/decentraland/creator-hub/issues/236

### Test cases:
1. If project does not have `node_modules`, running the project will install them
2. If a project get's externally deleted while the app is open, it should go back to the scenes page and remove the project from the scenes list
3. If workspace has auto update set on, entering a project with outdated deps, should update them automatically
4. If workspace has notify set on, entering a project with outdated deps, should notify about them. Clicking on the notification should update the notification
5. If workspace has "nothing" set on, entering a project with outdated deps, should do nothing