### PR TITLE
fix: Handle quotes in release notes and remove bash arrays

### DIFF
--- a/.github/actions/update-release-description/action.yml
+++ b/.github/actions/update-release-description/action.yml
@@ -56,7 +56,9 @@ runs:
           RELEASE_URL=$(echo "$RELEASE_INFO" | jq -r '.url')
 
           # Create temporary file for release notes
-          cat << 'EOF' > temp_release_notes.md
+          # IMPORTANT: The 'EOF' delimiters below must start at column 0 (no spaces or tabs).
+          # Otherwise, the heredoc will break and the release notes won't be written correctly.
+cat << 'EOF' > temp_release_notes.md
 ${{ inputs.release_notes }}
 EOF
 
@@ -78,7 +80,9 @@ EOF
           echo "🆕 Release not found. Creating new release..."
 
           # Create temporary file for release notes
-          cat << 'EOF' > temp_release_notes.md
+          # IMPORTANT: The 'EOF' delimiters below must start at column 0 (no spaces or tabs).
+          # Otherwise, the heredoc will break and the release notes won't be written correctly.
+cat << 'EOF' > temp_release_notes.md
 ${{ inputs.release_notes }}
 EOF
 


### PR DESCRIPTION
This PR fixes quoting issues in the composite GitHub Action that updates release descriptions.
Previously, `echo '${{ inputs.release_notes }}' > file` would break if the release notes contained quotes (`'` or `"`), backticks, or other special characters.

Changes:
- Replaced echo with a quoted **heredoc** (`cat << 'EOF' ... EOF`) to safely write release notes to a file without shell interpretation.
- Removed Bash arrays from the `gh release create` step. Arrays can fail when a POSIX mode is inherited from another action, since POSIX shells don’t support Bash arrays. Using plain command flags makes the action more portable and robust.

Why:
- Ensure release notes with any characters are written safely.
- Prevent errors like `syntax error near unexpected token '('` caused by Bash arrays under POSIX mode.
- Increase portability and maintainability of the action across different runners/environments.