### PR TITLE
fix: Update @dcl/sdk package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dcl/mini-rpc": "^1.0.7",
         "@dcl/schemas": "^11.10.4",
-        "@dcl/sdk": "^7.8.1",
+        "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/dcl-sdk-7.8.3-14387525114.commit-e4190bd.tgz",
         "@ethersproject/hash": "^5.7.0",
         "@segment/analytics-node": "^2.1.2",
         "@sentry/electron": "^6.1.0",
@@ -1079,9 +1079,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.8.1.tgz",
-      "integrity": "sha512-ZmAFmvFDoTJJi8GobAMbopm9Qo7cL5KSXAKazvZz+xInnuLP0I7pvR4rFBdWEwZIlB56zfoD2lMNTR6PWkbfMg==",
+      "version": "7.8.3-14387525114.commit-e4190bd",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/@dcl/ecs/dcl-ecs-7.8.3-14387525114.commit-e4190bd.tgz",
+      "integrity": "sha512-vYUYXGHgiy4ah+Yb97tmFATol/H3nV2+NKsPhnSgYq6iuGthnmdBAl8LutzBjwPalI0i1i1UqfJsj+q5xu+hPw==",
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/ecs-math": {
@@ -1107,18 +1107,18 @@
       }
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.8.1.tgz",
-      "integrity": "sha512-JVCqLhagopiESxlbwdNZqQRVGfqIsdCJjFkHTKcQLJKNIMEvUn9P1xSxrHw1+fRw/XwhMQy8wLomErA8XAu8kg==",
+      "version": "7.8.3-14387525114.commit-e4190bd",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/@dcl/inspector/dcl-inspector-7.8.3-14387525114.commit-e4190bd.tgz",
+      "integrity": "sha512-7wn7balceJe9UUmtlIuE1QKQgGigwK7zscTXDQwPBmyqJH1oa5i/NtZx+Y5xfUiO0mX+HROEoG3VHbqHFaYwHA==",
       "dependencies": {
         "@dcl/asset-packs": "2.2.1",
         "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.8.1.tgz",
-      "integrity": "sha512-6vEN73V3TgrxCrIUF5f5UezQz4tTfI1IDS00XApGzuu5mOv9u74PfFB1r94cScPukHEPzipznRorKO5dLUFh1A==",
+      "version": "7.8.3-14387525114.commit-e4190bd",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/@dcl/js-runtime/dcl-js-runtime-7.8.3-14387525114.commit-e4190bd.tgz",
+      "integrity": "sha512-OrCXeCMbT06S7MtRca5CZWg1P4lWIyus9qRCa8evgvKXtG4ydjjtn0w5132QKYAu1jOgKKNopmWlWJ8CPgBJpg==",
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/linker-dapp": {
@@ -1194,12 +1194,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.8.1.tgz",
-      "integrity": "sha512-Xuoymo3bi2lo6NxFulK7brTqNKaoPI2y8iEonlX2gafDHLG2w2OcZUE+HTaPOak5v1vhmyVM/pPc1KrC1YvZLA==",
+      "version": "7.8.3-14387525114.commit-e4190bd",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/@dcl/react-ecs/dcl-react-ecs-7.8.3-14387525114.commit-e4190bd.tgz",
+      "integrity": "sha512-wbXpNdVD25e6irVdwX948gUyANPadKnK5mGUUVnFCqiskAjQrHuTECJfKzuMM9e6vLhobQ25SdwsePZmCGadbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.8.1",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/@dcl/ecs/dcl-ecs-7.8.3-14387525114.commit-e4190bd.tgz",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -1226,30 +1226,31 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.8.1.tgz",
-      "integrity": "sha512-DPsp4htdfmxAOdnZDkoT9Em5nBdOIWvz+9OXnGEk9i3woTpV4oRGb/rXmre81/GpuSXhNVpdLdHlJBcoYK6j/Q==",
+      "version": "7.8.3-14387525114.commit-e4190bd",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/dcl-sdk-7.8.3-14387525114.commit-e4190bd.tgz",
+      "integrity": "sha512-nl79ILBp0oRRH9OhA8u+RCJGfsDHywy2jRRjzrGBfjdeXV9yXBFKyYhMOXD052KuG8PQ8xsYQi+p7p4pN/fCRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.8.1",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/@dcl/ecs/dcl-ecs-7.8.3-14387525114.commit-e4190bd.tgz",
         "@dcl/ecs-math": "2.1.0",
         "@dcl/explorer": "1.0.164509-20240802172549.commit-fb95b9b",
-        "@dcl/js-runtime": "7.8.1",
-        "@dcl/react-ecs": "7.8.1",
-        "@dcl/sdk-commands": "7.8.1",
+        "@dcl/inspector": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/@dcl/inspector/dcl-inspector-7.8.3-14387525114.commit-e4190bd.tgz",
+        "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/@dcl/js-runtime/dcl-js-runtime-7.8.3-14387525114.commit-e4190bd.tgz",
+        "@dcl/react-ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/@dcl/react-ecs/dcl-react-ecs-7.8.3-14387525114.commit-e4190bd.tgz",
+        "@dcl/sdk-commands": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/dcl-sdk-commands-7.8.3-14387525114.commit-e4190bd.tgz",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.8.1.tgz",
-      "integrity": "sha512-nzFw1pRJhENhI++Uw/fhnNBl6rRpZQDokg0TPJQJ8/auSrMDHVU5kgc2WkAsmjvQg7tprDB4tNpLZNyGviYacg==",
+      "version": "7.8.3-14387525114.commit-e4190bd",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/dcl-sdk-commands-7.8.3-14387525114.commit-e4190bd.tgz",
+      "integrity": "sha512-yoJ+tPYlku1a6mdssKrqwQyjSr1SBAZzy82h+dY4lHoqgba3F+HAzgsE2Xy+A+rXZQDAEH5R9WpI9p17YiUSRA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.8.1",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/@dcl/ecs/dcl-ecs-7.8.3-14387525114.commit-e4190bd.tgz",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.8.1",
+        "@dcl/inspector": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/@dcl/inspector/dcl-inspector-7.8.3-14387525114.commit-e4190bd.tgz",
         "@dcl/linker-dapp": "^0.14.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-14033082444.commit-84b403d",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@dcl/mini-rpc": "^1.0.7",
     "@dcl/schemas": "^11.10.4",
-    "@dcl/sdk": "^7.8.1",
+    "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/handle-components-schemas-errors/dcl-sdk-7.8.3-14387525114.commit-e4190bd.tgz",
     "@ethersproject/hash": "^5.7.0",
     "@segment/analytics-node": "^2.1.2",
     "@sentry/electron": "^6.1.0",


### PR DESCRIPTION
The `Tweens` basic view breaks the inspector UI, making the scene unusable.

How to test it:
- Create / Update a scene
- Add this [rising_pillar_pirates.zip](https://github.com/user-attachments/files/19712932/rising_pillar_pirates.zip)
- Verify the inspector UI works as expected

Fixes: https://github.com/decentraland/creator-hub/issues/496
Depends on: https://github.com/decentraland/js-sdk-toolchain/pull/1098