### PR TITLE
use sdk-commands SCENE package

### DIFF
--- a/packages/main/src/modules/cli.ts
+++ b/packages/main/src/modules/cli.ts
@@ -17,6 +17,7 @@ export async function init(path: string, repo?: string) {
     args: ['init', '--yes', '--skip-install', ...(repo ? ['--github-repo', repo] : [])],
     cwd: path,
     env: await getEnv(path),
+    workspace: path,
   });
   await initCommand.wait();
 }
@@ -30,6 +31,7 @@ export async function start(path: string) {
   previewServer = run('@dcl/sdk-commands', 'sdk-commands', {
     args: ['start', '--explorer-alpha', '--hub'],
     cwd: path,
+    workspace: path,
     env: await getEnv(path),
   });
   await previewServer.waitFor(/decentraland:\/\//i);
@@ -52,6 +54,7 @@ export async function deploy({ path, target, targetContent }: DeployOptions) {
     ],
     cwd: path,
     env: await getEnv(path),
+    workspace: path,
   });
 
   // App ready at

--- a/packages/main/src/modules/cli.ts
+++ b/packages/main/src/modules/cli.ts
@@ -17,7 +17,6 @@ export async function init(path: string, repo?: string) {
     args: ['init', '--yes', '--skip-install', ...(repo ? ['--github-repo', repo] : [])],
     cwd: path,
     env: await getEnv(path),
-    workspace: path,
   });
   await initCommand.wait();
 }

--- a/packages/main/src/modules/cli.ts
+++ b/packages/main/src/modules/cli.ts
@@ -1,7 +1,6 @@
 import type { DeployOptions } from '/shared/types/ipc';
 import { run, type Child } from './bin';
 import { getAvailablePort } from './port';
