### PR TITLE
feat: optimize main hot reload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33305,6 +33305,7 @@
         "@types/redux-logger": "3.0.13",
         "@types/segment-analytics": "0.0.38",
         "@types/semver": "7.5.8",
+        "@types/ws": "8.5.13",
         "@vitejs/plugin-react": "4.3.1",
         "ansi-to-html": "0.7.2",
         "classnames": "2.5.1",
@@ -33320,7 +33321,8 @@
         "react-redux": "9.1.2",
         "react-router-dom": "6.24.1",
         "redux-logger": "3.0.6",
-        "unplugin-auto-expose": "0.3.0"
+        "unplugin-auto-expose": "0.3.0",
+        "ws": "8.18.0"
       }
     },
     "packages/creator-hub/node_modules/@types/react": {
@@ -33342,6 +33344,38 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "packages/creator-hub/node_modules/@types/ws": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "packages/creator-hub/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "packages/inspector": {

--- a/packages/creator-hub/main/src/index.ts
+++ b/packages/creator-hub/main/src/index.ts
@@ -12,6 +12,7 @@ import { runMigrations } from '/@/modules/migrations';
 import { getAnalytics, track } from './modules/analytics';
 import { tryOpenDevToolsOnPort } from './modules/app-args-handle';
 import { addEditorsPathsToConfig } from './modules/code';
+import { initDevHotReload } from './modules/dev-hot-reload';
 
 import '/@/security-restrictions';
 
@@ -62,6 +63,10 @@ app
     log.info(`[App] Ready v${app.getVersion()}`);
     initIpc();
     log.info('[IPC] Ready');
+
+    if (import.meta.env.DEV) {
+      initDevHotReload();
+    }
     await restoreOrCreateMainWindow();
     log.info('[BrowserWindow] Ready');
     await addEditorsPathsToConfig();

--- a/packages/creator-hub/main/src/modules/dev-hot-reload.ts
+++ b/packages/creator-hub/main/src/modules/dev-hot-reload.ts
@@ -1,0 +1,131 @@
+import { BrowserWindow } from 'electron';
+import log from 'electron-log/main';
+import WebSocket from 'ws';
+
+const RELOAD_SERVER_PORT = parseInt(import.meta.env.VITE_DEV_RELOAD_PORT || '9999', 10);
+const RECONNECT_INTERVAL = 2000;
+
+let ws: WebSocket | null = null;
+let reconnectTimeout: NodeJS.Timeout | null = null;
+let isShuttingDown = false;
+
+/**
+ * Reloads all open BrowserWindow instances.
+ * This is called when the main process code changes,
+ * allowing the renderer to reconnect with updated IPC handlers.
+ */
+function reloadAllWindows(): void {
+  const windows = BrowserWindow.getAllWindows();
+  log.info(`[dev-hot-reload] Reloading ${windows.length} window(s)...`);
+
+  for (const window of windows) {
+    if (!window.isDestroyed()) {
+      window.webContents.reload();
+    }
+  }
+}
+
+/**
+ * Connects to the reload signal server.
+ * Automatically reconnects if the connection is lost.
+ */
+function connect(): void {
+  if (isShuttingDown) return;
+
+  try {
+    ws = new WebSocket(`ws://localhost:${RELOAD_SERVER_PORT}`);
+
+    ws.on('open', () => {
+      log.info('[dev-hot-reload] Connected to reload server');
+      if (reconnectTimeout) {
+        clearTimeout(reconnectTimeout);
+        reconnectTimeout = null;
+      }
+    });
+
+    ws.on('message', (data: WebSocket.RawData) => {
+      try {
+        const message = JSON.parse(data.toString());
+        if (message.type === 'main-reload') {
+          log.info('[dev-hot-reload] Received reload signal, reloading windows...');
+          reloadAllWindows();
+        }
+      } catch (err) {
+        log.error('[dev-hot-reload] Failed to parse message:', err);
+      }
+    });
+
+    ws.on('close', () => {
+      log.info('[dev-hot-reload] Disconnected from reload server');
+      ws = null;
+      scheduleReconnect();
+    });
+
+    ws.on('error', (err: Error) => {
+      // ECONNREFUSED is expected when the reload server isn't running yet
+      if ((err as NodeJS.ErrnoException).code !== 'ECONNREFUSED') {
+        log.error('[dev-hot-reload] WebSocket error:', err.message);
+      }
+      ws?.close();
+    });
+  } catch (err) {
+    log.error('[dev-hot-reload] Failed to create WebSocket:', err);
+    scheduleReconnect();
+  }
+}
+
+/**
+ * Schedules a reconnection attempt after a delay.
+ */
+function scheduleReconnect(): void {
+  if (isShuttingDown || reconnectTimeout) return;
+
+  reconnectTimeout = setTimeout(() => {
+    reconnectTimeout = null;
+    connect();
+  }, RECONNECT_INTERVAL);
+}
+
+/**
+ * Initializes the development hot reload system.
+ * This should only be called in development mode.
+ *
+ * The hot reload system:
+ * 1. Connects to the reload signal server (started by watch.js)
+ * 2. Listens for 'main-reload' signals
+ * 3. Reloads all BrowserWindow instances when signaled
+ *
+ * This allows the main process to be "hot reloaded" without
+ * completely restarting the Electron application.
+ */
+export function initDevHotReload(): void {
+  if (import.meta.env.PROD) {
+    log.warn('[dev-hot-reload] Attempted to init in production mode, skipping');
+    return;
+  }
+
+  log.info('[dev-hot-reload] Initializing development hot reload...');
+  connect();
+
+  // Clean up on app quit
+  process.on('beforeExit', () => {
+    shutdown();
+  });
+}
+
+/**
+ * Shuts down the hot reload system.
+ */
+export function shutdown(): void {
+  isShuttingDown = true;
+
+  if (reconnectTimeout) {
+    clearTimeout(reconnectTimeout);
+    reconnectTimeout = null;
+  }
+
+  if (ws) {
+    ws.close();
+    ws = null;
+  }
+}

--- a/packages/creator-hub/package.json
+++ b/packages/creator-hub/package.json
@@ -45,6 +45,7 @@
     "@types/redux-logger": "3.0.13",
     "@types/segment-analytics": "0.0.38",
     "@types/semver": "7.5.8",
+    "@types/ws": "8.5.13",
     "@vitejs/plugin-react": "4.3.1",
     "ansi-to-html": "0.7.2",
     "classnames": "2.5.1",
@@ -60,7 +61,8 @@
     "react-redux": "9.1.2",
     "react-router-dom": "6.24.1",
     "redux-logger": "3.0.6",
-    "unplugin-auto-expose": "0.3.0"
+    "unplugin-auto-expose": "0.3.0",
+    "ws": "^8.18.0"
   },
   "main": "main/dist/index.js",
   "private": true,

