### PR TITLE
Box Selection: drag rectangle selection with X-Ray / Select-Through toggles

### DIFF
--- a/packages/inspector/src/components/Renderer/BoxSelection.css
+++ b/packages/inspector/src/components/Renderer/BoxSelection.css
@@ -1,0 +1,11 @@
+.BoxSelection {
+  position: absolute;
+  pointer-events: none;
+  border: 1px dashed rgba(255, 255, 255, 0.8);
+  background-color: rgba(200, 200, 200, 0.05);
+  z-index: 1000;
+  box-sizing: border-box;
+  outline: 1px dashed rgba(0, 0, 0, 0.6);
+  outline-offset: -2px;
+}
+

--- a/packages/inspector/src/components/Renderer/BoxSelection.css
+++ b/packages/inspector/src/components/Renderer/BoxSelection.css
@@ -1,11 +1,11 @@
 .BoxSelection {
   position: absolute;
   pointer-events: none;
-  border: 1px dashed rgba(255, 255, 255, 0.8);
+  border: 2px dashed rgba(255, 255, 255, 0.8);
   background-color: rgba(200, 200, 200, 0.05);
-  z-index: 1000;
+  z-index: 10000;
   box-sizing: border-box;
-  outline: 1px dashed rgba(0, 0, 0, 0.6);
-  outline-offset: -2px;
+  outline: 2px dashed rgba(0, 0, 0, 0.6);
+  outline-offset: -3px;
 }
 

--- a/packages/inspector/src/components/Renderer/BoxSelection.tsx
+++ b/packages/inspector/src/components/Renderer/BoxSelection.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import type { BoxSelectionState } from '../../lib/babylon/setup/boxSelection';
+
+import './BoxSelection.css';
+
+interface BoxSelectionProps {
+  selectionState: BoxSelectionState;
+}
+
+export const BoxSelection: React.FC<BoxSelectionProps> = ({ selectionState }) => {
+  // Only show while actively dragging
+  if (!selectionState.isActive) {
+    return null;
+  }
+
+  const minX = Math.min(selectionState.startX, selectionState.currentX);
+  const minY = Math.min(selectionState.startY, selectionState.currentY);
+  const width = Math.abs(selectionState.currentX - selectionState.startX);
+  const height = Math.abs(selectionState.currentY - selectionState.startY);
+
+  // Only render if dragged at least 5 pixels (to avoid showing on simple clicks)
+  if (width < 5 && height < 5) {
+    return null;
+  }
+
+  return (
+    <div
+      className="BoxSelection"
+      style={{
+        left: `${minX}px`,
+        top: `${minY}px`,
+        width: `${width}px`,
+        height: `${height}px`,
+      }}
+    />
+  );
+};

--- a/packages/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/inspector/src/components/Renderer/Renderer.tsx
@@ -53,7 +53,11 @@ import { Shortcuts } from './Shortcuts';
 import { Metrics } from './Metrics';
 import { AxisHelper } from './AxisHelper';
 import { BoxSelection } from './BoxSelection';
-import { initBoxSelection, type BoxSelectionState } from '../../lib/babylon/setup/boxSelection';
+import {
+  initBoxSelection,
+  disposeBoxSelection,
+  type BoxSelectionState,
+} from '../../lib/babylon/setup/boxSelection';
 
 import './Renderer.css';
 
@@ -101,6 +105,13 @@ const Renderer: React.FC = () => {
         onEnd: state => setBoxSelectionState({ ...state }),
       });
     }
