### PR TITLE
chore: readme launch locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,14 @@ packages/inspector/test/e2e/       # Inspector E2E tests
 3. **Before Committing:**
     - Lint, format & typecheck will be run automatically
 
+#### Launch Build Locally
+
+To launch build locally on MacOS first run the command:
+
+```
+xattr -c /Applications/Decentraland\ Creator\ Hub.app/
+```
+
 ### Code Quality
 
 - **ESLint** - Code linting with custom rules


### PR DESCRIPTION
Added a note how to avoid the "image damaged" error on MacOS when testing PR builds
<img width="405" height="480" alt="image" src="https://github.com/user-attachments/assets/67e74789-8bfe-4394-ba0e-ac6343587175" />
