### PR TITLE
fix: Upgrade @dcl/inspector package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "hasInstallScript": true,
       "dependencies": {
-        "@dcl/inspector": "7.9.5",
+        "@dcl/inspector": "7.9.6",
         "@dcl/mini-rpc": "1.0.7",
         "@dcl/schemas": "11.10.4",
         "@ethersproject/hash": "5.7.0",
@@ -479,6 +479,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -542,9 +543,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.5.4.tgz",
-      "integrity": "sha512-iX88UjeclnZsMadaxfUHHDoxDrLnxWUjKttHFJrNNnQv3dT/0EJdRieQ/mEVDTCxXoiB8SkCuKyDVOhAOtiz/g==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.5.6.tgz",
+      "integrity": "sha512-RpCCMdq56GmVZAddZsQZ8qQF1uIYN2dpxR4efzmGwJRqtmUyWqdW2sUyj3vLrCMaV22fSdd4OFMN7vyk0IAFfA==",
       "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.8",
@@ -604,11 +605,11 @@
       }
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.9.5.tgz",
-      "integrity": "sha512-yve28Af+5mcNo+5+uiMbHPWUBLI6jNeveVK0gK6+BrW1i6ts4BgOi5v569AR8X3gKon3hqmB08Ze+Sh6a6np6w==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.9.6.tgz",
+      "integrity": "sha512-5Cw2M1bHsde59j8JxAZOUToNv913E+J0EloMh23sbw204DuauvxWee1Sao6U8nvoAIkcyY4hoHPQaBTdxT0zXA==",
       "dependencies": {
-        "@dcl/asset-packs": "2.5.4",
+        "@dcl/asset-packs": "2.5.6",
         "ts-deepmerge": "^7.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "vitest": "1.6.0"
   },
   "dependencies": {
-    "@dcl/inspector": "7.9.5",
+    "@dcl/inspector": "7.9.6",
     "@dcl/mini-rpc": "1.0.7",
     "@dcl/schemas": "11.10.4",
     "@ethersproject/hash": "5.7.0",


### PR DESCRIPTION
This PR upgrades the package `@dcl/inspector` to version `7.9.6`