### PR TITLE
fix: Upgrade inspector package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "hasInstallScript": true,
       "dependencies": {
-        "@dcl/inspector": "7.9.0",
+        "@dcl/inspector": "7.9.2",
         "@dcl/mini-rpc": "1.0.7",
         "@dcl/schemas": "11.10.4",
         "@ethersproject/hash": "5.7.0",
@@ -603,9 +603,9 @@
       }
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.9.0.tgz",
-      "integrity": "sha512-HaQ1+gFOk6zDEdfBeH27BkK8aDQFImoe1D6kXUz7qP1Z0xjR8krIfS8EVoYvM1MOpRVU/leoEgrN7Ew84oKeuA==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.9.2.tgz",
+      "integrity": "sha512-pMaVR+GtKxqZO9PGrYwQBdy0Dz0VM/lRMjUyYqgwUlk6EKu78TG9obJKsWePCOO38J7zZ2d49tRyYVCo6zBhJA==",
       "dependencies": {
         "@dcl/asset-packs": "2.5.2",
         "ts-deepmerge": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "vitest": "1.6.0"
   },
   "dependencies": {
-    "@dcl/inspector": "7.9.0",
+    "@dcl/inspector": "7.9.2",
     "@dcl/mini-rpc": "1.0.7",
     "@dcl/schemas": "11.10.4",
     "@ethersproject/hash": "5.7.0",


### PR DESCRIPTION
This PR upgrades the `@sdk/inspector` package to fix a loading model issue.

Depends on: https://github.com/decentraland/js-sdk-toolchain/pull/1173

Test cases:
- [x] Import this GLB model: https://github.com/user-attachments/files/21216079/genesis_tram.glb.zip
- [x] Import any model from the asset-packs library
- [ ] Import any custom item
- [x] Import a custom GLB model if possible