### PR TITLE
fix: gray out background inspector while updating dependencies

### DIFF
--- a/packages/creator-hub/renderer/src/components/Snackbar/component.styled.ts
+++ b/packages/creator-hub/renderer/src/components/Snackbar/component.styled.ts
@@ -1,0 +1,8 @@
+import { Backdrop, styled } from 'decentraland-ui2';
+
+const StyledBackdrop = styled(Backdrop)(({ theme }) => ({
+  zIndex: theme.zIndex.snackbar - 1,
+  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+}));
+
+export { StyledBackdrop };

--- a/packages/creator-hub/renderer/src/components/Snackbar/component.tsx
+++ b/packages/creator-hub/renderer/src/components/Snackbar/component.tsx
@@ -1,28 +1,22 @@
 import { useCallback } from 'react';
-import { Backdrop, styled } from 'decentraland-ui2';
 import { Snackbar } from '@mui/material';
 
 import type { Notification } from '/@/modules/store/snackbar/types';
 import { useSnackbar } from '/@/hooks/useSnackbar';
-import { useSelector } from '#store';
-
+import { useEditor } from '/@/hooks/useEditor';
 import { MissingScenes } from './MissingScenes';
 import { Generic } from './Generic';
 import { NewDependencyVersion } from './DependencyVersion';
 import { Deploy } from './Deploy';
+import { StyledBackdrop } from './component.styled';
 
 import './styles.css';
 
 const DEFAULT_DURATION_IN_MS = 5_000;
 
-const StyledBackdrop = styled(Backdrop)(({ theme }) => ({
-  zIndex: theme.zIndex.snackbar - 1,
-  backgroundColor: 'rgba(0, 0, 0, 0.5)',
-}));
-
 export function SnackbarComponent() {
   const { notifications, close, dismiss } = useSnackbar();
-  const isInstallingDependencies = useSelector(state => state.editor.isInstallingProject);
+  const { isInstallingProject: isInstallingDependencies } = useEditor();
 
   const getComponent = useCallback((notification: Notification) => {
     switch (notification.type) {

--- a/packages/creator-hub/renderer/src/modules/store/workspace/thunks.ts
+++ b/packages/creator-hub/renderer/src/modules/store/workspace/thunks.ts
@@ -64,7 +64,7 @@ export const updatePackages = createAsyncThunk(
     const latestPackages = Object.entries(project.dependencyAvailableUpdates).map(
       ([pkg, { latest }]) => `${pkg}@${latest}`,
     );
-    await dispatch(installProject({ path: project.path, packages: latestPackages }));
+    await dispatch(installProject({ path: project.path, packages: latestPackages })).unwrap();
   },
 );
 export const updateAvailableDependencyUpdates = createAsyncThunk(


### PR DESCRIPTION
# Gray out background inspector while updating dependencies

## Context and Problem Statement
While updating a scene's dependencies, it's risky to change anything about the scene, things could potentially break. It's also not a good idea to let users Deploy or run a Preview while this update is ongoing.

## Solution
Gray out the Preview, Deploy and the Inspector as a whole while these updates are going on.

## Screenshots
<img width="1726" height="957" alt="image" src="https://github.com/user-attachments/assets/91035d95-5e9d-4d60-9a45-766c7af79d16" />


closes: #671 
