### PR TITLE
fix: recover from node_modules from wrong platform error

### DIFF
--- a/packages/main/src/modules/cli.ts
+++ b/packages/main/src/modules/cli.ts
@@ -35,7 +35,10 @@ export async function start(path: string, retry = true) {
       env: await getEnv(path),
     });
 
-    await previewServer.waitFor(/decentraland:\/\//i);
+    await Promise.race([
+      previewServer.waitFor(/decentraland:\/\//i, /CliError/i),
+      await previewServer.wait(),
+    ]);
   } catch (error) {
     if (retry) {
       log.info('[CLI] Something went wrong trying to start preview:', (error as Error).message);


### PR DESCRIPTION
The following error does not get caught by the current try/catch because the `sdk-commands start` is being run, but the `waitFor(/decentraland:\/\//i)` keeps waiting forever for the success message that never arrives.

I added the `/CliError/i` regex to catch this particular error message that contains that string. I didn't add any `/error/i` because there might be errores logged by the CLI that don't require to kill the preview.

I also added the race against the `wait()` helper, that should throw if the process exits with a non-zero code.

The logs:

```
[2025-01-29 15:43:53.663] [info]  [UtilityProcess] @dcl/sdk-commands start v7.7.1

[2025-01-29 15:43:54.540] [info]  [UtilityProcess] [1/2] Bundling file /Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/src/index.ts

[2025-01-29 15:43:54.603] [info]  [UtilityProcess] Error: 
You installed esbuild for another platform than the one you're currently using.
This won't work because esbuild is written with native code and needs to
install a platform-specific binary executable.

Specifically the "@esbuild/darwin-arm64" package is present but this platform
needs the "@esbuild/darwin-x64" package instead. People often get into this
situation by installing esbuild with npm running inside of Rosetta 2 and then
trying to use it with node running outside of Rosetta 2, or vice versa (Rosetta
2 is Apple's on-the-fly x86_64-to-arm64 translation service).

If you are installing with npm, you can try ensuring that both npm and node are
not running under Rosetta 2 and then reinstalling esbuild. This likely involves
changing how you installed npm and/or node. For example, installing node with
the universal installer here should work: https://nodejs.org/en/download/. Or
you could consider using yarn instead of npm which has built-in support for
installing a package on multiple platforms simultaneously.

If you are installing with yarn, you can try listing both "arm64" and "x64"
in your ".yarnrc.yml" file using the "supportedArchitectures" feature:
https://yarnpkg.com/configuration/yarnrc/#supportedArchitectures
Keep in mind that this means multiple copies of esbuild will be present.

Another alternative is to use the "esbuild-wasm" package instead, which works
the same way on all platforms. But it comes with a heavy performance cost and
can sometimes be 10x slower than the "esbuild" package, so you may also not
want to do that.

    at generateBinPath (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/esbuild/lib/main.js:1888:17)
    at esbuildCommandAndArgs (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/esbuild/lib/main.js:1969:33)
    at ensureServiceIsRunning (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/esbuild/lib/main.js:2133:25)
    at Object.context (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/esbuild/lib/main.js:2026:33)
    at bundleSingleProject (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/logic/bundle.js:107:45)
    at async bundleProject (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/logic/bundle.js:95:9)
    at async buildScene (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/commands/build/index.js:62:35)
    at async Object.main (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/commands/start/index.js:141:17)
    at async runSdkCommand (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/run-command.js:71:25)
    at async main (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/index.js:15:9)

[2025-01-29 15:43:54.611] [info]  [UtilityProcess] Developer: All errors thrown must be an instance of "CliError"Error: 
You installed esbuild for another platform than the one you're currently using.
This won't work because esbuild is written with native code and needs to
install a platform-specific binary executable.

Specifically the "@esbuild/darwin-arm64" package is present but this platform
needs the "@esbuild/darwin-x64" package instead. People often get into this
situation by installing esbuild with npm running inside of Rosetta 2 and then
trying to use it with node running outside of Rosetta 2, or vice versa (Rosetta
2 is Apple's on-the-fly x86_64-to-arm64 translation service).

If you are installing with npm, you can try ensuring that both npm and node are
not running under Rosetta 2 and then reinstalling esbuild. This likely involves
changing how you installed npm and/or node. For example, installing node with
the universal installer here should work: https://nodejs.org/en/download/. Or
you could consider using yarn instead of npm which has built-in support for
installing a package on multiple platforms simultaneously.

If you are installing with yarn, you can try listing both "arm64" and "x64"
in your ".yarnrc.yml" file using the "supportedArchitectures" feature:
https://yarnpkg.com/configuration/yarnrc/#supportedArchitectures
Keep in mind that this means multiple copies of esbuild will be present.

Another alternative is to use the "esbuild-wasm" package instead, which works
the same way on all platforms. But it comes with a heavy performance cost and
can sometimes be 10x slower than the "esbuild" package, so you may also not
want to do that.

    at generateBinPath (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/esbuild/lib/main.js:1888:17)
    at esbuildCommandAndArgs (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/esbuild/lib/main.js:1969:33)
    at ensureServiceIsRunning (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/esbuild/lib/main.js:2133:25)
    at Object.context (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/esbuild/lib/main.js:2026:33)
    at bundleSingleProject (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/logic/bundle.js:107:45)
    at async bundleProject (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/logic/bundle.js:95:9)
    at async buildScene (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/commands/build/index.js:62:35)
    at async Object.main (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/commands/start/index.js:141:17)
    at async runSdkCommand (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/run-command.js:71:25)
    at async main (/Users/mostro/Library/Application Support/creator-hub/Scenes/New Scene/node_modules/@dcl/sdk-commands/dist/index.js:15:9)

[2025-01-29 15:43:54.613] [info]  [UtilityProcess] Exiting "sdk-commands start --explorer-alpha --hub" with pid=13016 and exit code=1
```
