### PR TITLE
fix: Hide add component button on scene/camera/player entities

### DIFF
--- a/packages/inspector/src/components/EntityInspector/EntityHeader/EntityHeader.tsx
+++ b/packages/inspector/src/components/EntityInspector/EntityHeader/EntityHeader.tsx
@@ -299,7 +299,7 @@ export default React.memo(
             ) : null}
           </div>
           <div className="RightContent">
-            {componentOptions.some(option => !option.header) ? (
+            {componentOptions.some(option => !option.header) && !isRoot(entity) ? (
               <Dropdown
                 className="AddComponent"
                 options={componentOptions}


### PR DESCRIPTION
# fix: Hide add component button on scene/camera/player entities

## Context and Problem Statement

Users can add components to the entities `scene | camera | player`, which could lead to unexpected issues, as the components in the CH are targeted to the scene's entities.

## Solution

Hide the `add component` button on root entities.

Original fix here: https://github.com/decentraland/creator-hub/pull/742