### PR TITLE
Add empty value handling to FileUploadField

### DIFF
--- a/packages/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
+++ b/packages/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
@@ -140,11 +140,13 @@ const FileUploadField: React.FC<Props> = ({
   const handleChangeTextField = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
-      if (value && (isValidFileName(value) || (acceptURLs && isValidHttpsUrl(value)))) {
-        setPath(addBase(value));
+      if (!value || (isValidFileName(value) || (acceptURLs && isValidHttpsUrl(value)))) {
+        // The value is a valid file name or a valid https url or it's empty (valid as the field is optional).
+        setPath(value ? addBase(value) : '');
         onChange && onChange(event);
         setDropError(false);
-      } else {
+      } else if (value) {
+        // There's a value but it's not a valid file name nor a valid https url.
         setDropError(true);
         setErrorMessage(
           acceptURLs && !isValidHttpsUrl(value)


### PR DESCRIPTION
# Summary

If an entity's Material has a Texture field, the user can't delete it, they can only change it to another texture. If they delete it, it says the file is invalid, and it won't consider the modification. Maybe they want to make it a plain color and don't need a texture.

Solved this issue by modifying the FileUploadField to accept empty values without throwing errors.

### Test cases

- Add a texture and then clear the input field -> No error and the texture should be removed from the entity in the render.
- ⚠️ ⚠️  All other file inputs should be working as before (Scene Thumbnail, GLTF, Audio, Image Action, Play Sound, Play Custom Emote)