### PR TITLE
Chore: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+# PR Title
+
+## Context and Problem Statement
+
+[Describe the issue or background that led to this change. What problem are we solving?]
+
+## Solution
+
+[Explain the solution implemented, focusing on the approach and key technical decisions]
+
+Key changes:
+- [Bullet points highlighting the main changes]
+- [Focus on what changed, not how it changed]
+- [Include architectural decisions if relevant]
+
+## Testing
+
+- [ ] [Specific test case 1]
+- [ ] [Specific test case 2]
+- [ ] [Edge cases tested]
+- [ ] [Regression testing performed]
+
+## Impact
+
+[Describe the user-facing impact and any potential side effects or considerations]
+
+## Screenshots
+
+[Include before and after screenshots or videos if it's a UI feature/fix]


### PR DESCRIPTION
# PR Title

## Context and Problem Statement

It's bothersome to write your PR description from scratch every time and we don't have an standard.

## Solution

Added a cool PR template to the repo 🚀 

## Testing

- [ ] Create a pull request and get the description template by default
