### PR TITLE
fix: broken new installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "cmd-shim": "^6.0.3",
         "decentraland-connect": "^7.1.0",
         "decentraland-crypto-fetch": "^2.0.1",
+        "deepmerge": "^4.3.1",
         "electron-log": "^5.1.6",
         "electron-updater": "6.2.1",
         "http-server": "^14.1.1",
@@ -8550,6 +8551,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "cmd-shim": "^6.0.3",
     "decentraland-connect": "^7.1.0",
     "decentraland-crypto-fetch": "^2.0.1",
+    "deepmerge": "^4.3.1",
     "electron-log": "^5.1.6",
     "electron-updater": "6.2.1",
     "http-server": "^14.1.1",

--- a/packages/main/src/modules/config.ts
+++ b/packages/main/src/modules/config.ts
@@ -1,7 +1,30 @@
 import path from 'node:path';
 import { FileSystemStorage } from '/shared/types/storage';
-import { SETTINGS_DIRECTORY } from '/shared/paths';
+import { SETTINGS_DIRECTORY, CONFIG_FILE_NAME, getFullScenesPath } from '/shared/paths';
+import { DEFAULT_CONFIG, mergeConfig } from '/shared/types/config';
 import { getUserDataPath } from './electron';
 
-export const CONFIG_PATH = path.join(getUserDataPath(), SETTINGS_DIRECTORY, 'config.json');
-export const config = await FileSystemStorage.getOrCreate(CONFIG_PATH);
+export const CONFIG_PATH = path.join(getUserDataPath(), SETTINGS_DIRECTORY, CONFIG_FILE_NAME);
+const storage = await FileSystemStorage.getOrCreate(CONFIG_PATH);
+
+// Initialize with default values if empty
+const existingConfig = await storage.get<Record<string, any>>('');
+const defaultConfig = { ...DEFAULT_CONFIG };
+defaultConfig.settings.scenesPath = getFullScenesPath(getUserDataPath());
+
+if (!existingConfig || Object.keys(existingConfig).length === 0) {
+  // Write the default config
+  for (const [key, value] of Object.entries(defaultConfig)) {
+    await storage.set(key, value);
+  }
+} else {
+  // Deep merge with defaults if config exists but might be missing properties
+  const mergedConfig = mergeConfig(existingConfig, defaultConfig);
+  if (JSON.stringify(existingConfig) !== JSON.stringify(mergedConfig)) {
+    for (const [key, value] of Object.entries(mergedConfig)) {
+      await storage.set(key, value);
+    }
+  }
+}
+
+export const config = storage;

--- a/packages/shared/paths.ts
+++ b/packages/shared/paths.ts
@@ -1,3 +1,10 @@
+import path from 'node:path';
+
 export const SCENES_DIRECTORY = 'Scenes';
 export const SETTINGS_DIRECTORY = 'Settings';
 export const CUSTOM_ASSETS_DIRECTORY = 'Custom Items';
+export const CONFIG_FILE_NAME = 'config.json';
+
+export function getFullScenesPath(userDataPath: string): string {
+  return path.join(userDataPath, SCENES_DIRECTORY);
+}

--- a/packages/shared/types/config.ts
+++ b/packages/shared/types/config.ts
@@ -1,4 +1,7 @@
+import deepmerge from 'deepmerge';
 import { type AppSettings } from './settings';
+import { DEFAULT_DEPENDENCY_UPDATE_STRATEGY } from './settings';
+import { SCENES_DIRECTORY } from '/shared/paths';
 
 export type Config = {
   version: number;
@@ -6,4 +9,23 @@ export type Config = {
     paths: string[];
   };
   settings: AppSettings;
+  userId?: string;
 };
+
+export const DEFAULT_CONFIG: Config = {
+  version: 1,
+  workspace: {
+    paths: [],
+  },
+  settings: {
+    scenesPath: SCENES_DIRECTORY, // Base directory name, will be joined with userDataPath by main/preload
+    dependencyUpdateStrategy: DEFAULT_DEPENDENCY_UPDATE_STRATEGY,
+  },
+};
+
+export function mergeConfig(target: Partial<Config>, source: Config): Config {
+  return deepmerge(source, target, {
+    // Clone arrays instead of merging them
+    arrayMerge: (_, sourceArray) => sourceArray,
+  });
+}


### PR DESCRIPTION
# Fix Config Initialization and Recovery

## Problem

We discovered a critical issue with config initialization:

1. The analytics module in the main process creates a minimal config file containing only `userId`
2. Later, when the renderer process tries to initialize the config, it skips creating the default config because a config file already exists (even though it's incomplete)
3. This leads to missing critical config properties throughout the application, as the code assumes a complete config structure

This issue was introduced when analytics support was added a few versions back. It specifically affects:

- New installations since that version
- Does NOT affect existing installations that already had a valid config file
- Persists across reinstalls since the config file is stored in the user's app data directory, outside the installation directory

This explains why the issue wasn't caught earlier - existing installations continued to work fine, while new users started experiencing problems with scene creation and template loading.

## Solution

### 1. Proper Config Initialization and Recovery

- Modified both main and preload processes to properly merge any existing config with default values
- Even if a config exists (e.g., created by analytics with just `userId`), we ensure all default properties are present
- Added deep merging to preserve existing values while guaranteeing config completeness

### 2. Implementation Improvements

- Integrated `deepmerge` library for robust config merging
- Centralized path handling in `shared/paths.ts`
- Ensured consistent path resolution between main and preload processes
- Standardized config initialization across the application

## Testing

1. Current Version (to verify the bug):

   ```
   # Windows
   Delete "C:\Users\<USERNAME>\AppData\Roaming\creator-hub\Settings\config.json"
   # Mac
   Delete "~/Library/Application Support/creator-hub/Settings/config.json"
   ```

   - Open Creator Hub
   - Observe that you cannot create new scenes and templates won't load
   - Note: Uninstalling/reinstalling doesn't fix this as the config file is preserved

2. Fixed Version (this PR):
   - Uninstall current Creator Hub
   - Install the version from this PR
   - The app should work correctly
   - For new installations (the affected group), no additional steps needed
   - For existing users, you will need to re-import your scenes, but this is a one-time operation (because you deleted the config file where those imports were stored)

## Migration

These changes are backward compatible and will automatically fix broken configs:

- Existing configs with only `userId` will be automatically populated with all required default values
- No user action or manual migration needed
- Existing valid configurations will be preserved
