### PR TITLE
feat: shared folder for custom assets

### DIFF
--- a/packages/renderer/src/modules/rpc/index.ts
+++ b/packages/renderer/src/modules/rpc/index.ts
@@ -27,7 +27,7 @@ interface Callbacks {
 const getBasePath = async (path: string, project: Project) => {
   if (path === 'custom' || path.startsWith('custom/')) {
     const homePath = await workspace.getPath();
-    return `${homePath}`;
+    return homePath;
   }
   return project.path;
 };


### PR DESCRIPTION
This PR modifies the RPC so all the operations that happen within the `custom` directory will be rerouted to the home directory. ie: path `/custom/asset.glb` will be routed to `.decentraland/custom/asset.glb` instead of `/path/to/project/custom/asset.glb`.

This is necessary because we save the custom items under the `/custom` directory, but we don't want that to be saved within each scene, but instead on a shared folder, so when you create a custom asset you will be able to reuse it across projects.