### PR TITLE
fix: audio source global not updating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dcl/mini-rpc": "^1.0.7",
         "@dcl/schemas": "^11.10.4",
-        "@dcl/sdk": "^7.8.7",
+        "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/dcl-sdk-7.8.8-14999911590.commit-4f0a206.tgz",
         "@ethersproject/hash": "^5.7.0",
         "@segment/analytics-node": "^2.1.2",
         "@sentry/electron": "^6.1.0",
@@ -873,7 +873,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.8.7.tgz",
-      "integrity": "sha512-xYv++VqOGlRWh29CljMWyRw8YTYKejfao2VPb6AGoqfkW+69+orklIVZTlU8KaezA0yAsMasX2ClgZxJL4MHig==",
+      "version": "7.8.8-14999911590.commit-4f0a206",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/@dcl/ecs/dcl-ecs-7.8.8-14999911590.commit-4f0a206.tgz",
+      "integrity": "sha512-OhEP4Rbv8CVZpNrbv13xsQWja8VlcnxNnZ51Ii0Ou70jk8Pmbzf/hkFoQsIL92qw72BAwvbJGPeQmG7jmju3OQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/ecs-math": {
@@ -1100,18 +1100,18 @@
       }
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.8.7.tgz",
-      "integrity": "sha512-EZySTyFNxML/yIVqiewPNagO72b29y9zsl6hzfbne0efjmneC3lbc4a7f5wlj7eFNHM5JRjeoW3qnZPEwO+Kbw==",
+      "version": "7.8.8-14999911590.commit-4f0a206",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/@dcl/inspector/dcl-inspector-7.8.8-14999911590.commit-4f0a206.tgz",
+      "integrity": "sha512-FrUqOsnlmxJdXVQQBo0bx6a3v+j2bT31Hk286ctzP2otKXg1dzqpKKrbVSeoxHSNvpUwreg/LwpfuLKc4jkR3Q==",
       "dependencies": {
         "@dcl/asset-packs": "2.4.0",
         "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.8.7.tgz",
-      "integrity": "sha512-G9mIx1yIhXeXxRCX4QJBavyDYQXafh3wKu+jpXhg/a+mfSlMYyCW7j3dDVkllRONhmSNIKLdgVWQRVoQKyDwBA==",
+      "version": "7.8.8-14999911590.commit-4f0a206",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/@dcl/js-runtime/dcl-js-runtime-7.8.8-14999911590.commit-4f0a206.tgz",
+      "integrity": "sha512-DqjNui960tuKJyzeqBi/nZS6JZDdATp8FIHbqV5Ks+lmFmzQ+fhr1AqDTFYOHwrphjKpR2XJjC4nQxsl6GbDvA==",
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/linker-dapp": {
@@ -1187,12 +1187,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.8.7.tgz",
-      "integrity": "sha512-PnS3jXg4cxXZVsSeF1mYZqmJVqVPu03yV+MoZA0n5naj6Zr9jnPjDRtdylHN5tEtldcBGr3s9NbsZud/causTQ==",
+      "version": "7.8.8-14999911590.commit-4f0a206",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/@dcl/react-ecs/dcl-react-ecs-7.8.8-14999911590.commit-4f0a206.tgz",
+      "integrity": "sha512-k/dZopyBzp/fMeUAxBSJqT9BeIpd00y300i7VfS7bautWZE3Qi/aOcMVeXzEFxvoP1yBdi2qAoSZJ5/RBVTipA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.8.7",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/@dcl/ecs/dcl-ecs-7.8.8-14999911590.commit-4f0a206.tgz",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -1219,30 +1219,31 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.8.7.tgz",
-      "integrity": "sha512-DL0mFd6vz5sBVgcEq54LTGzx1xdXY2dB1hrm86IMMe3pukqCttH+JfOSX0GPF2WxOG+88GJabf0cfK6DcX8l0g==",
+      "version": "7.8.8-14999911590.commit-4f0a206",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/dcl-sdk-7.8.8-14999911590.commit-4f0a206.tgz",
+      "integrity": "sha512-dRL+dIRpnB7IBPqVh20F0U+U6ZRQdNB74VsSXPm5NkQ4E+dH1ndblUYWnlglC99dJNIMsf6MpD7YoShGZEFIpA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.8.7",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/@dcl/ecs/dcl-ecs-7.8.8-14999911590.commit-4f0a206.tgz",
         "@dcl/ecs-math": "2.1.0",
         "@dcl/explorer": "1.0.164509-20240802172549.commit-fb95b9b",
-        "@dcl/js-runtime": "7.8.7",
-        "@dcl/react-ecs": "7.8.7",
-        "@dcl/sdk-commands": "7.8.7",
+        "@dcl/inspector": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/@dcl/inspector/dcl-inspector-7.8.8-14999911590.commit-4f0a206.tgz",
+        "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/@dcl/js-runtime/dcl-js-runtime-7.8.8-14999911590.commit-4f0a206.tgz",
+        "@dcl/react-ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/@dcl/react-ecs/dcl-react-ecs-7.8.8-14999911590.commit-4f0a206.tgz",
+        "@dcl/sdk-commands": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/dcl-sdk-commands-7.8.8-14999911590.commit-4f0a206.tgz",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.8.7.tgz",
-      "integrity": "sha512-N3eeCc3SPV1HisWX0gWgLWQzpI/+CdwCuVH1ssR/Lb+HUtr62t0Kf2K5NyejS9j0bjmrlu9W2WDBm1vxjjt83Q==",
+      "version": "7.8.8-14999911590.commit-4f0a206",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/dcl-sdk-commands-7.8.8-14999911590.commit-4f0a206.tgz",
+      "integrity": "sha512-wA3w2YxGvVFjmBXcOmIoT/lPmC7rL6/j5k0dnJIktfL21gtb997U3jtD1rO2B4Gku0l4cOd9NmNjmIrY3Q2u9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.8.7",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/@dcl/ecs/dcl-ecs-7.8.8-14999911590.commit-4f0a206.tgz",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.8.7",
+        "@dcl/inspector": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/@dcl/inspector/dcl-inspector-7.8.8-14999911590.commit-4f0a206.tgz",
         "@dcl/linker-dapp": "^0.14.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-14033082444.commit-84b403d",
@@ -17919,9 +17920,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.1.tgz",
-      "integrity": "sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.2.tgz",
+      "integrity": "sha512-f2ls6rpO6G153Cy+o2XQ+Y0sARLOZ17+OGVLHrc3VUKcLHYKEKWbkSujdBWQXM7gKn5NTfp0XnRPZn1MIu8n9w==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@dcl/mini-rpc": "^1.0.7",
     "@dcl/schemas": "^11.10.4",
-    "@dcl/sdk": "^7.8.7",
+    "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/fix/audio-source-global/dcl-sdk-7.8.8-14999911590.commit-4f0a206.tgz",
     "@ethersproject/hash": "^5.7.0",
     "@segment/analytics-node": "^2.1.2",
     "@sentry/electron": "^6.1.0",


### PR DESCRIPTION
Issue: https://github.com/decentraland/creator-hub/issues/593
Inspector PR: https://github.com/decentraland/js-sdk-toolchain/pull/1119

The global property was not being saved on the audio source component. Now we are saving it but only when you select a valid audio source. If not, it does not keep the selection. This issue was already discussed with Ezio and it will be hanlded in another ticket, as it's something that it's happening in more than one component.


https://github.com/user-attachments/assets/5a991bdd-e287-43e4-b333-33ef3c467a87




