### PR TITLE
Revert "chore: remove version from artifact (#237)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
           # The following are the parameters required by the esigner-codesign action to work, we must explicitly pass in even the optional ones since we're not using the action directly, but from the checked out repo
           CODE_SIGN_SCRIPT_PATH: "${{ github.workspace }}\\esigner-codesign\\dist\\index.js"
           INPUT_COMMAND: "sign"
-          INPUT_FILE_PATH: "${{ github.workspace }}\\dist\\Decentraland Creator Hub-win-x64.exe"
+          INPUT_FILE_PATH: "${{ github.workspace }}\\dist\\Decentraland Creator Hub-${{ steps.version.outputs.version }}-win-x64.exe"
           INPUT_OVERRIDE: "true"
           INPUT_MALWARE_BLOCK: "false"
           INPUT_CLEAN_LOGS: "false"

--- a/electron-builder.cjs
+++ b/electron-builder.cjs
@@ -11,7 +11,7 @@ const config = {
     target: 'deb',
   },
   productName: 'Decentraland Creator Hub',
-  artifactName: '${productName}-${os}-${arch}.${ext}',
+  artifactName: '${productName}-${version}-${os}-${arch}.${ext}',
   win: {
     publisherName: 'Decentraland Foundation',
     appId: 'Decentraland.CreatorsHub',
@@ -86,9 +86,9 @@ if (process.env.CODE_SIGN_SCRIPT_PATH) {
   config.win.sign = configuration => {
     console.log('Requested signing for ', configuration.path);
 
-    // Only proceed if the installer .exe file is in the configuration path - skip signing everything else
-    if (!/Decentraland Creator Hub-win-x64.exe$/.test(configuration.path)) {
-      console.log('This is not the installer .exe, skip signing');
+    // Only proceed if the versioned .exe file is in the configuration path - skip signing everything else
+    if (!/Decentraland Creator Hub-(\d+)\.(\d+)\.(\d+)-win-x64.exe$/.test(configuration.path)) {
+      console.log('This is not the versioned .exe, skip signing');
       return true;
     }
 


### PR DESCRIPTION
This reverts commit 6a425cf2f5e2ba461c667ae34df7673b944e2c04.

This PR makes the artifacts to include the version again in their filename. This was removed to make the download links static in this PR #237. 

Now the landing fetches the download links from GitHub https://github.com/decentraland/landing/pull/451, so we can add the version back.

This could potentially fix the issues #268 and #284, according to https://github.com/electron-userland/electron-builder/issues/5429#issuecomment-730022611