+
+    // Cleanup: remove event listeners when component unmounts or sdk changes
+    return () => {
+      if (sdk && sdk.scene) {
+        disposeBoxSelection(sdk.scene);
+      }
+    };
   }, [sdk]);
 
   useEffect(() => {

--- a/packages/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/inspector/src/components/Renderer/Renderer.tsx
@@ -52,6 +52,8 @@ import { CameraSpeed } from './CameraSpeed';
 import { Shortcuts } from './Shortcuts';
 import { Metrics } from './Metrics';
 import { AxisHelper } from './AxisHelper';
+import { BoxSelection } from './BoxSelection';
+import { initBoxSelection, type BoxSelectionState } from '../../lib/babylon/setup/boxSelection';
 
 import './Renderer.css';
 
@@ -76,12 +78,30 @@ const Renderer: React.FC = () => {
   const [placeSingleTile, setPlaceSingleTile] = useState(false);
   const [showSingleTileHint, setShowSingleTileHint] = useState(false);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+  const [boxSelectionState, setBoxSelectionState] = useState<BoxSelectionState>({
+    isActive: false,
+    startX: 0,
+    startY: 0,
+    currentX: 0,
+    currentY: 0,
+  });
 
   useEffect(() => {
     if (sdk) {
       sdk.gizmos.setEnabled(!gizmosDisabled);
     }
   }, [sdk, gizmosDisabled]);
+
+  // Initialize box selection
+  useEffect(() => {
+    if (sdk && sdk.scene && sdk.sceneContext) {
+      initBoxSelection(sdk.scene, sdk.sceneContext, {
+        onStart: state => setBoxSelectionState({ ...state }),
+        onUpdate: state => setBoxSelectionState({ ...state }),
+        onEnd: state => setBoxSelectionState({ ...state }),
+      });
+    }
+  }, [sdk]);
 
   useEffect(() => {
     if (sdk) {
@@ -457,6 +477,7 @@ const Renderer: React.FC = () => {
         id="canvas"
         touch-action="none"
       />
+      <BoxSelection selectionState={boxSelectionState} />
       <div
         style={{
           top: mousePosition.y + SINGLE_TILE_HINT_OFFSET,

--- a/packages/inspector/src/components/Toolbar/Preferences/Preferences.tsx
+++ b/packages/inspector/src/components/Toolbar/Preferences/Preferences.tsx
@@ -5,6 +5,7 @@ import cx from 'classnames';
 import { withSdk } from '../../../hoc/withSdk';
 import { ToolbarButton } from '../ToolbarButton';
 import { useOutsideClick } from '../../../hooks/useOutsideClick';
+import { useXRayToggle, useSelectThroughToggle } from '../../../hooks/editor/useBoxSelection';
 
 import './Preferences.css';
 import { useAppSelector, useAppDispatch } from '../../../redux/hooks';
@@ -15,6 +16,10 @@ export const Preferences = withSdk(({ sdk }) => {
   const [showPanel, setShowPanel] = useState(false);
   const preferences = useAppSelector(selectInspectorPreferences);
   const dispatch = useAppDispatch();
+  const { isEnabled: isXRayEnabled, toggle: toggleXRay } = useXRayToggle();
+  const { isEnabled: isSelectThroughEnabled, toggle: toggleSelectThrough } =
+    useSelectThroughToggle();
+
   const togglePanel = useCallback(() => {
     setShowPanel(!showPanel);
   }, [showPanel]);
@@ -47,6 +52,8 @@ export const Preferences = withSdk(({ sdk }) => {
     : BiCheckbox;
   const AutosaveEnabledIcon = preferences?.autosaveEnabled ? BiCheckboxChecked : BiCheckbox;
   const FreeCameraModeIcon = preferences?.cameraMode === 'free' ? BiCheckboxChecked : BiCheckbox;
+  const XRayIcon = isXRayEnabled ? BiCheckboxChecked : BiCheckbox;
+  const SelectThroughIcon = isSelectThroughEnabled ? BiCheckboxChecked : BiCheckbox;
 
   return (
     <div
@@ -80,6 +87,22 @@ export const Preferences = withSdk(({ sdk }) => {
           <AutosaveEnabledIcon
             className="icon"
             onClick={toggleAutosaveEnabled}
+          />
+        </div>
+        <div className="preference-row">
+          <label>X-Ray</label>
+          <XRayIcon
+            className="icon"
+            onClick={toggleXRay}
+            title="Show selected objects through other geometry"
+          />
+        </div>
+        <div className="preference-row">
+          <label>Select Through</label>
+          <SelectThroughIcon
+            className="icon"
+            onClick={toggleSelectThrough}
+            title="Box selection includes objects behind other objects"
           />
         </div>
       </div>

--- a/packages/inspector/src/hooks/editor/useBoxSelection.ts
+++ b/packages/inspector/src/hooks/editor/useBoxSelection.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { boxSelectionManager } from '../../lib/babylon/decentraland/box-selection-manager';
+
+/**
+ * Hook for managing "Select Through" toggle state
+ * When enabled (default), box selection selects all objects regardless of occlusion
+ * When disabled, only visible objects are selected
+ */
+export const useSelectThroughToggle = () => {
+  const [isEnabled, setEnabledInternal] = useState<boolean>(
+    boxSelectionManager.isSelectThroughEnabled(),
+  );
+  const skipSyncRef = useRef(false);
+
+  const setEnabled = useCallback((value: boolean, skipSync = false) => {
+    skipSyncRef.current = skipSync;
+    setEnabledInternal(value);
+  }, []);
+
+  const toggle = useCallback(() => setEnabled(!isEnabled), [isEnabled, setEnabled]);
+
+  // send update to manager
+  useEffect(() => {
+    if (skipSyncRef.current) return;
+    boxSelectionManager.setSelectThroughEnabled(isEnabled);
+  }, [isEnabled]);
+
+  // receive update from manager
+  useEffect(() => {
+    const unsubscribe = boxSelectionManager.onChange(() => {
+      setEnabled(boxSelectionManager.isSelectThroughEnabled(), true); // skip sync to avoid loop
+    });
+    return () => unsubscribe();
+  }, [setEnabled]);
+
+  return { isEnabled, setEnabled, toggle };
+};
+
+/**
+ * Hook for managing "X-Ray" toggle state
+ * When enabled (default), selected objects show their outline through other geometry
+ * When disabled, outlines are only visible when not occluded
+ */
+export const useXRayToggle = () => {
+  const [isEnabled, setEnabledInternal] = useState<boolean>(boxSelectionManager.isXRayEnabled());
+  const skipSyncRef = useRef(false);
+
+  const setEnabled = useCallback((value: boolean, skipSync = false) => {
+    skipSyncRef.current = skipSync;
+    setEnabledInternal(value);
+  }, []);
+
+  const toggle = useCallback(() => setEnabled(!isEnabled), [isEnabled, setEnabled]);
+
+  // send update to manager
+  useEffect(() => {
+    if (skipSyncRef.current) return;
+    boxSelectionManager.setXRayEnabled(isEnabled);
+  }, [isEnabled]);
+
+  // receive update from manager
+  useEffect(() => {
+    const unsubscribe = boxSelectionManager.onChange(() => {
+      setEnabled(boxSelectionManager.isXRayEnabled(), true); // skip sync to avoid loop
+    });
+    return () => unsubscribe();
+  }, [setEnabled]);
+
+  return { isEnabled, setEnabled, toggle };
+};

--- a/packages/inspector/src/lib/babylon/decentraland/box-selection-manager.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/box-selection-manager.ts
@@ -1,0 +1,69 @@
+import mitt from 'mitt';
+
+/**
+ * Box Selection Manager
+ * Manages settings for the box selection feature:
+ * - Select Through: When enabled, selects all objects in the box regardless of occlusion
+ * - X-Ray: When enabled, shows selected object outlines through other geometry
+ */
+
+const getBoxSelectionManager = () => {
+  // defaults
+  let selectThroughEnabled = true; // Select all objects (including occluded ones)
+  let xRayEnabled = false; // X-Ray mode disabled by default
+
+  // events
+  const events = mitt<{ change: void }>();
+
+  // Getters
+  function isSelectThroughEnabled() {
+    return selectThroughEnabled;
+  }
+
+  function isXRayEnabled() {
+    return xRayEnabled;
+  }
+
+  // Setters
+  function setSelectThroughEnabled(value: boolean) {
+    selectThroughEnabled = value;
+    events.emit('change');
+  }
+
+  function setXRayEnabled(value: boolean) {
+    xRayEnabled = value;
+    events.emit('change');
+  }
+
+  // Toggles
+  function toggleSelectThrough() {
+    const value = !isSelectThroughEnabled();
+    setSelectThroughEnabled(value);
+    return value;
+  }
+
+  function toggleXRay() {
+    const value = !isXRayEnabled();
+    setXRayEnabled(value);
+    return value;
+  }
+
+  // Event handler
+  function onChange(cb: (values: { selectThroughEnabled: boolean; xRayEnabled: boolean }) => void) {
+    const handler = () => cb({ selectThroughEnabled, xRayEnabled });
+    events.on('change', handler);
+    return () => events.off('change', handler);
+  }
+
+  return {
+    isSelectThroughEnabled,
+    setSelectThroughEnabled,
+    toggleSelectThrough,
+    isXRayEnabled,
+    setXRayEnabled,
+    toggleXRay,
+    onChange,
+  };
+};
+
+export const boxSelectionManager = getBoxSelectionManager();

--- a/packages/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
@@ -40,14 +40,20 @@ export const deleteEntitySelectedComponent: ComponentOperation = (entity, compon
 
 export function toggleMeshSelection(mesh: AbstractMesh, value: boolean) {
   mesh.renderOverlay = value;
-  mesh.overlayColor = Color3.White();
-  mesh.overlayAlpha = 0.2;
+  mesh.overlayColor = new Color3(0.9, 0.9, 0.9); // 10% grey (90% brightness instead of 100%)
+  mesh.overlayAlpha = 0.12; // 20% opacity - more visible than before
   const hl = highlightedMeshes.get(mesh);
   if (value && !hl) {
-    const newHl = new HighlightLayer('hl1', mesh.getScene());
-    newHl.addMesh(mesh as Mesh, Color3.Yellow());
-    newHl.blurHorizontalSize = 0.1;
-    newHl.blurVerticalSize = 0.1;
+    const newHl = new HighlightLayer('hl1', mesh.getScene(), {
+      mainTextureRatio: 2, // Higher resolution for sharper edges
+      blurTextureSizeRatio: 0.5, // Sharper blur
+      isStroke: false,
+      camera: null,
+    });
+    newHl.addMesh(mesh as Mesh, Color3.FromHexString('#FFFF00')); // Bright pure yellow
+    newHl.blurHorizontalSize = 0.5; // More blur for more visible glow
+    newHl.blurVerticalSize = 0.5;
+    newHl.innerGlow = false; // Only outer glow for cleaner look
     highlightedMeshes.set(mesh, newHl);
   } else if (!value && hl) {
     hl.removeMesh(mesh as Mesh);

--- a/packages/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
@@ -1,12 +1,70 @@
 import type { AbstractMesh, Mesh } from '@babylonjs/core';
-import { Color3, HighlightLayer } from '@babylonjs/core';
+import { HighlightLayer, Constants, StandardMaterial, Color4 } from '@babylonjs/core';
 import { ComponentType } from '@dcl/ecs';
 import type { EditorComponentsTypes } from '../../../sdk/components';
 import { CoreComponents } from '../../../sdk/components';
 import type { EcsEntity } from '../EcsEntity';
 import type { ComponentOperation } from '../component-operations';
+import { boxSelectionManager } from '../box-selection-manager';
 
-const highlightedMeshes = new Map<AbstractMesh, HighlightLayer>();
+// Store highlight info
+type HighlightInfo = {
+  highlightLayer: HighlightLayer;
+  originalRenderingGroupId: number;
+  xrayMesh?: AbstractMesh; // Mesh that renders ONLY occluded parts (GEQUAL depth test)
+};
+
+const highlightedMeshes = new Map<AbstractMesh, HighlightInfo>();
+
+// Subscribe to X-Ray setting changes and update all highlights
+boxSelectionManager.onChange(values => {
+  updateAllHighlightsXRayMode(values.xRayEnabled);
+});
+
+function updateAllHighlightsXRayMode(xRayEnabled: boolean) {
+  for (const [mesh, info] of highlightedMeshes) {
+    updateHighlightXRayMode(mesh, info, xRayEnabled);
+  }
+}
+
+/**
+ * X-ray mode: Shows occluded parts with a "see through walls" effect
+ * Simplified approach: Always render on top with reduced opacity to simulate X-ray
+ */
+function updateHighlightXRayMode(mesh: AbstractMesh, info: HighlightInfo, xRayEnabled: boolean) {
+  if (xRayEnabled && !info.xrayMesh) {
+    // Create a clone for X-ray effect
+    const xrayClone = mesh.clone(`xray_${mesh.uniqueId}`, null);
+    if (!xrayClone) return;
+
+    const scene = mesh.getScene();
+
+    // Make the clone mesh itself invisible but keep edges visible
+    const xrayMat = new StandardMaterial(`xrayMat_${mesh.uniqueId}`, scene);
+    xrayMat.alpha = 0; // Completely transparent mesh
+    xrayMat.alphaMode = Constants.ALPHA_COMBINE;
+
+    // CRITICAL: Make edges render through walls
+    xrayMat.depthFunction = Constants.ALWAYS; // Always render (through walls)
+    xrayMat.disableDepthWrite = true; // Don't write to depth buffer
+
+    xrayClone.material = xrayMat;
+    xrayClone.renderingGroupId = 2; // Render after everything
+    xrayClone.isPickable = false; // Don't interfere with picking
+
+    // Use EdgesRenderer for SOLID lines (no glow!)
+    (xrayClone as Mesh).enableEdgesRendering();
+    (xrayClone as Mesh).edgesWidth = 3.0; // Slightly thinner than normal selection
+    (xrayClone as Mesh).edgesColor = new Color4(1, 0.65, 0, 1); // Orange for X-ray
+
+    info.xrayMesh = xrayClone;
+  } else if (!xRayEnabled && info.xrayMesh) {
+    // Clean up X-ray mesh and edges
+    (info.xrayMesh as Mesh).disableEdgesRendering();
+    info.xrayMesh.dispose(false, true);
+    info.xrayMesh = undefined;
+  }
+}
 
 export const putEntitySelectedComponent: ComponentOperation = (entity, component) => {
   if (component.componentType === ComponentType.LastWriteWinElementSet) {
@@ -39,24 +97,70 @@ export const deleteEntitySelectedComponent: ComponentOperation = (entity, compon
 };
 
 export function toggleMeshSelection(mesh: AbstractMesh, value: boolean) {
-  mesh.renderOverlay = value;
-  mesh.overlayColor = new Color3(0.9, 0.9, 0.9); // 10% grey (90% brightness instead of 100%)
-  mesh.overlayAlpha = 0.12; // 20% opacity - more visible than before
-  const hl = highlightedMeshes.get(mesh);
-  if (value && !hl) {
-    const newHl = new HighlightLayer('hl1', mesh.getScene(), {
-      mainTextureRatio: 2, // Higher resolution for sharper edges
-      blurTextureSizeRatio: 0.5, // Sharper blur
+  // Don't use renderOverlay - it makes the whole mesh glow
+  // We only want the HighlightLayer outline effect
+  const info = highlightedMeshes.get(mesh);
+  if (value && !info) {
+    // Save the original rendering group ID before we potentially modify it
+    const originalRenderingGroupId = mesh.renderingGroupId;
+
+    const scene = mesh.getScene();
+
+    console.log('[Selection] Enabling edges for mesh:', mesh.name, mesh.uniqueId);
+
+    // ONLY use EdgesRenderer - NO HighlightLayer glow!
+    // First disable if already enabled to prevent accumulation
+    (mesh as Mesh).disableEdgesRendering();
+    (mesh as Mesh).enableEdgesRendering();
+    (mesh as Mesh).edgesWidth = 4.0; // Normal selection - keep visible
+    (mesh as Mesh).edgesColor = new Color4(1, 1, 0, 1); // Yellow outline
+
+    // Create a dummy HighlightLayer just to keep the data structure (but don't use it!)
+    const dummyHl = new HighlightLayer(`hl_${mesh.uniqueId}`, scene, {
+      mainTextureRatio: 0.1,
+      blurTextureSizeRatio: 0.1,
       isStroke: false,
       camera: null,
     });
-    newHl.addMesh(mesh as Mesh, Color3.FromHexString('#FFFF00')); // Bright pure yellow
-    newHl.blurHorizontalSize = 0.5; // More blur for more visible glow
-    newHl.blurVerticalSize = 0.5;
-    newHl.innerGlow = false; // Only outer glow for cleaner look
-    highlightedMeshes.set(mesh, newHl);
-  } else if (!value && hl) {
-    hl.removeMesh(mesh as Mesh);
+    // DON'T add the mesh to it! This prevents the glow!
+
+    // Store the highlight layer reference and original rendering group
+    const highlightInfo: HighlightInfo = {
+      highlightLayer: dummyHl,
+      originalRenderingGroupId,
+    };
+    highlightedMeshes.set(mesh, highlightInfo);
+
+    // Set up X-Ray mode based on current setting
+    const isXRayEnabled = boxSelectionManager.isXRayEnabled();
+    if (isXRayEnabled) {
+      updateHighlightXRayMode(mesh, highlightInfo, true);
+    }
+  } else if (value && info) {
+    // Already selected - don't re-enable edges to prevent brightening
+    console.log('[Selection] Mesh already selected, skipping:', mesh.name, mesh.uniqueId);
+    return;
+  } else if (!value && info) {
+    // Disable edges rendering
+    (mesh as Mesh).disableEdgesRendering();
+
+    // Clean up X-ray mesh if it exists
+    if (info.xrayMesh) {
+      info.xrayMesh.dispose(false, true);
+    }
+
+    // Clean up highlight layer
+    try {
+      info.highlightLayer.removeMesh(mesh as Mesh);
+      info.highlightLayer.dispose();
+    } catch (e) {
+      console.warn('[Selection] Error disposing highlight layer:', e);
+    }
+
+    // Restore original rendering group
+    mesh.renderingGroupId = info.originalRenderingGroupId;
+
+    // Remove from map
     highlightedMeshes.delete(mesh);
   }
 }
@@ -69,7 +173,9 @@ export const toggleSelection = (entity: EcsEntity, value: boolean) => {
   void entity.onAssetLoaded().then(() => {
     if (entity.gltfContainer) {
       for (const mesh of entity.gltfContainer.getChildMeshes()) {
+        // Skip colliders and X-ray clone meshes
         if (mesh.name.includes('collider')) continue;
+        if (mesh.name.startsWith('xray_')) continue;
         toggleMeshSelection(mesh, value);
       }
     }

--- a/packages/inspector/src/lib/babylon/setup/boxSelection.ts
+++ b/packages/inspector/src/lib/babylon/setup/boxSelection.ts
@@ -1,0 +1,295 @@
+import * as BABYLON from '@babylonjs/core';
+import type { EcsEntity } from '../decentraland/EcsEntity';
+import { keyState, Keys } from '../decentraland/keys';
+import type { SceneContext } from '../decentraland/SceneContext';
+
+export type BoxSelectionState = {
+  isActive: boolean;
+  startX: number;
+  startY: number;
+  currentX: number;
+  currentY: number;
+};
+
+export type BoxSelectionCallbacks = {
+  onStart: (state: BoxSelectionState) => void;
+  onUpdate: (state: BoxSelectionState) => void;
+  onEnd: (state: BoxSelectionState) => void;
+};
+
+let boxSelectionState: BoxSelectionState = {
+  isActive: false,
+  startX: 0,
+  startY: 0,
+  currentX: 0,
+  currentY: 0,
+};
+
+let callbacks: BoxSelectionCallbacks | null = null;
+let sceneContext: SceneContext | null = null;
+
+export function initBoxSelection(
+  scene: BABYLON.Scene,
+  context: SceneContext,
+  selectionCallbacks: BoxSelectionCallbacks,
+) {
+  callbacks = selectionCallbacks;
+  sceneContext = context;
+
+  // Listen for pointer events
+  scene.onPointerObservable.add(e => {
+    if (e.type === BABYLON.PointerEventTypes.POINTERDOWN) {
+      const evt = e.event as PointerEvent;
+      if (evt.button === 0) {
+        // Left click only
+        handlePointerDown(scene, evt.offsetX, evt.offsetY);
+      }
+    } else if (e.type === BABYLON.PointerEventTypes.POINTERMOVE) {
+      const evt = e.event as PointerEvent;
+      handlePointerMove(evt.offsetX, evt.offsetY);
+    } else if (e.type === BABYLON.PointerEventTypes.POINTERUP) {
+      const evt = e.event as PointerEvent;
+      if (evt.button === 0) {
+        handlePointerUp(scene, evt.offsetX, evt.offsetY);
+      }
+    }
+  });
+}
+
+function handlePointerDown(scene: BABYLON.Scene, x: number, y: number) {
+  // Don't start box selection if holding Ctrl/Shift (used for multi-select) or Alt (used for camera rotation)
+  if (keyState[Keys.KEY_CTRL] || keyState[Keys.KEY_SHIFT] || keyState[Keys.KEY_ALT]) {
+    return;
+  }
+
+  // Check what we clicked on
+  const pickingResult = scene.pick(x, y, void 0, false);
+  const pickedMesh = pickingResult?.pickedMesh;
+
+  // Don't start box selection if we clicked on a gizmo
+  if (pickedMesh && pickedMesh.name && pickedMesh.name.toLowerCase().includes('gizmo')) {
+    return;
+  }
+
+  // Don't start box selection if we clicked on a selected entity (allow gizmo manipulation)
+  if (pickedMesh) {
+    const entity = findParentEntity(pickedMesh);
+    if (entity && sceneContext) {
+      const { editorComponents } = sceneContext;
+      if (editorComponents.Selection.has(entity.entityId)) {
+        // Clicked on an already selected entity - don't start box selection
+        return;
+      }
+    }
+  }
+
+  // Start box selection
+  boxSelectionState = {
+    isActive: true,
+    startX: x,
+    startY: y,
+    currentX: x,
+    currentY: y,
+  };
+  callbacks?.onStart(boxSelectionState);
+}
+
+function handlePointerMove(x: number, y: number) {
+  if (boxSelectionState.isActive) {
+    boxSelectionState.currentX = x;
+    boxSelectionState.currentY = y;
+    callbacks?.onUpdate(boxSelectionState);
+  }
+}
+
+function handlePointerUp(scene: BABYLON.Scene, x: number, y: number) {
+  if (boxSelectionState.isActive) {
+    boxSelectionState.currentX = x;
+    boxSelectionState.currentY = y;
+
+    // Calculate selection box bounds
+    const minX = Math.min(boxSelectionState.startX, boxSelectionState.currentX);
+    const maxX = Math.max(boxSelectionState.startX, boxSelectionState.currentX);
+    const minY = Math.min(boxSelectionState.startY, boxSelectionState.currentY);
+    const maxY = Math.max(boxSelectionState.startY, boxSelectionState.currentY);
+
+    // Only select if the box has a minimum size (avoid accidental tiny selections)
+    const boxWidth = maxX - minX;
+    const boxHeight = maxY - minY;
+
+    if (boxWidth > 5 || boxHeight > 5) {
+      // Get all entities within the selection box
+      const selectedEntities = getEntitiesInBox(scene, minX, minY, maxX, maxY);
+
+      // Select the entities
+      if (sceneContext) {
+        const { operations, engine } = sceneContext;
+
+        if (selectedEntities.length > 0) {
+          // Clear existing selection first using the operations API
+          operations.removeSelectedEntities();
+
+          // Select all entities in the box
+          selectedEntities.forEach((entity, index) => {
+            operations.updateSelectedEntity(entity.entityId, index > 0);
+          });
+
+          void operations.dispatch();
+        } else {
+          // No entities selected - clear existing selection and select the scene (RootEntity)
+          operations.removeSelectedEntities();
+          operations.updateSelectedEntity(engine.RootEntity, false);
+          void operations.dispatch();
+        }
+      }
+    } else if (sceneContext) {
+      // Box is too small - treat as a click
+      // Check what was clicked
+      const pickingResult = scene.pick(
+        boxSelectionState.startX,
+        boxSelectionState.startY,
+        void 0,
+        false,
+      );
+      const pickedMesh = pickingResult?.pickedMesh;
+
+      // Check if we clicked on an actual selectable entity (not ground, gizmo, skybox, locked, or empty space)
+      const entity = pickedMesh ? findParentEntity(pickedMesh) : null;
+      const isEnvironmentMesh =
+        pickedMesh &&
+        (pickedMesh.name.toLowerCase().includes('gizmo') ||
+          pickedMesh.name.toLowerCase().includes('ground') ||
+          pickedMesh.name.toLowerCase().includes('skybox') ||
+          pickedMesh.name.toLowerCase().includes('hemi') ||
+          pickedMesh.id.includes('BackgroundPlane') ||
+          pickedMesh.id.includes('BackgroundSkybox'));
+
+      // Treat locked, hidden, ground, and tile entities as non-selectable (like empty space)
+      const isNonSelectable = entity && (entity.isLocked() || entity.isHidden());
+      const isGroundOrTile =
+        entity &&
+        sceneContext &&
+        (sceneContext.editorComponents.Ground.has(entity.entityId) ||
+          sceneContext.editorComponents.Tile.has(entity.entityId));
+
+      if (!entity || isEnvironmentMesh || isNonSelectable || isGroundOrTile) {
+        // Clicked on empty space, ground, skybox, or gizmo - select the scene (RootEntity)
+        const { operations, engine } = sceneContext;
+        // Clear existing selection first
+        operations.removeSelectedEntities();
+        // Then select the scene
+        operations.updateSelectedEntity(engine.RootEntity, false);
+        void operations.dispatch();
+      }
+      // If clicked on an entity, do nothing (let the input.ts handler deal with it)
+    }
+
+    // Reset state FIRST
+    boxSelectionState = {
+      isActive: false,
+      startX: 0,
+      startY: 0,
+      currentX: 0,
+      currentY: 0,
+    };
+
+    // Then notify with the reset state
+    callbacks?.onEnd(boxSelectionState);
+  }
+}
+
+function getEntitiesInBox(
+  scene: BABYLON.Scene,
+  minX: number,
+  minY: number,
+  maxX: number,
+  maxY: number,
+): EcsEntity[] {
+  const selectedEntities: EcsEntity[] = [];
+  const camera = scene.activeCamera;
+
+  if (!camera) return selectedEntities;
+
+  const engine = scene.getEngine();
+  const canvas = engine.getRenderingCanvas();
+  if (!canvas) return selectedEntities;
+
+  const canvasWidth = canvas.width;
+  const canvasHeight = canvas.height;
+
+  // Get all meshes in the scene
+  const allMeshes = scene.meshes;
+
+  for (const mesh of allMeshes) {
+    // Skip invisible meshes and gizmos
+    if (!mesh.isVisible || mesh.name.startsWith('gizmo')) {
+      continue;
+    }
+
+    // Try to find the parent DCL entity
+    const entity = findParentEntity(mesh);
+    if (!entity || entity.isLocked() || entity.isHidden()) {
+      continue;
+    }
+
+    // Check if already added
+    if (selectedEntities.includes(entity)) {
+      continue;
+    }
+
+    // Get the entity's world position
+    const worldPosition = entity.getAbsolutePosition();
+
+    // Project 3D position to 2D screen space
+    // Using identity matrix for world matrix since we already have world position
+    const screenPosition = BABYLON.Vector3.Project(
+      worldPosition,
+      BABYLON.Matrix.Identity(),
+      scene.getTransformMatrix(),
+      camera.viewport,
+    );
+
+    // Convert from normalized coordinates (0-1) to pixel coordinates
+    const screenX = screenPosition.x * canvasWidth;
+    const screenY = screenPosition.y * canvasHeight;
+
+    // Check if the projected position is within the selection box
+    // Also check that the point is in front of the camera (z >= 0 and <= 1)
+    if (
+      screenPosition.z >= 0 &&
+      screenPosition.z <= 1 &&
+      screenX >= minX &&
+      screenX <= maxX &&
+      screenY >= minY &&
+      screenY <= maxY
+    ) {
+      selectedEntities.push(entity);
+    }
+  }
+
+  return selectedEntities;
+}
+
+function isEcsEntity(x: any): x is EcsEntity {
+  return 'isDCLEntity' in x;
+}
+
+function findParentEntity<T extends BABYLON.Node & { isDCLEntity?: boolean }>(
+  node: T,
+): EcsEntity | null {
+  // Find the next entity parent to dispatch the event
+  let parent: BABYLON.Node | null = node.parent;
+
+  while (parent && !isEcsEntity(parent)) {
+    parent = parent.parent;
+
+    // If the element has no parent, stop execution
+    if (!parent) return null;
+  }
+
+  return (parent as any) || null;
+}
+
+export function getBoxSelectionState(): BoxSelectionState {
+  return boxSelectionState;
+}

--- a/packages/inspector/src/lib/babylon/setup/setup.ts
+++ b/packages/inspector/src/lib/babylon/setup/setup.ts
@@ -59,8 +59,10 @@ export function setupEngine(
 
   scene.autoClear = false; // Color buffer
   scene.autoClearDepthAndStencil = false; // Depth and stencil
-  scene.setRenderingAutoClearDepthStencil(0, false);
-  scene.setRenderingAutoClearDepthStencil(1, true, true, false);
+
+  // Configure rendering groups
+  scene.setRenderingAutoClearDepthStencil(0, false); // Group 0: Normal rendering
+  scene.setRenderingAutoClearDepthStencil(1, false, false, false); // Group 1: X-ray wireframes (GEQUAL depth test)
 
   // scene.gravity = new BABYLON.Vector3(0, playerConfigurations.gravity, 0)
   // scene.enablePhysics(scene.gravity, new BABYLON.OimoJSPlugin(2))


### PR DESCRIPTION
# Box Selection: drag rectangle selection with X-Ray / Select-Through toggles

## Context and Problem Statement

Added a box selection for multiple object for easier work
The earlier branch diverged from the “enhanced gizmos” work that was just merged upstream; we rebased the feature so it rides on those new gizmo controls

## Solution

Provide a rectangular “box selection” mode that integrates with the existing gizmo tooling and preferences panel.
Key changes:
Add BoxSelection overlay + box-selection-manager that handles drag rectangle selection, centroid placement, and gizmo updates for multiple entities.
Extend inspector Preferences with X-Ray (always render selected entities on top) and Select Through (include occluded items) toggles; wire them into new useBoxSelection hooks.
Improve selection visuals (highlight styling, feedback when multiple targets are selected) and keep gizmo world/local alignment support.
Sync the branch on top of feat/enhanced-gizmos, keeping the new Babylon camera controls and toolbar hotkeys.
Also users can no de-select object by clicking anywhere on the screen (it selects the scene)

## Testing

[x] Manual: Launched Creator Hub (npm run start), verified drag-select works, X-Ray + Select Through toggles behave as expected.
[ ] Automated unit tests (blocked by existing ERR_REQUIRE_ESM when Vitest loads @babylonjs/inspector; unchanged from upstream).
[ ] Additional edge-case coverage.
[ ] Regression suite / CI run.

## Impact

Users can lasso multiple entities quickly and fine-tune how the selection behaves through Preferences.
No migration needed; defaults keep current behavior (X-Ray + Select Through disabled).
Known limitation: Inspector unit tests still fail with the Babylon inspector ESM import error (pre-existing); call it out so reviewers expect it.

## Screenshots


https://github.com/user-attachments/assets/a540fec2-5eca-4389-b95d-854b7e6aee7c