--- a/packages/creator-hub/scripts/reload-server.js
+++ b/packages/creator-hub/scripts/reload-server.js
@@ -1,0 +1,96 @@
+import { WebSocketServer } from 'ws';
+
+/** @type {WebSocketServer | null} */
+let wss = null;
+
+/** @type {Set<import('ws').WebSocket>} */
+const clients = new Set();
+
+/**
+ * Starts the reload signal server.
+ * This WebSocket server is used to communicate reload signals
+ * from the watch script to the running Electron main process.
+ *
+ * @returns {Promise<WebSocketServer>}
+ */
+export function startReloadServer(port = 9999) {
+  return new Promise((resolve, reject) => {
+    if (wss) {
+      resolve(wss);
+      return;
+    }
+
+    wss = new WebSocketServer({ port });
+
+    wss.on('listening', () => {
+      console.log(`[reload-server] Hot reload server listening on port ${port}`);
+      resolve(wss);
+    });
+
+    wss.on('error', err => {
+      if (err.code === 'EADDRINUSE') {
+        console.warn(
+          `[reload-server] Port ${port} in use, attempting to continue without reload server`,
+        );
+        wss = null;
+        resolve(null);
+      } else {
+        reject(err);
+      }
+    });
+
+    wss.on('connection', ws => {
+      clients.add(ws);
+      console.log(`[reload-server] Client connected (total: ${clients.size})`);
+
+      ws.on('close', () => {
+        clients.delete(ws);
+        console.log(`[reload-server] Client disconnected (total: ${clients.size})`);
+      });
+
+      ws.on('error', err => {
+        console.error('[reload-server] Client error:', err.message);
+        clients.delete(ws);
+      });
+    });
+  });
+}
+
+/**
+ * Sends a reload signal to all connected clients (Electron main processes).
+ * This triggers a window reload instead of a full app restart.
+ */
+export function sendReloadSignal() {
+  if (clients.size === 0) {
+    console.log('[reload-server] No clients connected, cannot send reload signal');
+    return false;
+  }
+
+  const message = JSON.stringify({ type: 'main-reload', timestamp: Date.now() });
+
+  for (const client of clients) {
+    if (client.readyState === client.OPEN) {
+      client.send(message);
+    } else {
+      clients.delete(client);
+    }
+  }
+
+  console.log(`[reload-server] Sent reload signal to ${clients.size} client(s)`);
+  return true;
+}
+
+/**
+ * Stops the reload server and closes all connections.
+ */
+export function stopReloadServer() {
+  if (wss) {
+    for (const client of clients) {
+      client.close();
+    }
+    clients.clear();
+    wss.close();
+    wss = null;
+    console.log('[reload-server] Server stopped');
+  }
+}

--- a/packages/creator-hub/types/env.d.ts
+++ b/packages/creator-hub/types/env.d.ts
@@ -25,6 +25,7 @@ interface ImportMetaEnv {
   VITE_SEGMENT_INSPECTOR_API_KEY: string | undefined;
 
   // Local Development
+  VITE_DEV_RELOAD_PORT: string | undefined;
   VITE_INSPECTOR_PORT: string | undefined;
   VITE_ASSET_PACKS_CONTENT_URL: string | undefined;
   VITE_ASSET_PACKS_JS_PORT: string | undefined;


### PR DESCRIPTION
# Optimize main hot reload

## Context and Problem Statement
The current hot-reload implementation in `scripts/watch.js` kills and restarts the entire Electron application whenever there's a change in the main process code.

## Summary of Changes
The changes implement a hot reload system for the Electron main process during development. Here's what each piece does:
1. `reload-server.js` — WebSocket Reload Signal Server
2. `dev-hot-reload.ts` — Electron Main Process Client
3. `watch.js` — Modified Build Watcher

### Architecture Summary
<img width="1072" height="561" alt="image" src="https://github.com/user-attachments/assets/2bfb7d6c-42f8-40d3-a6ff-dd5cd5d29db8" />

closes: #643 
