### PR TITLE
WIP - Fix: needs to click button twice to create project

### DIFF
--- a/packages/creator-hub/renderer/src/components/Modals/CreateProject/component.tsx
+++ b/packages/creator-hub/renderer/src/components/Modals/CreateProject/component.tsx
@@ -52,7 +52,7 @@ export function CreateProject({ open, initialValue, onClose, onSubmit }: Props) 
   }, [value]);
 
   const handleSubmit = useCallback(async () => {
-    const valid = await validate();
+    const valid = await validateProjectPath(value.path, value.name);
     if (valid) onSubmit(value);
   }, [onSubmit, value, validate, error]);
 


### PR DESCRIPTION
# Fix: needs to click button twice to create project

## Context and Problem Statement

Problem: to create a project, you need to click the "Create" button twice.

