### PR TITLE
fix: animation weight support decimals between 0 and 1

### DIFF
--- a/packages/inspector/src/components/EntityInspector/AnimatorInspector/AnimatorInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/AnimatorInspector/AnimatorInspector.tsx
@@ -49,8 +49,6 @@ export default withSdk<Props>(({ sdk, entity: entityId, initialOpen = true }) =>
         // only add Animator component if there are actual animations
         if (animationGroups.length > 0) {
           await initializeAnimatorComponent(sdk, entityId, animationGroups);
-          const newStates = mapAnimationGroupsToStates(animationGroups);
-          setStates(newStates);
         }
       } catch (error) {
         // eslint-disable-next-line no-console
@@ -150,10 +148,13 @@ export default withSdk<Props>(({ sdk, entity: entityId, initialOpen = true }) =>
           <Block label="Weight">
             <RangeField
               onChange={(e: ChangeEvt) =>
-                handleStateChange({ weight: toNumber(e.target.value) }, idx)
+                handleStateChange({ weight: Number(e.target.value) }, idx)
               }
-              value={fromNumber($.weight ?? 1)}
+              value={$.weight ?? 1}
               isValidValue={isValidWeight}
+              step={0.01}
+              min={0}
+              max={1}
             />
           </Block>
           <Block label="Speed">

--- a/packages/inspector/src/components/EntityInspector/AnimatorInspector/utils.spec.ts
+++ b/packages/inspector/src/components/EntityInspector/AnimatorInspector/utils.spec.ts
@@ -40,11 +40,16 @@ describe('NumberUtils', () => {
 
   describe('isValidWeight', () => {
     it('returns true for a valid weight', () => {
-      const result = isValidWeight('50');
+      const result = isValidWeight('0.50');
       expect(result).toBe(true);
     });
 
-    it('returns false for an invalid weight', () => {
+    it('returns false for a invalid weight, number', () => {
+      const result = isValidWeight('50');
+      expect(result).toBe(false);
+    });
+
+    it('returns false for an invalid weight, string', () => {
       const result = isValidWeight('invalid');
       expect(result).toBe(false);
     });

--- a/packages/inspector/src/components/EntityInspector/AnimatorInspector/utils.ts
+++ b/packages/inspector/src/components/EntityInspector/AnimatorInspector/utils.ts
@@ -14,7 +14,7 @@ export function toNumber(value: string | number, div: number = 100) {
 
 export function isValidWeight(weight: string | undefined): boolean {
   const value = (weight ?? '').toString();
-  return !isNaN(parseFloat(value)) && parseFloat(value) >= 0 && parseFloat(value) <= 100;
+  return !isNaN(parseFloat(value)) && parseFloat(value) >= 0 && parseFloat(value) <= 1;
 }
 
 export function isValidSpeed(speed: string | undefined): boolean {

--- a/packages/inspector/src/components/ui/RangeField/RangeField.tsx
+++ b/packages/inspector/src/components/ui/RangeField/RangeField.tsx
@@ -70,6 +70,9 @@ const RangeField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
 
   const formatInput = useCallback(
     (value: Props['value'] = 0) => {
+      if (Number.isInteger(Number(value))) {
+        return Number(value.toString());
+      }
       const decimals = isFloat(step) ? 2 : 0;
       return parseFloat(value.toString()).toFixed(decimals);
     },
@@ -80,11 +83,11 @@ const RangeField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
 
-      setInputValue(value);
-
       const isValidValue = isValid(value);
 
       const formattedValue = isValidValue ? formatInput(value) : value;
+
+      setInputValue(formattedValue);
 
       onChange &&
         onChange({


### PR DESCRIPTION
# Animation weight support decimals between 0 and 1

## Context and Problem Statement
In the Creator Hub this value is a slider from 0 to 100. Any number larger than 1 is interpreted as 1.
The Creator Hub does not allow to set decimal numbers on the slider, only full numbers, so the only valid values are 0 or 1.

## Solution
User is able to set values between 0 and 1, using slider or typing in the field.

## Screenshots
<img width="400" height="117" alt="image" src="https://github.com/user-attachments/assets/16b500e2-1df1-4e8c-bdf0-c06edac89a69" />

<img width="400" height="117" alt="image" src="https://github.com/user-attachments/assets/9283de6b-4948-4b87-94f3-0a655644c3f5" />

closes: #786 



