### PR TITLE
feat: call sdk-commands programatically 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "hasInstallScript": true,
       "dependencies": {
-        "@dcl/inspector": "7.8.15",
+        "@dcl/inspector": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/errors/@dcl/inspector/dcl-inspector-7.8.16-15974595107.commit-9c2697d.tgz",
         "@dcl/mini-rpc": "1.0.7",
         "@dcl/schemas": "11.10.4",
         "@ethersproject/hash": "5.7.0",
@@ -604,9 +604,9 @@
       }
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.8.15",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.8.15.tgz",
-      "integrity": "sha512-7Y/jFMoM9EUwq4N/AN686Aw3V+40EiUbGiBzlgUK4dYymc2JEiGVGUFB3osINUv7TiBeopU5rNbI2CRwLkq3rQ==",
+      "version": "7.8.16-15974595107.commit-9c2697d",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/errors/@dcl/inspector/dcl-inspector-7.8.16-15974595107.commit-9c2697d.tgz",
+      "integrity": "sha512-pJGhFXmpveCMg7C3hXDCvPk5lDge3Umq9+r5vm1iN1MQahehCcHzFtEc34zSn/kaDMOHuujTrSjmONnPSLf4bA==",
       "dependencies": {
         "@dcl/asset-packs": "2.5.1",
         "ts-deepmerge": "^7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "hasInstallScript": true,
       "dependencies": {
-        "@dcl/inspector": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/errors/@dcl/inspector/dcl-inspector-7.8.16-15974595107.commit-9c2697d.tgz",
+        "@dcl/inspector": "^7.8.20",
         "@dcl/mini-rpc": "1.0.7",
         "@dcl/schemas": "11.10.4",
         "@ethersproject/hash": "5.7.0",
@@ -604,9 +604,9 @@
       }
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.8.16-15974595107.commit-9c2697d",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/errors/@dcl/inspector/dcl-inspector-7.8.16-15974595107.commit-9c2697d.tgz",
-      "integrity": "sha512-pJGhFXmpveCMg7C3hXDCvPk5lDge3Umq9+r5vm1iN1MQahehCcHzFtEc34zSn/kaDMOHuujTrSjmONnPSLf4bA==",
+      "version": "7.8.20",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.8.20.tgz",
+      "integrity": "sha512-xJB3V6nG4bHSBc/NaziR1ZZePV0uo7YrX5PB7glkL25qIXgTepaPgoAuFL8s625Z1v3ZgIzrT+b4A43GqgbuXA==",
       "dependencies": {
         "@dcl/asset-packs": "2.5.1",
         "ts-deepmerge": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "vitest": "1.6.0"
   },
   "dependencies": {
-    "@dcl/inspector": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/errors/@dcl/inspector/dcl-inspector-7.8.16-15974595107.commit-9c2697d.tgz",
+    "@dcl/inspector": "7.8.20",
     "@dcl/mini-rpc": "1.0.7",
     "@dcl/schemas": "11.10.4",
     "@ethersproject/hash": "5.7.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "vitest": "1.6.0"
   },
   "dependencies": {
-    "@dcl/inspector": "7.8.15",
+    "@dcl/inspector": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/errors/@dcl/inspector/dcl-inspector-7.8.16-15974595107.commit-9c2697d.tgz",
     "@dcl/mini-rpc": "1.0.7",
     "@dcl/schemas": "11.10.4",
     "@ethersproject/hash": "5.7.0",

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -70,7 +70,7 @@ app
 export async function killAll() {
   const promises: Promise<unknown>[] = [killAllPreviews()];
   if (deployServer) {
-    promises.push(deployServer.kill());
+    promises.push(deployServer.stop());
   }
   killInspectorServer();
   await Promise.all(promises);

--- a/packages/main/src/modules/cli.ts
+++ b/packages/main/src/modules/cli.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import fs from 'fs/promises';
+import { pathToFileURL } from 'url';
 import log from 'electron-log/main';
 
 import type { PreviewOptions } from '/shared/types/settings';
@@ -186,9 +187,9 @@ async function getComponents(path: string) {
 
 async function runCommand(path: string, command: string, args: string[]) {
   const components = await getComponents(path);
-  const { runSdkCommand } = await import(
-    join(path, 'node_modules', '@dcl/sdk-commands/dist/run-command.js')
-  );
+  const filePath = join(path, 'node_modules', '@dcl/sdk-commands/dist/run-command.js');
+  const fileUrl = pathToFileURL(filePath).href;
+  const { runSdkCommand } = await import(fileUrl);
   return runSdkCommand(components, command, args);
 }
 

--- a/packages/main/src/modules/cli.ts
+++ b/packages/main/src/modules/cli.ts
@@ -2,9 +2,9 @@ import { join } from 'path';
 import fs from 'fs/promises';
 import log from 'electron-log/main';
 
-import type { DeployOptions } from '/shared/types/ipc';
 import type { PreviewOptions } from '/shared/types/settings';
 import { CLIENT_NOT_INSTALLED_ERROR } from '/shared/utils';
+import type { DeployOptions } from '/shared/types/deploy';
 
 import { dclDeepLink, run, type Child } from './bin';
 import { getAvailablePort } from './port';
@@ -172,7 +172,7 @@ async function shouldRunLegacyDeploy(path: string) {
   const file = await fs.readFile(
     join(path, 'node_modules', '@dcl/sdk-commands/dist/commands/deploy/index.js'),
   );
-  return file.includes('--programmatic');
+  return !file.includes('--programmatic');
 }
 // ############################################################################################
 
@@ -192,7 +192,12 @@ async function runCommand(path: string, command: string, args: string[]) {
   return runSdkCommand(components, command, args);
 }
 
-export async function deploy({ path, target, targetContent }: DeployOptions): Promise<number> {
+export async function deploy({
+  path,
+  target,
+  targetContent,
+  language,
+}: DeployOptions): Promise<number> {
   if (deployServer) {
     await deployServer.stop();
   }
@@ -214,6 +219,7 @@ export async function deploy({ path, target, targetContent }: DeployOptions): Pr
     ...(target ? ['--target', target] : []),
     ...(targetContent ? ['--target-content', targetContent] : []),
     '--programmatic',
+    ...(language ? ['--language', language] : []),
   ]);
 
   deployServer = { stop };

--- a/packages/main/src/modules/handle.ts
+++ b/packages/main/src/modules/handle.ts
@@ -21,14 +21,18 @@ export async function handle<T extends keyof Ipc>(
       };
       return result;
     } catch (error: any) {
-      log.error(`[IPC] channel=${channel} error=${error.message}`);
+      const name = error.name || 'Error';
+      log.error(`[IPC] channel=${channel} name=${name} error=${error.message}`);
       Sentry.captureException(error, {
         tags: { source: 'ipc-handle' },
         extra: { channel },
       });
       const result: IpcError = {
         success: false,
-        error: error.message,
+        error: {
+          message: error.message,
+          name,
+        },
       };
       return result;
     }

--- a/packages/preload/src/modules/editor.ts
+++ b/packages/preload/src/modules/editor.ts
@@ -1,8 +1,7 @@
 import { ipcRenderer, type IpcRendererEvent } from 'electron';
 
-import type { DeployOptions } from '/shared/types/ipc';
+import type { DeployOptions } from '/shared/types/deploy';
 
-import { tryCatchAsValue } from '/shared/try-catch';
 import { invoke } from '../services/ipc';
 import type { PreviewOptions } from '/shared/types/settings';
 
@@ -58,7 +57,8 @@ export async function killPreviewScene(path: string) {
 }
 
 export async function publishScene(opts: DeployOptions) {
-  return tryCatchAsValue(invoke('cli.deploy', opts));
+  const port = await invoke('cli.deploy', opts);
+  return port;
 }
 
 export async function openPreview(port: number) {

--- a/packages/preload/src/modules/editor.ts
+++ b/packages/preload/src/modules/editor.ts
@@ -2,6 +2,7 @@ import { ipcRenderer, type IpcRendererEvent } from 'electron';
 
 import type { DeployOptions } from '/shared/types/ipc';
 
+import { tryCatchAsValue } from '/shared/try-catch';
 import { invoke } from '../services/ipc';
 import type { PreviewOptions } from '/shared/types/settings';
 
@@ -57,8 +58,7 @@ export async function killPreviewScene(path: string) {
 }
 
 export async function publishScene(opts: DeployOptions) {
-  const port = await invoke('cli.deploy', opts);
-  return port;
+  return tryCatchAsValue(invoke('cli.deploy', opts));
 }
 
 export async function openPreview(port: number) {

--- a/packages/preload/src/services/ipc.ts
+++ b/packages/preload/src/services/ipc.ts
@@ -5,13 +5,15 @@ import type { Ipc, IpcError, IpcResult } from '/shared/types/ipc';
 export async function invoke<T extends keyof Ipc>(
   channel: T,
   ...args: Parameters<Ipc[T]>
-): Promise<ReturnType<Ipc[T]>> {
+): Promise<Awaited<ReturnType<Ipc[T]>>> {
   const result = await (ipcRenderer.invoke(channel, ...args) as Promise<
-    IpcResult<ReturnType<Ipc[T]>> | IpcError
+    IpcResult<Awaited<ReturnType<Ipc[T]>>> | IpcError
   >);
   if (result.success) {
     return result.value;
   } else {
-    throw new Error(result.error);
+    const error = new Error(result.error.message);
+    error.name = result.error.name;
+    throw error;
   }
 }

--- a/packages/renderer/src/components/Modals/PublishProject/steps/Deploy/component.tsx
+++ b/packages/renderer/src/components/Modals/PublishProject/steps/Deploy/component.tsx
@@ -62,7 +62,7 @@ export function Deploy(props: Props) {
   const { project } = props;
   const { chainId, wallet, avatar } = useAuth();
   const { updateProjectInfo } = useWorkspace();
-  const { loadingPublish } = useEditor();
+  const { loadingPublish, publishError } = useEditor();
   const { getDeployment, executeDeployment } = useDeploy();
   const { pushCustom } = useSnackbar();
   const [showWarning, setShowWarning] = useState(false);
@@ -162,6 +162,8 @@ export function Deploy(props: Props) {
         ) : null}
         {loadingPublish ? (
           <Loader />
+        ) : publishError ? (
+          <div className="error">{publishError}</div>
         ) : !deployment ? null : (
           <>
             <div className="ethereum">

--- a/packages/renderer/src/components/TemplatesPage/component.tsx
+++ b/packages/renderer/src/components/TemplatesPage/component.tsx
@@ -39,7 +39,7 @@ export function TemplatesPage() {
 
   const handleClickTemplate = useCallback(
     (repo?: string) => async () => {
-      const [data, error] = await getAvailableProject();
+      const [error, data] = await getAvailableProject();
       if (!error) {
         const { name, path } = data;
         const payload = {

--- a/packages/renderer/src/components/TranslationProvider/utils.ts
+++ b/packages/renderer/src/components/TranslationProvider/utils.ts
@@ -1,4 +1,4 @@
-import type { Locale } from '../../modules/store/translation/types';
+import type { Locale } from '/shared/types/translation';
 
 export function getPreferredLocale(availableLocales: Locale[]): Locale | null {
   if (!availableLocales) {

--- a/packages/renderer/src/hooks/useEditor.ts
+++ b/packages/renderer/src/hooks/useEditor.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import type { DeployOptions } from '/shared/types/ipc';
+import type { DeployOptions } from '/shared/types/deploy';
 import type { PreviewOptions } from '/shared/types/settings';
 
 import { actions as editorActions } from '/@/modules/store/editor';

--- a/packages/renderer/src/modules/store/deployment/slice.ts
+++ b/packages/renderer/src/modules/store/deployment/slice.ts
@@ -163,7 +163,6 @@ export const executeDeployment = createAsyncThunk(
           }),
         );
       }
-      console.log('executeDeployment.rejected 3', { path, error });
       throw error;
     }
   },

--- a/packages/renderer/src/modules/store/editor/slice.ts
+++ b/packages/renderer/src/modules/store/editor/slice.ts
@@ -7,6 +7,7 @@ import type { DeployOptions } from '/shared/types/ipc';
 import { type Project } from '/shared/types/projects';
 import type { PreviewOptions } from '/shared/types/settings';
 import { WorkspaceError } from '/shared/types/workspace';
+import type { ErrorAsValue } from '/shared/try-catch';
 
 import { actions as deploymentActions } from '../deployment';
 import { actions as workspaceActions } from '../workspace';
@@ -27,10 +28,20 @@ export const runScene = createAsyncThunk(
   },
 );
 
-export const publishScene = createAsyncThunk(
+export const publishScene = createAsyncThunk<
+  number,
+  DeployOptions & { chainId: ChainId; wallet: string },
+  {
+    rejectValue: ErrorAsValue;
+  }
+>(
   'editor/publishScene',
-  async (opts: DeployOptions & { chainId: ChainId; wallet: string }, { dispatch }) => {
-    const port = await editor.publishScene(opts);
+  async (
+    opts: DeployOptions & { chainId: ChainId; wallet: string },
+    { dispatch, rejectWithValue },
+  ) => {
+    const [error, port] = await editor.publishScene(opts);
+    if (error) return rejectWithValue(error);
     const deployment = { path: opts.path, port, chainId: opts.chainId, wallet: opts.wallet };
     dispatch(deploymentActions.initializeDeployment(deployment));
     return port;
@@ -122,7 +133,7 @@ export const slice = createSlice({
       state.loadingPublish = false;
     });
     builder.addCase(publishScene.rejected, (state, action) => {
-      state.publishError = action.error.message || null;
+      state.publishError = action.payload?.name || null;
       state.loadingPublish = false;
     });
     builder.addCase(workspaceActions.createProject.pending, state => {

--- a/packages/renderer/src/modules/store/translation/slice.ts
+++ b/packages/renderer/src/modules/store/translation/slice.ts
@@ -1,7 +1,9 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
-import type { Locale, TranslationKeys } from './types';
+import type { Locale } from '/shared/types/translation';
+
+import type { TranslationKeys } from './types';
 import * as utils from './utils';
 
 // state

--- a/packages/renderer/src/modules/store/translation/types.ts
+++ b/packages/renderer/src/modules/store/translation/types.ts
@@ -1,4 +1,5 @@
-export type Locale = 'en' | 'es' | 'zh';
+// Import the English translations type for type checking
+import type enTranslations from './locales/en.json';
 
 export interface TranslationKeys {
   [key: string]: string;
@@ -7,9 +8,6 @@ export interface TranslationKeys {
 export interface Translation {
   [locale: string]: TranslationKeys | null;
 }
-
-// Import the English translations type for type checking
-import type enTranslations from './locales/en.json';
 
 type DotNotation<T> = T extends string | number | boolean
   ? never

--- a/packages/renderer/src/modules/store/translation/utils.ts
+++ b/packages/renderer/src/modules/store/translation/utils.ts
@@ -1,7 +1,9 @@
 import { createIntl, createIntlCache, FormattedMessage } from 'react-intl';
 import { flatten } from 'flat';
 
-import type { Locale, Translation, TranslationKeys, TranslationPath } from './types';
+import type { Locale } from '/shared/types/translation';
+
+import type { Translation, TranslationKeys, TranslationPath } from './types';
 import * as languages from './locales';
 
 export const locales = Object.keys(languages) as Locale[];

--- a/packages/shared/try-catch.ts
+++ b/packages/shared/try-catch.ts
@@ -1,8 +1,33 @@
-export async function tryCatch<T, E = Error>(promise: Promise<T>): Promise<[T, null] | [null, E]> {
+export type ErrorAsValue = {
+  name: string;
+  message: string;
+};
+
+/**
+ * A function that wraps a promise in a try-catch block.
+ * @param promise - The promise to be wrapped.
+ * @returns A promise that resolves to an array with the error as the first element and the data as the second element,
+ * or the other way around if the promise resolves successfully.
+ */
+export async function tryCatch<T, E = Error>(promise: Promise<T>): Promise<[null, T] | [E, null]> {
   try {
     const data = await promise;
-    return [data, null];
+    return [null, data];
   } catch (error) {
-    return [null, error as E];
+    return [error as E, null];
   }
+}
+
+/**
+ * A function that wraps a promise in a try-catch block and returns the error as a value.
+ * @param promise - The promise to be wrapped.
+ * @returns A promise that resolves to an array with the error as the first element and the data as the second element,
+ * or the other way around if the promise resolves successfully.
+ */
+export async function tryCatchAsValue<T>(
+  promise: Promise<T>,
+): Promise<[null, T] | [ErrorAsValue, null]> {
+  const [error, data] = await tryCatch(promise);
+  if (error) return [{ name: error.name, message: error.message }, null];
+  return [null, data];
 }

--- a/packages/shared/types/deploy.ts
+++ b/packages/shared/types/deploy.ts
@@ -1,0 +1,8 @@
+import type { Locale } from './translation';
+
+export type DeployOptions = {
+  path: string;
+  target?: string;
+  targetContent?: string;
+  language?: Locale;
+};

--- a/packages/shared/types/ipc.ts
+++ b/packages/shared/types/ipc.ts
@@ -1,10 +1,11 @@
 import type { OpenDialogOptions } from 'electron';
 
 import type { Outdated } from '/shared/types/npm';
-import type { PreviewOptions } from './settings';
 import type { Events } from '/shared/types/analytics';
+import type { DeployOptions } from '/shared/types/deploy';
 
-export type DeployOptions = { path: string; target?: string; targetContent?: string };
+import type { PreviewOptions } from './settings';
+
 export type IpcResult<T> = {
   success: true;
   value: T;

--- a/packages/shared/types/ipc.ts
+++ b/packages/shared/types/ipc.ts
@@ -11,7 +11,10 @@ export type IpcResult<T> = {
 };
 export type IpcError = {
   success: false;
-  error: string;
+  error: {
+    message: string;
+    name: string;
+  };
 };
 
 export interface Ipc {

--- a/packages/shared/types/translation.ts
+++ b/packages/shared/types/translation.ts
@@ -1,0 +1,1 @@
+export type Locale = 'en' | 'es' | 'zh';


### PR DESCRIPTION
requires: https://github.com/decentraland/js-sdk-toolchain/pull/1144

# Enhance Deployment System with Programmatic Mode and Improved Error Handling

## Overview
This PR introduces significant improvements to the deployment system, including programmatic deployment mode, enhanced error handling with structured error information, and better integration between the main process and SDK commands.

## Key Changes

### 🚀 Programmatic Deployment Mode
- **Added programmatic deployment support** that directly integrates with SDK commands instead of spawning child processes
- **Implemented legacy deployment detection** to maintain backward compatibility with older SDK versions
- **Enhanced deployment server management** with proper cleanup and stop functionality
- **Improved deployment flow** with better error propagation and user feedback

## Breaking Changes
None - this is a backward-compatible enhancement that maintains all existing functionality while adding new capabilities.

## New Features
The deployment system now supports direct integration with SDK commands, providing:
- **Better performance**: No need to spawn child processes
- **Enhanced error handling**: Direct access to SDK command errors
- **Improved debugging**: Better error context and stack traces
- **Resource efficiency**: Reduced memory and process overhead

## Testing
- All existing deployment workflows continue to work
- Legacy SDK versions are properly detected and handled
- Error states are properly displayed in the UI
- Process cleanup works correctly in all scenarios
- IPC error handling preserves error context

## Migration Notes
- No action required for users - the system automatically detects and uses the appropriate deployment mode
- Developers can now use programmatic deployment for better integration
- Error handling improvements provide better debugging information