### PR TITLE
fix: release description action

### DIFF
--- a/.github/actions/update-release-description/action.yml
+++ b/.github/actions/update-release-description/action.yml
@@ -56,11 +56,7 @@ runs:
           RELEASE_URL=$(echo "$RELEASE_INFO" | jq -r '.url')
 
           # Create temporary file for release notes
-          # IMPORTANT: The 'EOF' delimiters below must start at column 0 (no spaces or tabs).
-          # Otherwise, the heredoc will break and the release notes won't be written correctly.
-          cat << 'EOF' > temp_release_notes.md
-${{ inputs.release_notes }}
-EOF
+          printf '%s' "$RELEASE_NOTES" > temp_release_notes.md
 
           # Update the release description
           gh release edit "${{ inputs.tag_name }}" --notes-file temp_release_notes.md
@@ -80,11 +76,7 @@ EOF
           echo "🆕 Release not found. Creating new release..."
 
           # Create temporary file for release notes
-          # IMPORTANT: The 'EOF' delimiters below must start at column 0 (no spaces or tabs).
-          # Otherwise, the heredoc will break and the release notes won't be written correctly.
-          cat << 'EOF' > temp_release_notes.md
-${{ inputs.release_notes }}
-EOF
+          printf '%s' "$RELEASE_NOTES" > temp_release_notes.md
 
           # Determine release title
           if [[ -n "${{ inputs.release_title }}" ]]; then
@@ -137,3 +129,4 @@ EOF
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        RELEASE_NOTES: ${{ inputs.release_notes }}

--- a/packages/inspector/README.md
+++ b/packages/inspector/README.md
@@ -198,5 +198,3 @@ For a deeper understanding of the architecture and design decisions:
 ## License
 
 Apache 2.0
-
-test


### PR DESCRIPTION
Fixed YAML parsing error in the `update-release-description` action by passing release notes through an environment
variable instead of using heredoc syntax.

## Problem
The action was failing with a YAML parsing error:
Error: (Line: 63, Col: 1, Idx: 2185) - While scanning a simple key, could not find expected ':''.

The heredoc delimiter `EOF` at column 0 was confusing the YAML parser, which interpreted it as a YAML key without a
value. Additionally, using `echo` or direct variable assignment broke when release notes contained apostrophes in
commit messages.

## Solution
- Pass `release_notes` input as an environment variable (`RELEASE_NOTES`)
- Use `printf '%s' "$RELEASE_NOTES"` to write the content to a temporary file
- This approach safely handles all special characters (quotes, apostrophes, newlines) without YAML parsing issues