### PR TITLE
Fix: canvas resize on delete entity

### DIFF
--- a/packages/inspector/src/lib/sdk/operations/remove-entity.ts
+++ b/packages/inspector/src/lib/sdk/operations/remove-entity.ts
@@ -4,13 +4,34 @@ import { getComponentEntityTree, Transform as TransformEngine } from '@dcl/ecs';
 import { isLastWriteWinComponent } from '../../../hooks/sdk/useComponentValue';
 import type { EditorComponents } from '../components';
 import { EditorComponentNames } from '../components';
-import { removeNode } from '../nodes';
+import { removeNode, getParent } from '../nodes';
 
 export function removeEntity(engine: IEngine) {
   return function removeEntity(entity: Entity) {
     const Transform = engine.getComponent(TransformEngine.componentName) as typeof TransformEngine;
     const Nodes = engine.getComponent(EditorComponentNames.Nodes) as EditorComponents['Nodes'];
+    const Selection = engine.getComponent(
+      EditorComponentNames.Selection,
+    ) as EditorComponents['Selection'];
 
+    // Check if entity being removed or any of its children are currently selected
+    const entityTree = Array.from(getComponentEntityTree(engine, entity, Transform));
+    const wasSelected = entityTree.some(e => Selection.has(e));
+
+    // Get parent and gizmo before removing entity (for potential selection)
+    if (wasSelected) {
+      const nodes = Nodes.getOrNull(engine.RootEntity)?.value || [];
+     const parentToSelect = getParent(entity, nodes);
+      const selectedGizmo =
+        Selection.getOrNull(entity)?.gizmo ||
+        (entityTree.find(e => Selection.has(e)) &&
+          Selection.getOrNull(entityTree.find(e => Selection.has(e))!)?.gizmo) ||
+        0;
+      Selection.createOrReplace(parentToSelect, { gizmo: selectedGizmo });
+
+    }
+
+    // Remove entity and all its children
     for (const entityIterator of getComponentEntityTree(engine, entity, Transform)) {
       Nodes.createOrReplace(engine.RootEntity, { value: removeNode(engine, entityIterator) });
       for (const component of engine.componentsIter()) {

--- a/packages/inspector/src/lib/sdk/operations/remove-entity.ts
+++ b/packages/inspector/src/lib/sdk/operations/remove-entity.ts
@@ -22,11 +22,9 @@ export function removeEntity(engine: IEngine) {
     if (wasSelected) {
       const nodes = Nodes.getOrNull(engine.RootEntity)?.value || [];
       const parentToSelect = getParent(entity, nodes);
-      const selectedGizmo =
-        Selection.getOrNull(entity)?.gizmo ||
-        (entityTree.find(e => Selection.has(e)) &&
-          Selection.getOrNull(entityTree.find(e => Selection.has(e))!)?.gizmo) ||
-        0;
+      // Find the first selected entity in the tree to get its gizmo
+      const firstSelectedEntity = entityTree.find(e => Selection.has(e));
+      const selectedGizmo =  firstSelectedEntity ? Selection.getOrNull(firstSelectedEntity)?.gizmo || 0 : 0;
       Selection.createOrReplace(parentToSelect, { gizmo: selectedGizmo });
     }
 

--- a/packages/inspector/src/lib/sdk/operations/remove-entity.ts
+++ b/packages/inspector/src/lib/sdk/operations/remove-entity.ts
@@ -28,7 +28,6 @@ export function removeEntity(engine: IEngine) {
           Selection.getOrNull(entityTree.find(e => Selection.has(e))!)?.gizmo) ||
         0;
       Selection.createOrReplace(parentToSelect, { gizmo: selectedGizmo });
-
     }
 
     // Remove entity and all its children

--- a/packages/inspector/src/lib/sdk/operations/remove-entity.ts
+++ b/packages/inspector/src/lib/sdk/operations/remove-entity.ts
@@ -21,7 +21,7 @@ export function removeEntity(engine: IEngine) {
     // Get parent and gizmo before removing entity (for potential selection)
     if (wasSelected) {
       const nodes = Nodes.getOrNull(engine.RootEntity)?.value || [];
-     const parentToSelect = getParent(entity, nodes);
+      const parentToSelect = getParent(entity, nodes);
       const selectedGizmo =
         Selection.getOrNull(entity)?.gizmo ||
         (entityTree.find(e => Selection.has(e)) &&

--- a/packages/inspector/src/lib/sdk/operations/remove-entity.ts
+++ b/packages/inspector/src/lib/sdk/operations/remove-entity.ts
@@ -24,7 +24,9 @@ export function removeEntity(engine: IEngine) {
       const parentToSelect = getParent(entity, nodes);
       // Find the first selected entity in the tree to get its gizmo
       const firstSelectedEntity = entityTree.find(e => Selection.has(e));
-      const selectedGizmo =  firstSelectedEntity ? Selection.getOrNull(firstSelectedEntity)?.gizmo || 0 : 0;
+      const selectedGizmo = firstSelectedEntity
+        ? Selection.getOrNull(firstSelectedEntity)?.gizmo || 0
+        : 0;
       Selection.createOrReplace(parentToSelect, { gizmo: selectedGizmo });
     }
 


### PR DESCRIPTION
# Summary 

#### Related Issue [https://github.com/decentraland/creator-hub/issues/704](https://github.com/decentraland/creator-hub/issues/704)

Whenever an item is deleted, this closes the right-side panel with the item properties. The problem is that the canvas changes size and the center of the screen shifts in an abrupt way, this motion is very distracting and doesn't feel good.

This PR solves this issue by selecting the parent element of the removed entity to keep the right-side panel.

## Test Cases

- Remove a selected item on the root
- Remove a selected item that has a parent node
- Remove the parent of a selected item



