### PR TITLE
feat: use userData path instead of home path

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -9,6 +9,7 @@ import { deployServer, previewServer } from './modules/cli';
 import { inspectorServer } from './modules/inspector';
 import { getAnalytics, track } from './modules/analytics';
 import './security-restrictions';
+import { runMigrations } from './modules/migrations';
 
 log.initialize();
 
@@ -44,6 +45,7 @@ app.on('activate', restoreOrCreateWindow);
 app
   .whenReady()
   .then(async () => {
+    await runMigrations();
     log.info(`[App] Ready v${app.getVersion()}`);
     initIpc();
     log.info('[IPC] Ready');

--- a/packages/main/src/modules/config.ts
+++ b/packages/main/src/modules/config.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
-import { app } from 'electron';
+import { FileSystemStorage } from '/shared/types/storage';
+import { SETTINGS_DIRECTORY } from '/shared/paths';
+import { getUserDataPath } from './electron';
 
-import { FileSystemStorage } from '../../../shared/types/storage';
-
-export const CONFIG_PATH = path.join(app.getPath('userData'), 'config.json');
+export const CONFIG_PATH = path.join(getUserDataPath(), SETTINGS_DIRECTORY, 'config.json');
 export const config = await FileSystemStorage.getOrCreate(CONFIG_PATH);

--- a/packages/main/src/modules/electron.ts
+++ b/packages/main/src/modules/electron.ts
@@ -6,7 +6,11 @@ export function getHome() {
   return app.getPath('home');
 }
 
-export function getAppHome() {
+export function getUserDataPath() {
+  return app.getPath('userData');
+}
+
+export function getAppHomeLegacy() {
   return path.join(getHome(), '.decentraland');
 }
 

--- a/packages/main/src/modules/ipc.ts
+++ b/packages/main/src/modules/ipc.ts
@@ -9,7 +9,7 @@ import * as npm from './npm';
 export function initIpc() {
   // electron
   handle('electron.getAppVersion', () => electron.getAppVersion());
-  handle('electron.getAppHome', () => electron.getAppHome());
+  handle('electron.getUserDataPath', () => electron.getUserDataPath());
   handle('electron.getWorkspaceConfigPath', (_event, path) =>
     electron.getWorkspaceConfigPath(path),
   );

--- a/packages/main/src/modules/migrations.ts
+++ b/packages/main/src/modules/migrations.ts
@@ -1,0 +1,157 @@
+import path from 'path';
+import fs from 'fs/promises';
+import log from 'electron-log/main';
+import { SCENES_DIRECTORY } from '/shared/paths';
+import { getAppHomeLegacy, getUserDataPath } from './electron';
+import { CONFIG_PATH } from './config';
+
+export async function runMigrations() {
+  log.info('[Migrations] Starting migrations');
+  await migrateLegacyPaths();
+  log.info('[Migrations] Migrations completed');
+}
+
+async function isValidScene(scenePath: string): Promise<boolean> {
+  try {
+    // Check if it's a directory first
+    const stats = await fs.stat(scenePath);
+    if (!stats.isDirectory()) {
+      log.info('[Migration] Not a directory:', scenePath);
+      return false;
+    }
+
+    // check if scene is a valid scene (if it contains a scene.json)
+    const sceneJsonPath = path.join(scenePath, 'scene.json');
+    await fs.stat(sceneJsonPath);
+    return true;
+  } catch (err) {
+    log.info('[Migration] Invalid scene:', scenePath, err instanceof Error ? err.message : '');
+    return false;
+  }
+}
+
+async function copyScene(sourcePath: string, targetPath: string) {
+  log.info('[Migration] Copying scene:', { from: sourcePath, to: targetPath });
+
+  // Create target directory
+  await fs.mkdir(targetPath, { recursive: true });
+
+  // Copy scene directory contents excluding node_modules
+  const entries = await fs.readdir(sourcePath, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === 'node_modules') {
+      log.info('[Migration] Skipping node_modules directory for scene:', sourcePath);
+      continue;
+    }
+
+    const srcPath = path.join(sourcePath, entry.name);
+    const destPath = path.join(targetPath, entry.name);
+    await fs.cp(srcPath, destPath, { recursive: true });
+  }
+
+  log.info('[Migration] Successfully copied scene:', sourcePath);
+}
+
+// Migrations
+async function migrateLegacyPaths() {
+  log.info('[Migration] Starting legacy paths migration');
+  const userDataPath = getUserDataPath();
+  const appHomeLegacy = getAppHomeLegacy();
+  const normalizedLegacyPath = path.normalize(appHomeLegacy);
+
+  log.info('[Migration] Paths:', {
+    userDataPath,
+    appHomeLegacy,
+  });
+
+  // Create scenes directory if it doesn't exist
+  const scenesPath = path.join(userDataPath, SCENES_DIRECTORY);
+  try {
+    await fs.stat(scenesPath);
+    // If scenes directory exists, migration was already done
+    log.info('[Migration] Scenes directory already exists, skipping migration');
+    return;
+  } catch {
+    // Create scenes directory if it doesn't exist
+    log.info('[Migration] Creating scenes directory:', scenesPath);
+    await fs.mkdir(scenesPath, { recursive: true });
+  }
+
+  try {
+    // Read config.json if it exists
+    const legacyConfigPath = path.join(appHomeLegacy, 'config.json');
+    let config: { workspace?: { paths?: string[] }; settings?: { scenesPath?: string } } = {};
+
+    try {
+      log.info('[Migration] Reading config.json from legacy path');
+      const configContent = await fs.readFile(legacyConfigPath, 'utf8');
+      config = JSON.parse(configContent);
+    } catch {
+      log.info('[Migration] No config.json found in legacy path, skipping migration');
+      return;
+    }
+
+    // Update default scenes path if it points to legacy path
+    if (config.settings?.scenesPath) {
+      const normalizedScenesPath = path.normalize(config.settings.scenesPath);
+      if (normalizedScenesPath === normalizedLegacyPath) {
+        log.info('[Migration] Updating default scenes path:', {
+          from: normalizedScenesPath,
+          to: scenesPath,
+        });
+        config.settings.scenesPath = scenesPath;
+      }
+    }
+
+    if (config.workspace?.paths?.length) {
+      // Process each path in the workspace
+      const updatedPaths: string[] = [];
+      for (const scenePath of config.workspace.paths) {
+        const normalizedPath = path.normalize(scenePath);
+
+        // Only process paths within the legacy directory
+        if (!normalizedPath.startsWith(normalizedLegacyPath)) {
+          log.info('[Migration] Skipping path outside legacy directory:', scenePath);
+          updatedPaths.push(scenePath);
+          continue;
+        }
+
+        // Validate the scene
+        if (!(await isValidScene(normalizedPath))) {
+          log.info('[Migration] Skipping invalid scene:', scenePath);
+          updatedPaths.push(scenePath);
+          continue;
+        }
+
+        // Calculate new path and copy scene
+        const relativePath = path.relative(normalizedLegacyPath, normalizedPath);
+        const newPath = path.join(scenesPath, relativePath);
+        await copyScene(normalizedPath, newPath);
+        updatedPaths.push(newPath);
+      }
+
+      // Update and write the config
+      config.workspace.paths = updatedPaths;
+    } else {
+      log.info('[Migration] No workspace paths found in config.json');
+    }
+
+    log.info('[Migration] Writing updated config.json to:', CONFIG_PATH);
+    await fs.writeFile(CONFIG_PATH, JSON.stringify(config, null, 2));
+    log.info('[Migration] Successfully migrated config.json');
+
+    log.info('[Migration] Legacy paths migration completed successfully');
+  } catch (error) {
+    // If anything fails during migration, delete the scenes directory so it will be attempted again
+    log.error('[Migration] Error during migration:', error);
+    try {
+      log.info('[Migration] Cleaning up scenes directory after failure');
+      await fs.rm(scenesPath, { recursive: true, force: true });
+      log.info('[Migration] Successfully cleaned up scenes directory');
+    } catch (cleanupError) {
+      // Ignore errors during cleanup
+      log.error('[Migration] Failed to cleanup scenes directory:', cleanupError);
+    }
+    throw error; // Re-throw the original error
+  }
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -6,3 +6,4 @@ export * as analytics from './modules/analytics';
 export * as npm from './modules/npm';
 export * as settings from './modules/settings';
 export * as scene from './modules/scene';
+export * as custom from './modules/custom';

--- a/packages/preload/src/modules/config.ts
+++ b/packages/preload/src/modules/config.ts
@@ -7,6 +7,7 @@ import { DEFAULT_DEPENDENCY_UPDATE_STRATEGY } from '/shared/types/settings';
 
 import { invoke } from './invoke';
 import { getDefaultScenesPath } from './settings';
+import { SETTINGS_DIRECTORY } from '/shared/paths';
 
 const CONFIG_FILE_NAME = 'config.json';
 
@@ -31,13 +32,13 @@ async function getDefaultConfig(): Promise<Config> {
  * @returns {Promise<string>} The configuration file path.
  */
 export async function getConfigPath(): Promise<string> {
-  const appHome = await invoke('electron.getAppHome');
+  const userDataPath = await invoke('electron.getUserDataPath');
   try {
-    await fs.stat(appHome);
+    await fs.stat(userDataPath);
   } catch (_) {
-    await fs.mkdir(appHome);
+    await fs.mkdir(userDataPath);
   }
-  return path.join(appHome, CONFIG_FILE_NAME);
+  return path.join(userDataPath, SETTINGS_DIRECTORY, CONFIG_FILE_NAME);
 }
 
 /**

--- a/packages/preload/src/modules/custom.ts
+++ b/packages/preload/src/modules/custom.ts
@@ -1,0 +1,8 @@
+import path from 'path';
+import { CUSTOM_ASSETS_DIRECTORY } from '/shared/paths';
+import { invoke } from './invoke';
+
+export async function getPath() {
+  const userDataPath = await invoke('electron.getUserDataPath');
+  return path.join(userDataPath, CUSTOM_ASSETS_DIRECTORY);
+}

--- a/packages/preload/src/modules/settings.ts
+++ b/packages/preload/src/modules/settings.ts
@@ -1,14 +1,17 @@
+import path from 'path';
 import {
   DEPENDENCY_UPDATE_STRATEGY,
   DEFAULT_DEPENDENCY_UPDATE_STRATEGY,
 } from '/shared/types/settings';
 import type { AppSettings } from '/shared/types/settings';
+import { SCENES_DIRECTORY } from '/shared/paths';
 
 import { invoke } from './invoke';
 import { getConfig, setConfig } from './config';
 
-export function getDefaultScenesPath() {
-  return invoke('electron.getAppHome');
+export async function getDefaultScenesPath() {
+  const userDataPath = await invoke('electron.getUserDataPath');
+  return path.join(userDataPath, SCENES_DIRECTORY);
 }
 
 export async function getScenesPath() {

--- a/packages/renderer/src/modules/rpc/index.ts
+++ b/packages/renderer/src/modules/rpc/index.ts
@@ -2,13 +2,12 @@ import { MessageTransport } from '@dcl/mini-rpc';
 
 import { CameraRPC } from './camera';
 
-import { fs } from '#preload';
+import { fs, custom } from '#preload';
 
 import { type Project } from '/shared/types/projects';
 
 import { UiRPC } from './ui';
 import { type Method, type Params, type Result, StorageRPC } from './storage';
-import { workspace } from '#preload';
 
 export type RPCInfo = {
   iframe: HTMLIFrameElement;
@@ -27,8 +26,7 @@ interface Callbacks {
 const getPath = async (path: string, project: Project) => {
   let basePath = project.path;
   if (path === 'custom' || path.startsWith('custom/')) {
-    const homePath = await workspace.getPath();
-    basePath = homePath;
+    basePath = await custom.getPath();
   }
   return await fs.resolve(basePath, path);
 };

--- a/packages/shared/paths.ts
+++ b/packages/shared/paths.ts
@@ -1,0 +1,3 @@
+export const SCENES_DIRECTORY = 'Scenes';
+export const SETTINGS_DIRECTORY = 'Settings';
+export const CUSTOM_ASSETS_DIRECTORY = 'Custom';

--- a/packages/shared/types/ipc.ts
+++ b/packages/shared/types/ipc.ts
@@ -13,7 +13,7 @@ export type IpcError = {
 };
 
 export interface Ipc {
-  'electron.getAppHome': () => string;
+  'electron.getUserDataPath': () => string;
   'electron.getAppVersion': () => Promise<string>;
   'electron.getWorkspaceConfigPath': (path: string) => Promise<string>;
   'electron.showOpenDialog': (opts: Partial<OpenDialogOptions>) => Promise<string[]>;


### PR DESCRIPTION
This PR changes the default path for scens from `.decentraland` to the electron's `userPath`, and migrates all the imported scenes from that legacy path to the new one.