### PR TITLE
Fix: cannot drag duplicates

### DIFF
--- a/packages/inspector/src/lib/babylon/decentraland/gizmos/FreeGizmo.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/gizmos/FreeGizmo.ts
@@ -288,7 +288,9 @@ export class FreeGizmo implements IGizmoTransformer {
   }
 
   private initializePivotPosition(): void {
-    this.pivotPosition = this.getCentroid();
+    // Use cursor position at drag start as pivot to avoid entities jumping to center
+    const pickInfo = this.scene.pick(this.scene.pointerX, this.scene.pointerY);
+    this.pivotPosition = pickInfo?.pickedPoint ? pickInfo.pickedPoint.clone() : this.getCentroid();
     this.lastSnappedPivotPosition = this.pivotPosition.clone();
   }
 

--- a/packages/inspector/src/lib/babylon/decentraland/gizmos/FreeGizmo.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/gizmos/FreeGizmo.ts
@@ -160,7 +160,6 @@ export class FreeGizmo implements IGizmoTransformer {
     this.scene.onPointerMove = () => {
       if (!this.isDragging) return;
 
-      console.log('FreeGizmo: handling pointer move during drag');
       const delta = this.calculateDragDelta();
       if (!delta) return;
 


### PR DESCRIPTION
# Fix: cannot drag duplicates

## Context and Problem Statement

#### Related issue: [https://github.com/decentraland/creator-hub/issues/700](https://github.com/decentraland/creator-hub/issues/700)

After I duplicate an item, the first thing I always want to do is move it to a new position so that it doesn't overlap with the original. However, I can't do this with the free movement tool.

After the paste, I have the new item selected, but I can't click to drag it.
I assume this is because my clicks are interpreted as going to the original copy. So I can click and drag all I want on the item and nothing happens. To move the item I have to select some third item in the scene and then click back. And when I do that, I end up selecting and moving the original and not the copy.

The technical reason: Babylon engine _interprets_ that the original item is overlapping in front of the duplicated item, so the cursor never _touches_ the selected duplicated entity when trying to drag it, then it does not trigger the dragging logic as the component is _untouched_.

## Solution

The solution consisted on reimplementing the drag logic to manually calculate the dragged distance when dragging an overlapping item.

## Testing

- Drag an item -> It drags as expected
- Duplicate an item and drag it -> Duplicate drags as expected
- Duplicate an item, **click on it** and drag it -> Original item is selected and dragged
- Select multiple items and drag them -> They drag as expected
- Select multiple items, duplicate them and drag -> Only one of the duplicated items should be selected and dragged
- Move the camera starting the drag on a selected item -> The camera moves and the item should not be dragged

## Screenshots


https://github.com/user-attachments/assets/f068a333-d161-4ad8-a41e-0f2a4d105add

