### PR TITLE
fix: Deploy to available catalyst server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "happy-dom": "14.12.3",
         "nano-staged": "0.8.0",
         "playwright": "1.45.0",
+        "prettier": "^3.5.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-intl": "^6.6.8",
@@ -871,7 +872,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17659,6 +17660,22 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "happy-dom": "14.12.3",
     "nano-staged": "0.8.0",
     "playwright": "1.45.0",
+    "prettier": "^3.5.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-intl": "^6.6.8",

--- a/packages/renderer/src/components/HomePage/styles.css
+++ b/packages/renderer/src/components/HomePage/styles.css
@@ -87,6 +87,7 @@
   text-transform: none;
   color: var(--white) !important;
   border-radius: 8px;
+  margin-left: 0;
 }
 
 .HomePage .Card .CardActions {

--- a/packages/renderer/src/components/Modals/PublishProject/steps/Deploy/component.tsx
+++ b/packages/renderer/src/components/Modals/PublishProject/steps/Deploy/component.tsx
@@ -202,7 +202,7 @@ export function Deploy(props: Props) {
                   </Typography>
                 </div>
               </div>
-              {deployment.status === 'idle' && (
+              {deployment.status === 'idle' && deployment.retryAttempt === 0 && (
                 <Idle
                   files={deployment.files}
                   error={deployment.error}

--- a/packages/renderer/src/components/Modals/PublishProject/steps/Deploy/component.tsx
+++ b/packages/renderer/src/components/Modals/PublishProject/steps/Deploy/component.tsx
@@ -31,7 +31,9 @@ const MAX_FILE_PATH_LENGTH = 50;
 
 function getPath(filename: string) {
   return filename.length > MAX_FILE_PATH_LENGTH
-    ? `${filename.slice(0, MAX_FILE_PATH_LENGTH / 2)}...${filename.slice(-(MAX_FILE_PATH_LENGTH / 2))}`
+    ? `${filename.slice(0, MAX_FILE_PATH_LENGTH / 2)}...${filename.slice(
+        -(MAX_FILE_PATH_LENGTH / 2),
+      )}`
     : filename;
 }
 
@@ -57,7 +59,8 @@ export function Deploy(props: Props) {
   const { chainId, wallet, avatar } = useAuth();
   const { updateProjectInfo } = useWorkspace();
   const { loadingPublish } = useEditor();
-  const { getDeployment, overallStatus, isDeployFinishing, executeDeployment } = useDeploy();
+  const { getDeployment, overallStatus, isDeployFinishing, executeDeploymentWithRetry } =
+    useDeploy();
   const { pushCustom } = useSnackbar();
   const [showWarning, setShowWarning] = useState(false);
   const [skipWarning, setSkipWarning] = useState(project.info.skipPublishWarning ?? false);
@@ -66,7 +69,7 @@ export function Deploy(props: Props) {
   const handlePublish = useCallback(() => {
     setShowWarning(false);
     updateProjectInfo(project.path, { skipPublishWarning: skipWarning }); // write skip warning flag
-    executeDeployment(project.path);
+    executeDeploymentWithRetry(project.path);
   }, [skipWarning, project]);
 
   const handleBack = useCallback(() => {
@@ -107,8 +110,8 @@ export function Deploy(props: Props) {
             ? t('modal.publish_project.deploy.world')
             : t('modal.publish_project.deploy.land')
           : loadingPublish
-            ? t('modal.publish_project.deploy.loading')
-            : t('modal.publish_project.deploy.error')
+          ? t('modal.publish_project.deploy.loading')
+          : t('modal.publish_project.deploy.error')
       }
       size="large"
       {...props}

--- a/packages/renderer/src/components/Modals/PublishProject/steps/Deploy/component.tsx
+++ b/packages/renderer/src/components/Modals/PublishProject/steps/Deploy/component.tsx
@@ -110,8 +110,8 @@ export function Deploy(props: Props) {
             ? t('modal.publish_project.deploy.world')
             : t('modal.publish_project.deploy.land')
           : loadingPublish
-          ? t('modal.publish_project.deploy.loading')
-          : t('modal.publish_project.deploy.error')
+            ? t('modal.publish_project.deploy.loading')
+            : t('modal.publish_project.deploy.error')
       }
       size="large"
       {...props}

--- a/packages/renderer/src/hooks/useDeploy.ts
+++ b/packages/renderer/src/hooks/useDeploy.ts
@@ -31,7 +31,7 @@ export const useDeploy = () => {
   );
 
   const executeDeploymentWithRetry = useCallback(
-    async (path: string) => {
+    (path: string) => {
       dispatch(actions.executeDeploymentWithRetry(path));
     },
     [dispatch],

--- a/packages/renderer/src/hooks/useDeploy.ts
+++ b/packages/renderer/src/hooks/useDeploy.ts
@@ -30,6 +30,13 @@ export const useDeploy = () => {
     [dispatch],
   );
 
+  const executeDeploymentWithRetry = useCallback(
+    async (path: string) => {
+      dispatch(actions.executeDeploymentWithRetry(path));
+    },
+    [dispatch],
+  );
+
   const removeDeployment = useCallback(
     (path: string) => {
       dispatch(actions.removeDeployment({ path }));
@@ -52,6 +59,7 @@ export const useDeploy = () => {
     getDeployment,
     initializeDeployment,
     executeDeployment,
+    executeDeploymentWithRetry,
     overallStatus,
     isDeployFinishing,
     removeDeployment,

--- a/packages/renderer/src/modules/store/deployment/slice.spec.ts
+++ b/packages/renderer/src/modules/store/deployment/slice.spec.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChainId } from '@dcl/schemas';
+import { createTestStore } from '../../../../tests/utils/testStore';
+import { executeDeploymentWithRetry, initializeDeployment } from './slice';
+import { deploy, checkDeploymentStatus } from './utils';
+
+const TEST_PATH = '/test/path';
+const TEST_WALLET = '0x123';
+const TEST_CHAIN_ID = ChainId.ETHEREUM_MAINNET;
+const TEST_PORT = 3000;
+const TEST_SCENE_INFO = {
+  id: 'test-id',
+  name: 'Test Scene',
+};
+
+vi.mock('@dcl/single-sign-on-client', () => ({
+  localStorageGetIdentity: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@dcl/crypto', () => ({
+  Authenticator: {
+    signPayload: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('/@/modules/store/editor/slice', () => ({
+  publishScene: vi.fn().mockImplementation(({ path, target }) => ({
+    type: 'editor/publishScene/fulfilled',
+    meta: { arg: { path, target } },
+    payload: { port: 3000 },
+    unwrap: () => Promise.resolve({ port: 3000 }),
+  })),
+}));
+
+vi.mock('./utils', async () => {
+  const actual = await vi.importActual('./utils');
+  return {
+    ...actual,
+    deploy: vi.fn(),
+    checkDeploymentStatus: vi.fn(),
+    fetchFiles: vi.fn().mockResolvedValue([]),
+    fetchInfo: vi.fn().mockResolvedValue({
+      id: 'test-id',
+      name: 'Test Scene',
+    }),
+  };
+});
+
+describe('deployment slice', () => {
+  let store: ReturnType<typeof createTestStore>;
+
+  const initDeploymentStore = async () => {
+    const store = createTestStore();
+    await store
+      .dispatch(
+        initializeDeployment({
+          path: TEST_PATH,
+          port: TEST_PORT,
+          chainId: TEST_CHAIN_ID,
+          wallet: TEST_WALLET,
+        }),
+      )
+      .unwrap();
+    return store;
+  };
+
+  const mockDeploySuccess = () => {
+    vi.mocked(deploy).mockResolvedValue(undefined);
+  };
+
+  const mockDeployWithRetryOnce = () => {
+    let called = false;
+    vi.mocked(deploy).mockImplementation(() => {
+      if (!called) {
+        called = true;
+        throw new Error('Failed');
+      }
+      return Promise.resolve();
+    });
+  };
+
+  const mockDeployAlwaysFail = () => {
+    vi.mocked(deploy).mockRejectedValue(new Error('Failed'));
+  };
+
+  const mockCheckStatus = (status = 'complete') => {
+    vi.mocked(checkDeploymentStatus).mockResolvedValue({ status });
+  };
+
+  const advanceRetryTimers = async (times = 1, delay = 1000) => {
+    for (let i = 0; i < times; i++) {
+      await vi.advanceTimersByTimeAsync(delay);
+    }
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('executeDeploymentWithRetry', () => {
+    describe('when deployment exists', () => {
+      beforeEach(async () => {
+        store = await initDeploymentStore();
+        mockDeploySuccess();
+        mockCheckStatus();
+      });
+
+      it('should execute deployment successfully', async () => {
+        const result = await store.dispatch(executeDeploymentWithRetry(TEST_PATH)).unwrap();
+        expect(result).toEqual({
+          info: TEST_SCENE_INFO,
+          componentsStatus: { status: 'complete' },
+        });
+      });
+
+      it('should not retry on success', async () => {
+        await store.dispatch(executeDeploymentWithRetry(TEST_PATH)).unwrap();
+        expect(deploy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when deployment fails and needs retry', () => {
+      beforeEach(async () => {
+        vi.useFakeTimers();
+        store = await initDeploymentStore();
+        mockDeployWithRetryOnce();
+        mockCheckStatus();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('should retry with new server', async () => {
+        const resultPromise = store.dispatch(executeDeploymentWithRetry(TEST_PATH));
+        await advanceRetryTimers(1);
+        const result = await resultPromise.unwrap();
+
+        expect(result).toEqual({
+          info: TEST_SCENE_INFO,
+          componentsStatus: { status: 'complete' },
+        });
+        expect(deploy).toHaveBeenCalledTimes(2);
+      });
+
+      it('should track deployment attempts', async () => {
+        const resultPromise = store.dispatch(executeDeploymentWithRetry(TEST_PATH));
+        await advanceRetryTimers(1);
+        await resultPromise;
+        const deployment = store.getState().deployment.deployments[TEST_PATH];
+        expect(deployment?.status).toBe('complete');
+      });
+    });
+
+    describe('when deployment not found', () => {
+      beforeEach(() => {
+        store = createTestStore(); // not initialized
+      });
+
+      it('should reject with appropriate error', async () => {
+        const result = await store.dispatch(executeDeploymentWithRetry(TEST_PATH));
+        expect(result.type).toBe('deployment/executeWithRetry/rejected');
+        expect(result.payload).toEqual({
+          message: 'Deployment not found. Initialize it first.',
+          info: {},
+        });
+      });
+    });
+
+    describe('when max retries are reached', () => {
+      beforeEach(async () => {
+        vi.useFakeTimers();
+        store = await initDeploymentStore();
+        mockDeployAlwaysFail();
+        mockCheckStatus();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('should fail after max retries', async () => {
+        const resultPromise = store.dispatch(executeDeploymentWithRetry(TEST_PATH));
+        await advanceRetryTimers(3);
+        const result = await resultPromise;
+
+        expect(result.type).toBe('deployment/executeWithRetry/rejected');
+        expect(deploy).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+      });
+    });
+  });
+});

--- a/packages/renderer/src/modules/store/deployment/utils.spec.ts
+++ b/packages/renderer/src/modules/store/deployment/utils.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ChainId } from '@dcl/schemas';
+import { getAvailableCatalystServer } from './utils';
+
+vi.mock('dcl-catalyst-client/dist/contracts-snapshots', () => ({
+  getCatalystServersFromCache: vi.fn((network: string) => {
+    switch (network) {
+      case 'sepolia':
+        return [
+          { address: 'https://peer.decentraland.zone' },
+          { address: 'https://peer-ec2.decentraland.zone' },
+        ];
+      default:
+        return [
+          { address: 'https://peer.decentraland.org' },
+          { address: 'https://peer-ec2.decentraland.org' },
+        ];
+    }
+  }),
+}));
+
+describe('getAvailableCatalystServer', () => {
+  it('should return a server for sepolia network', () => {
+    const triedServers = new Set<string>();
+    const result = getAvailableCatalystServer(triedServers, ChainId.ETHEREUM_SEPOLIA);
+
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('string');
+  });
+
+  it('should return a server for mainnet network', () => {
+    const triedServers = new Set<string>();
+    const result = getAvailableCatalystServer(triedServers, ChainId.ETHEREUM_MAINNET);
+
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('string');
+  });
+
+  it('should exclude tried servers from the selection', () => {
+    const triedServers = new Set<string>();
+    const firstResult = getAvailableCatalystServer(triedServers, ChainId.ETHEREUM_SEPOLIA);
+    triedServers.add(firstResult);
+    const secondResult = getAvailableCatalystServer(triedServers, ChainId.ETHEREUM_SEPOLIA);
+    triedServers.add(secondResult);
+
+    expect(triedServers).toContain(firstResult);
+    expect(triedServers).toContain(secondResult);
+  });
+
+  describe('when no servers in cache', () => {
+    it('should throw error', () => {
+      const triedServers = new Set<string>([
+        'https://peer.decentraland.zone',
+        'https://peer-ec2.decentraland.zone',
+      ]);
+
+      expect(() => getAvailableCatalystServer(triedServers, ChainId.ETHEREUM_SEPOLIA)).toThrow(
+        'No available catalyst servers to try',
+      );
+    });
+  });
+});

--- a/packages/renderer/src/modules/store/deployment/utils.ts
+++ b/packages/renderer/src/modules/store/deployment/utils.ts
@@ -2,7 +2,8 @@ import { minutes, seconds } from '/shared/time';
 import equal from 'fast-deep-equal';
 import type { AuthIdentity } from 'decentraland-crypto-fetch';
 import { type AuthChain, Authenticator } from '@dcl/crypto';
-import type { ChainId } from '@dcl/schemas';
+import { ChainId } from '@dcl/schemas';
+import { getCatalystServersFromCache } from 'dcl-catalyst-client/dist/contracts-snapshots';
 
 import { delay } from '/shared/utils';
 import { DEPLOY_URLS, type Info } from '/shared/types/deploy';
@@ -268,4 +269,17 @@ export function checkDeploymentCompletion(
   if (total === 0) return false;
   const completedCount = statuses.filter(value => value === 'complete').length;
   return completedCount / total >= percentage;
+}
+
+export function getAvailableCatalystServer(triedServers: Set<string>, chainId: ChainId): string {
+  const network = chainId === ChainId.ETHEREUM_SEPOLIA ? 'sepolia' : 'mainnet';
+  const catalystServers = getCatalystServersFromCache(network).map(server => server.address);
+  const availableServers = catalystServers.filter(server => !triedServers.has(server));
+
+  if (availableServers.length === 0) {
+    throw new Error('No available catalyst servers to try');
+  }
+
+  const randomIndex = Math.floor(Math.random() * availableServers.length);
+  return availableServers[randomIndex];
 }

--- a/packages/renderer/src/modules/store/deployment/utils.ts
+++ b/packages/renderer/src/modules/store/deployment/utils.ts
@@ -273,8 +273,13 @@ export function checkDeploymentCompletion(
 
 export function getAvailableCatalystServer(triedServers: Set<string>, chainId: ChainId): string {
   const network = chainId === ChainId.ETHEREUM_SEPOLIA ? 'sepolia' : 'mainnet';
-  const catalystServers = getCatalystServersFromCache(network).map(server => server.address);
-  const availableServers = catalystServers.filter(server => !triedServers.has(server));
+  const availableServers = [];
+
+  for (const server of getCatalystServersFromCache(network)) {
+    if (!triedServers.has(server.address)) {
+      availableServers.push(server.address);
+    }
+  }
 
   if (availableServers.length === 0) {
     throw new Error('No available catalyst servers to try');

--- a/packages/renderer/src/modules/store/utils.spec.ts
+++ b/packages/renderer/src/modules/store/utils.spec.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { dispatchWithRetry } from './utils';
+
+const TEST_DELAY_MS = 100;
+
+describe('dispatchWithRetry', () => {
+  const mockDispatch = vi.fn();
+  const mockThunk = createAsyncThunk('test/thunk', async (arg: string) => {
+    if (arg === 'fail') throw new Error('Failed');
+    return 'success';
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDispatch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('when the thunk succeeds', () => {
+    beforeEach(() => {
+      mockDispatch.mockImplementationOnce(_action => ({
+        unwrap: () => Promise.resolve('success'),
+      }));
+    });
+
+    it('should return the success value', async () => {
+      const result = await dispatchWithRetry(mockDispatch, mockThunk, 'success');
+      expect(result).toBe('success');
+    });
+
+    it('should dispatch only once', async () => {
+      await dispatchWithRetry(mockDispatch, mockThunk, 'success');
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when the thunk fails and retries', () => {
+    beforeEach(() => {
+      mockDispatch
+        .mockImplementationOnce(() => ({
+          unwrap: () => Promise.reject(new Error('Failed')),
+        }))
+        .mockImplementationOnce(() => ({
+          unwrap: () => Promise.resolve('success'),
+        }));
+    });
+
+    it('should eventually succeed', async () => {
+      const result = await dispatchWithRetry(mockDispatch, mockThunk, 'fail', {
+        delayMs: TEST_DELAY_MS,
+      });
+      expect(result).toBe('success');
+    });
+
+    it('should dispatch twice', async () => {
+      await dispatchWithRetry(mockDispatch, mockThunk, 'fail', {
+        delayMs: TEST_DELAY_MS,
+      });
+      expect(mockDispatch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should wait for the specified delay between retries', async () => {
+      vi.useFakeTimers();
+      const promise = dispatchWithRetry(mockDispatch, mockThunk, 'fail', {
+        delayMs: TEST_DELAY_MS,
+      });
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(TEST_DELAY_MS);
+      expect(mockDispatch).toHaveBeenCalledTimes(2);
+
+      const result = await promise;
+      expect(result).toBe('success');
+    });
+  });
+
+  describe('when the thunk fails and reaches max retries', () => {
+    beforeEach(() => {
+      mockDispatch.mockImplementation(() => ({
+        unwrap: () => Promise.reject(new Error('Failed')),
+      }));
+    });
+
+    it('should throw the error', async () => {
+      await expect(
+        dispatchWithRetry(mockDispatch, mockThunk, 'fail', {
+          maxRetries: 2,
+          delayMs: TEST_DELAY_MS,
+        }),
+      ).rejects.toThrow('Failed');
+    });
+
+    it('should attempt the specified number of retries', async () => {
+      await expect(
+        dispatchWithRetry(mockDispatch, mockThunk, 'fail', {
+          maxRetries: 2,
+          delayMs: TEST_DELAY_MS,
+        }),
+      ).rejects.toThrow('Failed');
+
+      expect(mockDispatch).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('when the operation is aborted', () => {
+    let controller: AbortController;
+
+    beforeEach(() => {
+      controller = new AbortController();
+      controller.abort();
+    });
+
+    it('should throw an abort error', async () => {
+      await expect(
+        dispatchWithRetry(mockDispatch, mockThunk, 'success', { signal: controller.signal }),
+      ).rejects.toThrow('Operation aborted');
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when using custom retry logic', () => {
+    beforeEach(() => {
+      mockDispatch.mockImplementation(() => ({
+        unwrap: () => Promise.reject(new Error('Failed')),
+      }));
+    });
+
+    it('should respect the custom retry logic', async () => {
+      const shouldRetry = vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(false);
+      await expect(
+        dispatchWithRetry(mockDispatch, mockThunk, 'fail', {
+          shouldRetry,
+          maxRetries: 2,
+          delayMs: TEST_DELAY_MS,
+        }),
+      ).rejects.toThrow('Failed');
+
+      expect(shouldRetry).toHaveBeenCalledTimes(2);
+      expect(mockDispatch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('when using failure callbacks', () => {
+    let onFailure: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      onFailure = vi.fn();
+      mockDispatch
+        .mockImplementationOnce(() => ({
+          unwrap: () => Promise.reject(new Error('Failed')),
+        }))
+        .mockImplementationOnce(() => ({
+          unwrap: () => Promise.resolve('success'),
+        }));
+    });
+
+    it('should call the onFailure callback with error and attempt number', async () => {
+      await dispatchWithRetry(mockDispatch, mockThunk, 'fail', {
+        onFailure: onFailure as (error: unknown, attempt: number) => void | Promise<void>,
+        delayMs: TEST_DELAY_MS,
+      });
+      expect(onFailure).toHaveBeenCalledWith(expect.any(Error), 0);
+    });
+
+    it('should handle async onFailure callbacks', async () => {
+      vi.useFakeTimers();
+      onFailure.mockImplementationOnce(async () => {
+        await new Promise(resolve => setTimeout(resolve, 10));
+      });
+
+      const promise = dispatchWithRetry(mockDispatch, mockThunk, 'fail', {
+        onFailure: onFailure as (error: unknown, attempt: number) => void | Promise<void>,
+        delayMs: TEST_DELAY_MS,
+      });
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(onFailure).toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(TEST_DELAY_MS);
+      const result = await promise;
+      expect(result).toBe('success');
+    });
+  });
+
+  describe('when handling edge cases', () => {
+    describe('and the error is undefined', () => {
+      beforeEach(() => {
+        mockDispatch.mockImplementation(() => ({
+          unwrap: () => Promise.reject(undefined),
+        }));
+      });
+
+      it('should propagate the undefined error', async () => {
+        await expect(
+          dispatchWithRetry(mockDispatch, mockThunk, 'fail', {
+            maxRetries: 1,
+            delayMs: TEST_DELAY_MS,
+          }),
+        ).rejects.toBeUndefined();
+      });
+    });
+
+    describe('and the error is null', () => {
+      beforeEach(() => {
+        mockDispatch.mockImplementation(() => ({
+          unwrap: () => Promise.reject(null),
+        }));
+      });
+
+      it('should propagate the null error', async () => {
+        await expect(
+          dispatchWithRetry(mockDispatch, mockThunk, 'fail', {
+            maxRetries: 1,
+            delayMs: TEST_DELAY_MS,
+          }),
+        ).rejects.toBeNull();
+      });
+    });
+
+    describe('and the error is a custom type', () => {
+      class CustomError extends Error {
+        constructor(message: string) {
+          super(message);
+          this.name = 'CustomError';
+        }
+      }
+
+      beforeEach(() => {
+        mockDispatch.mockImplementation(() => ({
+          unwrap: () => Promise.reject(new CustomError('Custom error')),
+        }));
+      });
+
+      it('should propagate the custom error', async () => {
+        await expect(
+          dispatchWithRetry(mockDispatch, mockThunk, 'fail', {
+            maxRetries: 1,
+            delayMs: TEST_DELAY_MS,
+          }),
+        ).rejects.toThrow('Custom error');
+      });
+    });
+  });
+});

--- a/packages/renderer/src/modules/store/utils.spec.ts
+++ b/packages/renderer/src/modules/store/utils.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { dispatchWithRetry } from './utils';
 
-const TEST_DELAY_MS = 100;
+const TEST_DELAY_MS = 1;
 
 describe('dispatchWithRetry', () => {
   const mockDispatch = vi.fn();

--- a/packages/renderer/src/modules/store/utils.ts
+++ b/packages/renderer/src/modules/store/utils.ts
@@ -1,0 +1,37 @@
+import { type AsyncThunk } from '@reduxjs/toolkit';
+import { type AppDispatch } from '#store';
+
+export type RetryConfig = {
+  maxRetries?: number;
+  delayMs?: number;
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+  onFailure?: (error: unknown, attempt: number) => Promise<void> | void;
+  signal?: AbortSignal;
+};
+
+export const dispatchWithRetry = async <TReturn, TArg, TRejectValue>(
+  dispatch: AppDispatch,
+  thunk: AsyncThunk<TReturn, TArg, { rejectValue: TRejectValue }>,
+  arg: TArg,
+  config: RetryConfig = {},
+): Promise<TReturn> => {
+  const { maxRetries = 3, delayMs = 1000, shouldRetry = () => true, onFailure, signal } = config;
+
+  let attempt = 0;
+  while (attempt <= maxRetries) {
+    if (signal?.aborted) throw new Error('Operation aborted');
+
+    try {
+      return await dispatch(thunk(arg)).unwrap();
+    } catch (error) {
+      if (attempt === maxRetries || !shouldRetry(error, attempt)) throw error;
+
+      if (onFailure) await onFailure(error, attempt);
+
+      await new Promise(res => setTimeout(res, delayMs));
+      attempt++;
+    }
+  }
+
+  throw new Error('Retry limit reached unexpectedly');
+};

--- a/packages/renderer/tests/setupTests.ts
+++ b/packages/renderer/tests/setupTests.ts
@@ -1,0 +1,5 @@
+import { afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});

--- a/packages/renderer/tests/setupTests.ts
+++ b/packages/renderer/tests/setupTests.ts
@@ -1,5 +1,50 @@
 import { afterEach, vi } from 'vitest';
 
+// Mock preload modules
+vi.mock('#preload', () => ({
+  fs: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    readdir: vi.fn(),
+    mkdir: vi.fn(),
+    exists: vi.fn(),
+  },
+  custom: {
+    getPath: vi.fn(),
+    getEnv: vi.fn(),
+  },
+  analytics: {
+    track: vi.fn(),
+    identify: vi.fn(),
+  },
+  editor: {
+    getState: vi.fn(),
+    setState: vi.fn(),
+  },
+  npm: {
+    install: vi.fn(),
+    uninstall: vi.fn(),
+    list: vi.fn(),
+  },
+  workspace: {
+    getProjects: vi.fn(),
+    createProject: vi.fn(),
+    deleteProject: vi.fn(),
+  },
+  scene: {
+    getState: vi.fn(),
+    setState: vi.fn(),
+  },
+  settings: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+  misc: {
+    openExternal: vi.fn(),
+    showMessage: vi.fn(),
+  },
+}));
+
 afterEach(() => {
   vi.clearAllMocks();
 });

--- a/packages/renderer/tests/setupTests.ts
+++ b/packages/renderer/tests/setupTests.ts
@@ -1,49 +1,28 @@
 import { afterEach, vi } from 'vitest';
 
 // Mock preload modules
-vi.mock('#preload', () => ({
-  fs: {
-    readFile: vi.fn(),
-    writeFile: vi.fn(),
-    readdir: vi.fn(),
-    mkdir: vi.fn(),
-    exists: vi.fn(),
-  },
-  custom: {
-    getPath: vi.fn(),
-    getEnv: vi.fn(),
-  },
-  analytics: {
-    track: vi.fn(),
-    identify: vi.fn(),
-  },
-  editor: {
-    getState: vi.fn(),
-    setState: vi.fn(),
-  },
-  npm: {
-    install: vi.fn(),
-    uninstall: vi.fn(),
-    list: vi.fn(),
-  },
-  workspace: {
-    getProjects: vi.fn(),
-    createProject: vi.fn(),
-    deleteProject: vi.fn(),
-  },
-  scene: {
-    getState: vi.fn(),
-    setState: vi.fn(),
-  },
-  settings: {
-    get: vi.fn(),
-    set: vi.fn(),
-  },
-  misc: {
-    openExternal: vi.fn(),
-    showMessage: vi.fn(),
-  },
-}));
+vi.mock('#preload', async () => {
+  const actual = await import('../../preload/src/index');
+
+  const deepMockObject = (obj: Record<string, any>) => {
+    const result: Record<string, any> = {};
+
+    for (const key in obj) {
+      const value = obj[key];
+      if (typeof value === 'function') {
+        result[key] = vi.fn(); // mock functions
+      } else if (value && typeof value === 'object') {
+        result[key] = deepMockObject(value); // recurse for nested modules
+      } else {
+        result[key] = value; // passthrough for constants if needed
+      }
+    }
+
+    return result;
+  };
+
+  return deepMockObject(actual);
+});
 
 afterEach(() => {
   vi.clearAllMocks();

--- a/packages/renderer/tests/utils/testStore.ts
+++ b/packages/renderer/tests/utils/testStore.ts
@@ -1,0 +1,30 @@
+import { configureStore } from '@reduxjs/toolkit';
+import * as editor from '../../src/modules/store/editor';
+import * as snackbar from '../../src/modules/store/snackbar';
+import * as translations from '../../src/modules/store/translation';
+import * as workspace from '../../src/modules/store/workspace';
+import * as deployment from '../../src/modules/store/deployment';
+import * as analytics from '../../src/modules/store/analytics';
+import * as ens from '../../src/modules/store/ens';
+import * as land from '../../src/modules/store/land';
+
+export const createTestStore = () =>
+  configureStore({
+    reducer: {
+      editor: editor.reducer,
+      snackbar: snackbar.reducer,
+      translation: translations.reducer,
+      workspace: workspace.reducer,
+      deployment: deployment.reducer,
+      analytics: analytics.reducer,
+      ens: ens.reducer,
+      land: land.reducer,
+    },
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        thunk: true,
+        serializableCheck: false,
+      }),
+  });
+
+export type TestStore = ReturnType<typeof createTestStore>;

--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -23,7 +23,6 @@ const config = {
       '/shared/': join(PROJECT_ROOT, 'packages', 'shared') + '/',
       '/assets/': join(PACKAGE_ROOT, 'assets') + '/',
       '#store': join(PACKAGE_ROOT, 'src', 'modules', 'store') + '/',
-      '#preload': join(PROJECT_ROOT, 'packages', 'preload', 'src', 'index.ts'),
     },
   },
   base: '',

--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -23,6 +23,7 @@ const config = {
       '/shared/': join(PROJECT_ROOT, 'packages', 'shared') + '/',
       '/assets/': join(PACKAGE_ROOT, 'assets') + '/',
       '#store': join(PACKAGE_ROOT, 'src', 'modules', 'store') + '/',
+      '#preload': join(PROJECT_ROOT, 'packages', 'preload', 'src', 'index.ts'),
     },
   },
   base: '',
@@ -44,6 +45,8 @@ const config = {
   },
   test: {
     environment: 'happy-dom',
+    setupFiles: ['./tests/setupTests.ts'],
+    include: ['./src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
   },
   plugins: [
     react(),

--- a/packages/shared/types/deploy.ts
+++ b/packages/shared/types/deploy.ts
@@ -66,3 +66,9 @@ export class DeploymentError extends ErrorBase<Error> {
 
 export const isDeploymentError = (error: unknown, type: Error): error is DeploymentError =>
   error instanceof DeploymentError && error.name === type;
+
+export const isDeploymentErrorMessage = (error: unknown): error is DeploymentError =>
+  !!error &&
+  typeof error === 'object' &&
+  'message' in error &&
+  error.message === 'Max retries reached. Deployment failed.';


### PR DESCRIPTION
This PR adds a retry mechanism to deploy scenes to an available catalyst server when one of them is unavailable.

Fixes: https://github.com/decentraland/creator-hub/issues/491