-import { install } from './npm';
 import { getProjectId } from './analytics';
 
 async function getEnv(path: string) {
@@ -26,7 +25,6 @@ export async function start(path: string) {
   if (previewServer) {
     await previewServer.kill();
   }
-  await install(path);
   previewServer = run('@dcl/sdk-commands', 'sdk-commands', {
     args: ['start', '--explorer-alpha', '--hub'],
     cwd: path,

--- a/packages/renderer/src/components/EditorPage/component.tsx
+++ b/packages/renderer/src/components/EditorPage/component.tsx
@@ -38,7 +38,7 @@ export function EditorPage() {
     updateScene,
     loadingPreview,
     loadingPublish,
-    isInstalling,
+    isInstallingProject,
   } = useEditor();
   const userId = useSelector(state => state.analytics.userId);
   const iframeRef = useRef<ReturnType<typeof initRpc>>();
@@ -168,17 +168,17 @@ export function EditorPage() {
               </Button>
               <Button
                 color="secondary"
-                disabled={loadingPreview || isInstalling}
+                disabled={loadingPreview || isInstallingProject}
                 onClick={openPreview}
-                startIcon={(loadingPreview || isInstalling) ? <Loader size={20} /> : <PlayCircleIcon />}
+                startIcon={loadingPreview ? <Loader size={20} /> : <PlayCircleIcon />}
               >
                 {t('editor.header.actions.preview')}
               </Button>
               <Button
                 color="primary"
-                disabled={loadingPublish || isInstalling}
+                disabled={loadingPublish || isInstallingProject}
                 onClick={handleOpenModal('publish')}
-                startIcon={(loadingPublish || isInstalling) ? <Loader size={20} /> : <PublicIcon />}
+                startIcon={loadingPublish ? <Loader size={20} /> : <PublicIcon />}
               >
                 {t('editor.header.actions.publish')}
               </Button>

--- a/packages/renderer/src/components/EditorPage/component.tsx
+++ b/packages/renderer/src/components/EditorPage/component.tsx
@@ -38,6 +38,7 @@ export function EditorPage() {
     updateScene,
     loadingPreview,
     loadingPublish,
+    isInstalling,
   } = useEditor();
   const userId = useSelector(state => state.analytics.userId);
   const iframeRef = useRef<ReturnType<typeof initRpc>>();
@@ -167,17 +168,17 @@ export function EditorPage() {
               </Button>
               <Button
                 color="secondary"
-                disabled={loadingPreview}
+                disabled={loadingPreview || isInstalling}
                 onClick={openPreview}
-                startIcon={loadingPreview ? <Loader size={20} /> : <PlayCircleIcon />}
+                startIcon={(loadingPreview || isInstalling) ? <Loader size={20} /> : <PlayCircleIcon />}
               >
                 {t('editor.header.actions.preview')}
               </Button>
               <Button
                 color="primary"
-                disabled={loadingPublish}
+                disabled={loadingPublish || isInstalling}
                 onClick={handleOpenModal('publish')}
-                startIcon={loadingPublish ? <Loader size={20} /> : <PublicIcon />}
+                startIcon={(loadingPublish || isInstalling) ? <Loader size={20} /> : <PublicIcon />}
               >
                 {t('editor.header.actions.publish')}
               </Button>

--- a/packages/renderer/src/modules/store/editor/slice.ts
+++ b/packages/renderer/src/modules/store/editor/slice.ts
@@ -150,6 +150,9 @@ export const slice = createSlice({
       state.isInstalledProject = true;
       state.isInstallingProject = false;
     });
+    builder.addCase(workspaceActions.installProject.rejected, (state) => {
+      state.isInstallingProject = false;
+    });
     builder.addCase(workspaceActions.saveAndGetThumbnail.fulfilled, (state, action) => {
       if (state.project) {
         state.project.thumbnail = action.payload;

--- a/packages/renderer/src/modules/store/editor/slice.ts
+++ b/packages/renderer/src/modules/store/editor/slice.ts
@@ -143,14 +143,14 @@ export const slice = createSlice({
     builder.addCase(workspaceActions.saveAndGetThumbnail.pending, state => {
       if (state.project) state.project.status = 'loading';
     });
-    builder.addCase(workspaceActions.installProject.pending, (state) => {
+    builder.addCase(workspaceActions.installProject.pending, state => {
       state.isInstallingProject = true;
     });
-    builder.addCase(workspaceActions.installProject.fulfilled, (state) => {
+    builder.addCase(workspaceActions.installProject.fulfilled, state => {
       state.isInstalledProject = true;
       state.isInstallingProject = false;
     });
-    builder.addCase(workspaceActions.installProject.rejected, (state) => {
+    builder.addCase(workspaceActions.installProject.rejected, state => {
       state.isInstallingProject = false;
     });
     builder.addCase(workspaceActions.saveAndGetThumbnail.fulfilled, (state, action) => {

--- a/packages/renderer/src/modules/store/editor/slice.ts
+++ b/packages/renderer/src/modules/store/editor/slice.ts
@@ -28,6 +28,8 @@ export type EditorState = {
   loadingPreview: boolean;
   isInstalling: boolean;
   isInstalled: boolean;
+  isInstallingProject: boolean;
+  isInstalledProject: boolean;
   isFetchingVersion: boolean;
   error: Error | null;
 };
@@ -41,6 +43,8 @@ const initialState: EditorState = {
   loadingInspector: false,
   loadingPreview: false,
   isInstalling: false,
+  isInstallingProject: false,
+  isInstalledProject: false,
   isInstalled: false,
   isFetchingVersion: false,
   error: null,
@@ -138,6 +142,13 @@ export const slice = createSlice({
     });
     builder.addCase(workspaceActions.saveAndGetThumbnail.pending, state => {
       if (state.project) state.project.status = 'loading';
+    });
+    builder.addCase(workspaceActions.installProject.pending, (state) => {
+      state.isInstallingProject = true;
+    });
+    builder.addCase(workspaceActions.installProject.fulfilled, (state) => {
+      state.isInstalledProject = true;
+      state.isInstallingProject = false;
     });
     builder.addCase(workspaceActions.saveAndGetThumbnail.fulfilled, (state, action) => {
       if (state.project) {

--- a/packages/renderer/src/modules/store/snackbar/slice.ts
+++ b/packages/renderer/src/modules/store/snackbar/slice.ts
@@ -44,6 +44,29 @@ export const slice = createSlice({
           }),
         );
       })
+      .addCase(workspaceActions.installProject.pending, (state, payload) => {
+        const { requestId } = payload.meta;
+        state.notifications.push(
+          createGenericNotification('loading', t('snackbar.generic.installing_dependencies'), {
+            requestId,
+            duration: 0,
+          }),
+        );
+      })
+      .addCase(workspaceActions.installProject.fulfilled, (state, payload) => {
+        const { requestId } = payload.meta;
+        state.notifications = state.notifications.filter($ => $.id !== requestId);
+      })
+      .addCase(workspaceActions.installProject.rejected, (state, payload) => {
+        const { requestId } = payload.meta;
+        state.notifications = state.notifications.filter($ => $.id !== requestId);
+        state.notifications.push(
+          createGenericNotification('error', t('snackbar.generic.installing_dependencies_failed'), {
+            requestId,
+            duration: 2_000,
+          }),
+        );
+      })
       .addCase(workspaceActions.importProject.fulfilled, (state, payload) => {
         const { requestId } = payload.meta;
         state.notifications = state.notifications.filter($ => $.id !== requestId);

--- a/packages/renderer/src/modules/store/translation/locales/en.json
+++ b/packages/renderer/src/modules/store/translation/locales/en.json
@@ -204,7 +204,9 @@
       "duplicate_scene_failed": "Failed duplicating scene",
       "delete_scene": "Deleting scene...",
       "delete_scene_failed": "Failed deleting scene",
-      "dependencies_updated": "Scene dependencies were updated"
+      "dependencies_updated": "Scene dependencies were updated",
+      "installing_dependencies": "Installing dependencies...",
+      "installing_dependencies_failed": "Failed installing dependencies"
     },
     "missing_projects": {
       "title": "{scenes} {scenes, plural, one {scene} other {scenes}} could not be loaded due to missing files",

--- a/packages/renderer/src/modules/store/translation/locales/es.json
+++ b/packages/renderer/src/modules/store/translation/locales/es.json
@@ -202,7 +202,9 @@
       "duplicate_scene_failed": "Error al duplicar escena",
       "delete_scene": "Borrando escena...",
       "delete_scene_failed": "Error al borrar escena",
-      "dependencies_updated": "Las dependencias de la escena fueron actualizadas"
+      "dependencies_updated": "Las dependencias de la escena fueron actualizadas",
+      "installing_dependencies": "Instalando dependencias...",
+      "installing_dependencies_failed": "Error al instalar dependencias"
     },
     "missing_projects": {
       "title": "{scenes} {scenes, plural, one {escena} other {escenas}} {scenes, plural, one {faltante} other {faltantes}}",

--- a/packages/renderer/src/modules/store/translation/locales/zh.json
+++ b/packages/renderer/src/modules/store/translation/locales/zh.json
@@ -202,7 +202,9 @@
       "duplicate_scene_failed": "复制场景失败",
       "delete_scene": "删除场景...",
       "delete_scene_failed": "删除场景失败",
-      "dependencies_updated": "場景相依性已更新"
+      "dependencies_updated": "場景相依性已更新",
+      "installing_dependencies": "安装依赖项",
+      "installing_dependencies_failed": "安装依赖项失败"
     },
     "missing_projects": {
       "title": "{scenes} 丢失的 {scenes, plural, one {场景} other {场景}} 成立",


### PR DESCRIPTION
The Preview & Publish flow was using the creator hub SDK instead of the one inside the scene.
So you CAN'T test other versions of the SDK using the creators-hub


```ts
type RunOptions = {
  args?: string[]; // this are the arguments for the command
  cwd?: string; // this is the directory where the command should be executed, it defaults to the app path.
  env?: Record<string, string>; // this are the env vars that should be added to the command's env
  workspace?: string; // this is the path where the node_modules that should be used are located, it defaults to the app path.
};
```

I change the workspace options based on this comment
