### PR TITLE
Fix: Cant create new scenes

### DIFF
--- a/packages/creator-hub/main/src/modules/config.ts
+++ b/packages/creator-hub/main/src/modules/config.ts
@@ -13,6 +13,12 @@ export const CONFIG_PATH = path.join(getUserDataPath(), SETTINGS_DIRECTORY, CONF
 
 let configStorage: IFileSystemStorage<Config> | undefined;
 
+export function getDefaultConfig(): Config {
+  const defaultConfig = deepmerge({}, DEFAULT_CONFIG);
+  defaultConfig.settings.scenesPath = getFullScenesPath(getUserDataPath());
+  return defaultConfig;
+}
+
 export async function getConfigStorage(): Promise<IFileSystemStorage<Config>> {
   await waitForMigrations();
 
@@ -20,10 +26,7 @@ export async function getConfigStorage(): Promise<IFileSystemStorage<Config>> {
     configStorage = await FileSystemStorage.getOrCreate(CONFIG_PATH);
 
     // Initialize with default values if empty or merge with defaults if partial
-    const defaultConfig = deepmerge({}, DEFAULT_CONFIG);
-
-    defaultConfig.settings.scenesPath = getFullScenesPath(getUserDataPath());
-
+    const defaultConfig = getDefaultConfig();
     const existingConfig = await configStorage.getAll();
 
     // Deep merge with defaults if config exists but might be missing properties

--- a/packages/creator-hub/main/src/modules/migrations.ts
+++ b/packages/creator-hub/main/src/modules/migrations.ts
@@ -3,19 +3,13 @@ import fs from 'fs/promises';
 import * as Sentry from '@sentry/electron/main';
 import log from 'electron-log/main';
 import { future } from 'fp-future';
-import deepmerge from 'deepmerge';
 
 import { SCENES_DIRECTORY } from '/shared/paths';
 import { FileSystemStorage, type IFileSystemStorage } from '/shared/types/storage';
-import {
-  type Config,
-  CURRENT_CONFIG_VERSION,
-  DEFAULT_CONFIG,
-  mergeConfig,
-} from '/shared/types/config';
+import { type Config, CURRENT_CONFIG_VERSION, mergeConfig } from '/shared/types/config';
 
 import { getAppHomeLegacy, getUserDataPath } from './electron';
-import { CONFIG_PATH } from './config';
+import { CONFIG_PATH, getDefaultConfig } from './config';
 
 const migrationsFuture = future<void>();
 
@@ -236,7 +230,7 @@ async function migrateLegacyPaths(configStorage: IFileSystemStorage<Config>) {
     }
 
     log.info('[Migration] Writing updated config.json to:', CONFIG_PATH);
-    const defaultConfig = deepmerge({}, DEFAULT_CONFIG);
+    const defaultConfig = getDefaultConfig();
     await configStorage.setAll(mergeConfig(config as Partial<Config>, defaultConfig));
     log.info('[Migration] Successfully migrated config.json');
 

--- a/packages/creator-hub/preload/src/modules/settings.ts
+++ b/packages/creator-hub/preload/src/modules/settings.ts
@@ -17,7 +17,7 @@ export async function getDefaultScenesPath() {
 
 export async function getScenesPath() {
   const config = await getConfig();
-  return config.settings?.scenesPath ?? (await getDefaultScenesPath());
+  return config.settings?.scenesPath || (await getDefaultScenesPath());
 }
 
 export function isValidUpdateStrategy(value?: string): value is DEPENDENCY_UPDATE_STRATEGY {

--- a/packages/creator-hub/preload/src/modules/workspace.ts
+++ b/packages/creator-hub/preload/src/modules/workspace.ts
@@ -226,7 +226,7 @@ export function initializeWorkspace(services: Services) {
         // TODO: implement migrations for config file...
         dependencyUpdateStrategy:
           cfg.settings?.dependencyUpdateStrategy ?? DEFAULT_DEPENDENCY_UPDATE_STRATEGY,
-        scenesPath: cfg.settings?.scenesPath ?? (await getDefaultScenesPath()),
+        scenesPath: cfg.settings?.scenesPath || (await getDefaultScenesPath()),
       },
     };
   }

--- a/packages/creator-hub/preload/src/modules/workspace.ts
+++ b/packages/creator-hub/preload/src/modules/workspace.ts
@@ -51,6 +51,15 @@ export function initializeWorkspace(services: Services) {
     }
   }
 
+  async function isDirectory(_path: string) {
+    try {
+      const result = await fs.isDirectory(_path);
+      return result;
+    } catch (_) {
+      return false;
+    }
+  }
+
   /**
    * Return whether or not the provided directory has a node_modules directory
    */
@@ -464,6 +473,7 @@ export function initializeWorkspace(services: Services) {
   return {
     isDCL,
     isEmpty,
+    isDirectory,
     hasNodeModules,
     getProjectThumbnailAsBase64,
     getOutdatedPackages,

--- a/packages/creator-hub/renderer/src/components/Modals/AppSettings/styles.css
+++ b/packages/creator-hub/renderer/src/components/Modals/AppSettings/styles.css
@@ -20,6 +20,10 @@
   gap: 16px;
 }
 
+.AppSettingsModal .error {
+  color: var(--error);
+}
+
 .AppSettingsModal .MuiInputBase-root .MuiOutlinedInput-notchedOutline {
   /* TODO: Fix styles in the ui2 library */
   border-color: #ffffff3b;

--- a/packages/creator-hub/renderer/src/components/TemplatesPage/component.tsx
+++ b/packages/creator-hub/renderer/src/components/TemplatesPage/component.tsx
@@ -2,11 +2,10 @@ import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MenuItem, type SelectChangeEvent, Chip, Typography } from 'decentraland-ui2';
 
-import { misc } from '#preload';
-
 import type { Template } from '/shared/types/workspace';
 
 import { useWorkspace } from '/@/hooks/useWorkspace';
+import { useSnackbar } from '/@/hooks/useSnackbar';
 import { ProjectCard } from '/@/components/ProjectCard';
 import { t } from '/@/modules/store/translation/utils';
 
@@ -23,11 +22,14 @@ import { CreateProject } from '../Modals/CreateProject';
 import { SortBy, Difficulty, type ModalType, type CreateProjectValue } from './types';
 import { sortTemplatesBy } from './utils';
 
+import { misc } from '#preload';
+
 import './styles.css';
 
 export function TemplatesPage() {
   const navigate = useNavigate();
   const { createProject, templates: _templates, getAvailableProject } = useWorkspace();
+  const { pushGeneric } = useSnackbar();
   const [openModal, setOpenModal] = useState<ModalType | undefined>();
   const [templates, setTemplates] = useState(_templates);
   const [sortBy, setSortBy] = useState(SortBy.DEFAULT);
@@ -48,9 +50,20 @@ export function TemplatesPage() {
           repo,
         };
         setOpenModal({ type: 'create-project', payload });
+      } else {
+        // Check if error is related to invalid/missing scenes path to show instructions to solve it.
+        const errorMessage = error?.message || error?.toString() || '';
+        const isPathError = errorMessage.includes('mkdir');
+
+        pushGeneric(
+          'error',
+          isPathError
+            ? t('templates.new_scene.errors.invalid_scenes_path')
+            : t('templates.new_scene.errors.create_scene_failed'),
+        );
       }
     },
-    [],
+    [getAvailableProject, pushGeneric],
   );
 
   const handleCreateProject = useCallback(

--- a/packages/creator-hub/renderer/src/hooks/useWorkspace.ts
+++ b/packages/creator-hub/renderer/src/hooks/useWorkspace.ts
@@ -71,6 +71,11 @@ export const useWorkspace = () => {
     return dispatch(workspaceActions.updateSceneJson({ path, updates }));
   }, []);
 
+  const validateScenesPath = useCallback(async (path: string) => {
+    const isDir = await workspacePreload.isDirectory(path);
+    return isDir;
+  }, []);
+
   const validateProjectPath = useCallback(async (path: string) => {
     const valid = await workspacePreload.isProjectPathAvailable(path);
     return valid;
@@ -107,6 +112,7 @@ export const useWorkspace = () => {
     updatePackages,
     updateProject,
     updateSceneJson,
+    validateScenesPath,
     validateProjectPath,
     selectNewProjectPath,
     getAvailableProject,

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
@@ -409,7 +409,11 @@
     },
     "new_scene": {
       "title": "Empty Scene",
-      "description": "Start your own scene from scratch"
+      "description": "Start your own scene from scratch",
+      "errors": {
+        "invalid_scenes_path": "Invalid Scenes Folder. Please configure a valid Scenes Folder in Settings before creating a scene.",
+        "create_scene_failed": "An error occurred while trying to create the scene. Please try again."
+      }
     },
     "filters": {
       "title": "Filter by",

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
@@ -239,7 +239,10 @@
       "fields": {
         "scenes_folder": {
           "label": "Scenes Folder",
-          "change_button": "Change Folder"
+          "change_button": "Change Folder",
+          "errors": {
+            "invalid_path": "Invalid Scenes Folder. Please select a valid folder."
+          }
         },
         "scene_editor_dependencies": {
           "label": "Scene Editor Dependencies",

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/es.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/es.json
@@ -239,7 +239,10 @@
       "fields": {
         "scenes_folder": {
           "label": "Carpeta de escenas",
-          "change_button": "Cambiar carpeta"
+          "change_button": "Cambiar carpeta",
+          "errors": {
+            "invalid_path": "Carpeta inválida. Por favor selecciona una carpeta válida."
+          }
         },
         "scene_editor_dependencies": {
           "label": "Dependencias del editor de escenas",

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/es.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/es.json
@@ -409,7 +409,11 @@
     },
     "new_scene": {
       "title": "Escena Vacía",
-      "description": "Comienza tu propia escena desde cero"
+      "description": "Comienza tu propia escena desde cero",
+      "errors": {
+        "invalid_scenes_path": "Carpeta de escenas inválida. Por favor, ingresa una carpeta de escenas válida en la configuración de la aplicación antes de crear una escena.",
+        "create_scene_failed": "Ocurrió un error al crear la escena. Por favor, inténtalo nuevamente."
+      }
     },
     "filters": {
       "title": "Filtrar por",

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/zh.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/zh.json
@@ -236,7 +236,10 @@
       "fields": {
         "scenes_folder": {
           "label": "場景資料夾",
-          "change_button": "更改資料夾"
+          "change_button": "更改資料夾",
+          "errors": {
+            "invalid_path": "無效的場景資料夾。請選擇有效的資料夾。"
+          }
         },
         "scene_editor_dependencies": {
           "label": "場景編輯器依賴項",

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/zh.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/zh.json
@@ -406,7 +406,11 @@
     },
     "new_scene": {
       "title": "空景",
-      "description": "从头开始创建自己的场景"
+      "description": "从头开始创建自己的场景",
+      "errors": {
+        "invalid_scenes_path": "无效的场景文件夹。请在创建场景之前在设置中配置有效的场景文件夹。",
+        "create_scene_failed": "尝试创建场景时发生错误。请重试。"
+      }
     },
     "filters": {
       "title": "过滤依据",

--- a/packages/creator-hub/shared/types/config.ts
+++ b/packages/creator-hub/shared/types/config.ts
@@ -1,5 +1,4 @@
 import deepmerge from 'deepmerge';
-import { SCENES_DIRECTORY } from '/shared/paths';
 import { type AppSettings } from './settings';
 import { DEFAULT_DEPENDENCY_UPDATE_STRATEGY } from './settings';
 
@@ -28,7 +27,7 @@ export const DEFAULT_CONFIG: Config = {
     paths: [],
   },
   settings: {
-    scenesPath: SCENES_DIRECTORY, // Base directory name, will be joined with userDataPath by main/preload
+    scenesPath: '', // Will be set with userDataPath + SCENES_DIRECTORY by main/preload
     dependencyUpdateStrategy: DEFAULT_DEPENDENCY_UPDATE_STRATEGY,
     previewOptions: {
       debugger: false,
@@ -42,6 +41,12 @@ export const DEFAULT_CONFIG: Config = {
 
 export function mergeConfig(target: Partial<Config>, source: Config): Config {
   return deepmerge(source, target, {
+    customMerge: key => {
+      if (key === 'scenesPath') {
+        // Avoid overwriting scenesPath with empty string, use default (sourcePath) instead.
+        return (targetPath: string, sourcePath: string) => targetPath || sourcePath;
+      }
+    },
     // Clone arrays instead of merging them
     arrayMerge: (_, sourceArray) => sourceArray,
   });


### PR DESCRIPTION
# Fix: Can't create new scenes

## Context and Problem Statement

Unknower reported in Discord that he had this experience: "creator hub is completely unusable for me. Clicking on the scene templates does nothing. Have uninstalled and reinstalled countless times."

This behaviour also showed up during testing stage with QA team. The reason behind the issue is that the config.json file we use on the CH get's the scenesPath key value overwritten with just "Scenes" or empty string, which are not valid paths, so when trying to create a new scene, the app tries to create it under a path which doesn’t exist, so it fails. But even though there's a known reason for the issue, the app is not showing any visual feedback to the user about the problem.

## Solution

The solution is both on the UX and on the paths handling:

1. Fixed the root cause of the path being overwritten with just "Scenes" or empty string when reinstalling or updating the app.
2. Added visual feedback for users when the scene creation fails. 
3. Added error message on path input when entering a non-existent directory path.

## Testing

- [x] 

## Screenshots

[Include before and after screenshots or videos if it's a UI feature/fix]
