### PR TITLE
fix: unpackaging npm dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
+          node-version: 22
           cache: 'npm'
 
       - name: 'Install dependencies'
@@ -134,6 +135,8 @@ jobs:
           shell: 'bash'
           command: npx electron-builder --config electron-builder.cjs --config.extraMetadata.version=${{ steps.version.outputs.version }} ${{ matrix.os == 'macos-latest' && format('--config.mac.notarize={0}', true) || '' }} --publish ${{ inputs.dry-run && 'never' || 'always' }}
         env:
+          # Disable hard links to avoid issues with npm
+          USE_HARD_LINKS: false
           # Code Signing params
           # See https://www.electron.build/code-signing
           CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}

--- a/electron-builder.cjs
+++ b/electron-builder.cjs
@@ -6,8 +6,20 @@ const config = {
     output: 'dist',
     buildResources: 'buildResources',
   },
-  files: ['packages/**/dist/**', 'node_modules/npm/**/*'],
-  asarUnpack: ['node_modules/npm/**/*', 'node_modules/npm/**/package.json'],
+  files: [
+    'packages/**/dist/**',
+    {
+      from: 'node_modules/npm',
+      to: 'node_modules/npm',
+      filter: ['**/*'],
+    },
+    {
+      from: 'node_modules/npm/node_modules',
+      to: 'node_modules/npm/node_modules',
+      filter: ['**/*'],
+    },
+  ],
+  asarUnpack: ['node_modules/npm/**/*'],
   linux: {
     target: 'deb',
   },


### PR DESCRIPTION
This PR updates the `files` and `asarUnpack` patterns to align with the latest changes in electron-builder.

Recent updates to electron-builder modified how these patterns are interpreted, causing some required dependencies to be excluded from the final build. 

These dependencies are necessary for installing scene-related packages at runtime.