### PR TITLE
fix: babylon transparency materials

### DIFF
--- a/packages/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
@@ -278,9 +278,6 @@ export function processGLTFAssetContainer(assetContainer: BABYLON.AssetContainer
       if (mesh.geometry && !assetContainer.geometries.includes(mesh.geometry)) {
         assetContainer.geometries.push(mesh.geometry);
       }
-      if (mesh.material instanceof BABYLON.Material) {
-        mesh.material.alphaMode = 0;
-      }
     }
     mesh.subMeshes &&
       mesh.subMeshes.forEach(subMesh => {


### PR DESCRIPTION
# fix: babylon transparency materials

## Context and Problem Statement
When placing things in the inspector, anything that is transparent or semi-transparent is rendered as fully opaque
This can sometimes bring problems when trying to position things properly

## Solution
Materials with transparency (alpha blend, alpha test, or auto-detected) now render correctly in the inspector, when they load on the scene the first time and also when they are cloned.

## Testing
- [ ] Test transparency in scene with png image with transparency on it [platformer-dcl.zip](https://github.com/user-attachments/files/24213797/platformer-dcl.zip)
- [ ] Test copy & paste behavior on entity with transparency [rock1.zip](https://github.com/user-attachments/files/23752437/rock1.zip)

## Screenshots
Transparency before:

https://github.com/user-attachments/assets/c9731d90-aef9-43d8-85f3-d6396130c199

Transparency after:

https://github.com/user-attachments/assets/b65b7924-e1ff-4188-ac96-cf52ab42ec08



Copy & paste before:

https://github.com/user-attachments/assets/5d0b9e11-65a7-484a-ac13-07cf15231de0

Copy & paste after:

https://github.com/user-attachments/assets/81b0192e-73ec-4db9-b6e3-5dfd699a43e2



closes: #904 
