### PR TITLE
fix: config reset on app restart and improve migrations handling

### DIFF
--- a/packages/main/src/modules/analytics.ts
+++ b/packages/main/src/modules/analytics.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import log from 'electron-log';
 import { randomUUID, type UUID } from 'node:crypto';
 import { FileSystemStorage } from '/shared/types/storage';
-import { config } from './config';
+import { getConfig } from './config';
 import { getWorkspaceConfigPath } from './electron';
 
 let analytics: Analytics | null = null;
@@ -19,6 +19,7 @@ export function setUserId(userId: string) {
 }
 
 export async function getAnonymousId() {
+  const config = await getConfig();
   const userId = await config.get<string>('userId');
   if (!userId) {
     const uuid = randomUUID();

--- a/packages/main/src/modules/config.ts
+++ b/packages/main/src/modules/config.ts
@@ -1,30 +1,36 @@
 import path from 'node:path';
-import { FileSystemStorage } from '/shared/types/storage';
+import { FileSystemStorage, type IFileSystemStorage } from '/shared/types/storage';
 import { SETTINGS_DIRECTORY, CONFIG_FILE_NAME, getFullScenesPath } from '/shared/paths';
-import { DEFAULT_CONFIG, mergeConfig } from '/shared/types/config';
+import { DEFAULT_CONFIG, mergeConfig, type Config } from '/shared/types/config';
 import { getUserDataPath } from './electron';
+import { waitForMigrations } from './migrations';
+import log from 'electron-log/main';
 
 export const CONFIG_PATH = path.join(getUserDataPath(), SETTINGS_DIRECTORY, CONFIG_FILE_NAME);
-const storage = await FileSystemStorage.getOrCreate(CONFIG_PATH);
 
-// Initialize with default values if empty
-const existingConfig = await storage.get<Record<string, any>>('');
-const defaultConfig = { ...DEFAULT_CONFIG };
-defaultConfig.settings.scenesPath = getFullScenesPath(getUserDataPath());
+let configStorage: IFileSystemStorage | undefined;
 
-if (!existingConfig || Object.keys(existingConfig).length === 0) {
-  // Write the default config
-  for (const [key, value] of Object.entries(defaultConfig)) {
-    await storage.set(key, value);
-  }
-} else {
-  // Deep merge with defaults if config exists but might be missing properties
-  const mergedConfig = mergeConfig(existingConfig, defaultConfig);
-  if (JSON.stringify(existingConfig) !== JSON.stringify(mergedConfig)) {
-    for (const [key, value] of Object.entries(mergedConfig)) {
-      await storage.set(key, value);
+export async function getConfig(): Promise<IFileSystemStorage> {
+  await waitForMigrations();
+
+  if (!configStorage) {
+    configStorage = await FileSystemStorage.getOrCreate(CONFIG_PATH);
+
+    // Initialize with default values if empty or merge with defaults if partial
+    const defaultConfig = { ...DEFAULT_CONFIG };
+    defaultConfig.settings.scenesPath = getFullScenesPath(getUserDataPath());
+
+    const existingConfig = await configStorage.getAll<Partial<Config>>();
+
+    // Deep merge with defaults if config exists but might be missing properties
+    const mergedConfig = mergeConfig(existingConfig, defaultConfig);
+    if (JSON.stringify(existingConfig) !== JSON.stringify(mergedConfig)) {
+      log.info('[Config] Writing merged config to storage');
+      await configStorage.setAll(mergedConfig);
+    } else {
+      log.info('[Config] Config already exists and is up to date');
     }
   }
-}
 
-export const config = storage;
+  return configStorage;
+}

--- a/packages/preload/src/modules/workspace.ts
+++ b/packages/preload/src/modules/workspace.ts
@@ -304,9 +304,11 @@ export async function duplicateProject(_path: string): Promise<Project> {
  * @throws An error if the selected directory is not a valid project.
  */
 export async function importProject(): Promise<Project | undefined> {
+  const config = await getConfig();
   const [projectPath] = await invoke('electron.showOpenDialog', {
     title: 'Import project',
     properties: ['openDirectory'],
+    defaultPath: config.settings.scenesPath,
   });
 
   const cancelled = !projectPath;
@@ -314,7 +316,6 @@ export async function importProject(): Promise<Project | undefined> {
   if (cancelled) return undefined;
 
   const pathBaseName = path.basename(projectPath);
-  const config = await getConfig();
   const [projects] = await getProjects(config.workspace.paths);
   const projectAlreadyExists = projects.find($ => $.path === projectPath);
 

--- a/packages/shared/types/config.ts
+++ b/packages/shared/types/config.ts
@@ -3,6 +3,8 @@ import { type AppSettings } from './settings';
 import { DEFAULT_DEPENDENCY_UPDATE_STRATEGY } from './settings';
 import { SCENES_DIRECTORY } from '/shared/paths';
 
+export const CURRENT_CONFIG_VERSION = 2;
+
 export type Config = {
   version: number;
   workspace: {
@@ -13,7 +15,7 @@ export type Config = {
 };
 
 export const DEFAULT_CONFIG: Config = {
-  version: 1,
+  version: CURRENT_CONFIG_VERSION,
   workspace: {
     paths: [],
   },

--- a/packages/shared/types/storage.ts
+++ b/packages/shared/types/storage.ts
@@ -44,9 +44,16 @@ async function _createFileSystemStorage(storagePath: string) {
       const data = await read();
       return data[key] as T | undefined;
     },
+    getAll: async <T extends StorageData>(): Promise<T> => {
+      const data = await read();
+      return data as T;
+    },
     set: async <T>(key: string, value: T): Promise<void> => {
       const data = await read();
       data[key] = value;
+      await write(data);
+    },
+    setAll: async <T extends StorageData>(data: T): Promise<void> => {
       await write(data);
     },
     has: async (key: string): Promise<boolean> => {


### PR DESCRIPTION
# Fix config reset on app restart and improve migrations handling

## Config Reset Bug

The config was being reset to default values on app restart because we were incorrectly using `storage.get('')` to check for config existence. This was unreliable and caused the config to reset even when valid data existed.

### Fix

- Added `getAll()` and `setAll()` methods to read/write entire config state at once
- Properly merge existing config with defaults
- Write back merged config only when necessary
- Added better logging for debugging

## Migrations Improvement

Added synchronization to prevent race conditions between config operations and migrations:

- Created `waitForMigrations()` utility using `fp-future`
- Modified `getConfig()` to await migrations before proceeding
- Single source of truth for migrations status

### V2 Migration

Added version-based migration that automatically includes scene directories in workspace:

- Scans `scenesPath` for valid scenes (containing scene.json)
- Adds scene paths to workspace while preserving existing paths
- Ensures no duplicate paths in workspace
- Updates config version to 2

## Testing

1. Start app fresh
2. Import scenes
3. Restart app
4. Verify scenes persist
5. Verify config settings persist
6. Verify scenes from scenesPath are added to workspace
7. Verify migration only runs once (on next restart)
