### PR TITLE
fix: correct thumbnail sound icon for imported sounds

### DIFF
--- a/packages/inspector/src/components/AssetPreview/AssetPreview.css
+++ b/packages/inspector/src/components/AssetPreview/AssetPreview.css
@@ -1,13 +1,22 @@
-.AssetPreview {
+.assetPreview {
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.AssetPreview canvas {
+.assetPreview canvas {
   width: 100%;
 }
 
-.AssetPreview .GltfPreview.hidden {
+.assetPreview .GltfPreview.hidden {
   visibility: hidden;
+}
+
+.assetPreview .loading {
+  margin-bottom: 12px;
+  width: 150px;
+  height: 150px;
+  background-color: var(--background-gray);
+  background-size: cover;
+  background-position: center;
 }

--- a/packages/inspector/src/components/AssetPreview/AssetPreview.tsx
+++ b/packages/inspector/src/components/AssetPreview/AssetPreview.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState, useRef } from 'react';
-import { AiFillSound } from 'react-icons/ai';
+import { AiOutlineSound } from 'react-icons/ai';
 import { IoVideocamOutline } from 'react-icons/io5';
 import { FaFile } from 'react-icons/fa';
 import cx from 'classnames';
@@ -8,6 +8,7 @@ import { WearablePreview } from 'decentraland-ui';
 
 import { toEmoteWithBlobs, toWearableWithBlobs } from './utils';
 import { type Props } from './types';
+import { Loading } from '../Loading';
 
 import './AssetPreview.css';
 
@@ -42,15 +43,15 @@ export function AssetPreview({ value, resources, onScreenshot, onLoad, isEmote }
       case 'mp3':
       case 'wav':
       case 'ogg':
-        return <AiFillSound />;
+        return <AiOutlineSound size="large" />;
       case 'mp4':
-        return <IoVideocamOutline />;
+        return <IoVideocamOutline size="large" />;
       default:
-        return <FaFile />;
+        return <FaFile size="large" />;
     }
   }, []);
 
-  return <div className="AssetPreview">{preview}</div>;
+  return <div className="assetPreview">{preview}</div>;
 }
 
 function GltfPreview({ value, resources, onScreenshot, onLoad, isEmote }: Props) {
@@ -92,6 +93,7 @@ function GltfPreview({ value, resources, onScreenshot, onLoad, isEmote }: Props)
 
   return (
     <>
+      <div>{loading && <Loading dimmer={false} />}</div>
       <div className={cx('GltfPreview', { hidden: loading })}>
         <WearablePreview
           id={value.name}
@@ -111,6 +113,7 @@ function GltfPreview({ value, resources, onScreenshot, onLoad, isEmote }: Props)
 }
 
 function PngPreview({ value, onScreenshot, onLoad }: Props) {
+  const [loading, setLoading] = useState(true);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   const url = URL.createObjectURL(value);
@@ -145,16 +148,21 @@ function PngPreview({ value, onScreenshot, onLoad }: Props) {
       ctx.drawImage(img, 0, 0, WIDTH, HEIGHT);
 
       onScreenshot(canvas.toDataURL('image/png'));
+      setLoading(false);
 
       canvas2.remove();
     }
   };
 
   return (
-    <canvas
-      ref={canvasRef}
-      id="asset-png-preview"
-      touch-action="none"
-    ></canvas>
+    <>
+      <div>{loading && <Loading dimmer={false} />}</div>
+      <canvas
+        ref={canvasRef}
+        id="asset-png-preview"
+        touch-action="none"
+        style={{ display: loading ? 'none' : 'block' }}
+      ></canvas>
+    </>
   );
 }

--- a/packages/inspector/src/components/ImportAsset/Slider/AssetSlides.tsx
+++ b/packages/inspector/src/components/ImportAsset/Slider/AssetSlides.tsx
@@ -4,16 +4,14 @@ import cx from 'classnames';
 
 import { AssetPreview } from '../../AssetPreview';
 import { Input } from '../../Input';
-import { Loading } from '../../Loading';
 
 import { getAssetSize, getAssetResources } from '../utils';
 import { Asset } from '../types';
-import { AssetWithEmote, Thumbnails } from './types';
+import { AssetWithEmote } from './types';
 
 interface AssetSlidesProps {
   uploadedAssets: AssetWithEmote[];
   currentSlide: number;
-  screenshots: Thumbnails;
   onSlideChange: (newSlide: number) => void;
   onScreenshot: (file: Asset) => (thumbnail: string) => void;
   onNameChange: (fileIdx: number) => (newName: string) => void;
@@ -23,7 +21,6 @@ interface AssetSlidesProps {
 export function AssetSlides({
   uploadedAssets,
   currentSlide,
-  screenshots,
   onSlideChange,
   onScreenshot,
   onNameChange,
@@ -64,14 +61,6 @@ export function AssetSlides({
                 onScreenshot={onScreenshot($)}
                 isEmote={$.isEmote}
               />
-              {screenshots[$.blob.name] ? (
-                <div
-                  className="thumbnail"
-                  style={{ backgroundImage: `url(${screenshots[$.blob.name]})` }}
-                ></div>
-              ) : (
-                <Loading dimmer={false} />
-              )}
               <Input
                 value={$.name}
                 onChange={onNameChange(i)}

--- a/packages/inspector/src/components/ImportAsset/Slider/Slider.css
+++ b/packages/inspector/src/components/ImportAsset/Slider/Slider.css
@@ -50,16 +50,6 @@
   display: none;
 }
 
-.Slider .asset .thumbnail,
-.Slider .asset .loading {
-  margin-bottom: 12px;
-  width: 150px;
-  height: 150px;
-  background-color: var(--background-gray);
-  background-size: cover;
-  background-position: center;
-}
-
 .Slider .asset .name-error {
   font-size: 12px;
   color: var(--yellow);

--- a/packages/inspector/src/components/ImportAsset/Slider/Slider.tsx
+++ b/packages/inspector/src/components/ImportAsset/Slider/Slider.tsx
@@ -123,7 +123,6 @@ export function Slider({ assets, onSubmit, isNameValid }: PropTypes) {
           <AssetSlides
             uploadedAssets={uploadedAssets}
             currentSlide={slide}
-            screenshots={screenshots}
             onSlideChange={setSlide}
             onScreenshot={handleScreenshot}
             onNameChange={handleNameChange}


### PR DESCRIPTION
# Correct thumbnail sound icon for imported sounds

## Context and Problem Statement
When user loads a sound file (eg .mp3) the ui shows a spinner and never disappear, creating a bad UX

## Solution
Refactored AssetPreview component to manage loading state for png and glb extensions, and let the rest of the files to shows an icon accordingly their extension

## Screenshots
<img width="513" height="369" alt="image" src="https://github.com/user-attachments/assets/5201d214-0215-4fd0-89df-abb8aff7f89c" />

solves: #441 
