### PR TITLE
fix: custom axis indicator with north sign arrow

### DIFF
--- a/packages/inspector/src/lib/babylon/decentraland/axis-indicator.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/axis-indicator.ts
@@ -1,0 +1,111 @@
+import type { Mesh, Scene, TransformNode } from '@babylonjs/core';
+import { Color3, MeshBuilder, StandardMaterial, Vector3 } from '@babylonjs/core';
+
+const AXIS_CONFIG = {
+  length: 1,
+  thickness: 0.05,
+  arrow: {
+    height: 0.375,
+    diameter: 0.18,
+  },
+};
+
+const AXIS_COLORS = {
+  x: { diffuse: new Color3(0.9, 0.2, 0.2), emissive: new Color3(0.6, 0, 0) },
+  y: { diffuse: new Color3(0.2, 0.9, 0.2), emissive: new Color3(0, 0.6, 0) },
+  z: { diffuse: new Color3(0.2, 0.2, 0.9), emissive: new Color3(0, 0, 0.6) },
+};
+
+function createAxisMaterial(
+  name: string,
+  diffuseColor: Color3,
+  emissiveColor: Color3,
+  scene: Scene,
+): StandardMaterial {
+  const material = new StandardMaterial(`axis_${name}_material`, scene);
+  material.diffuseColor = diffuseColor;
+  material.emissiveColor = emissiveColor;
+  material.specularColor = Color3.Black();
+  return material;
+}
+
+function createAxisLine(
+  name: string,
+  colors: { diffuse: Color3; emissive: Color3 },
+  direction: Vector3,
+  scene: Scene,
+  parent: TransformNode,
+  doubleSided: boolean = false,
+): Mesh {
+  const material = createAxisMaterial(name, colors.diffuse, colors.emissive, scene);
+  const length = doubleSided ? AXIS_CONFIG.length * 2 : AXIS_CONFIG.length;
+  const axis = MeshBuilder.CreateCylinder(
+    `axis_${name}_line`,
+    { height: length, diameter: AXIS_CONFIG.thickness },
+    scene,
+  );
+
+  if (!doubleSided) {
+    axis.position = direction.scale(AXIS_CONFIG.length / 2);
+  }
+
+  // Rotate cylinder to align with direction
+  if (direction.x !== 0) {
+    axis.rotation.z = -Math.PI / 2;
+  } else if (direction.z !== 0) {
+    axis.rotation.x = Math.PI / 2;
+  }
+
+  axis.material = material;
+  axis.isPickable = false;
+  axis.parent = parent;
+
+  return axis;
+}
+
+function createNorthArrow(scene: Scene, parent: TransformNode): Mesh[] {
+  const meshes: Mesh[] = [];
+  const axisLine = createAxisLine('z', AXIS_COLORS.z, new Vector3(0, 0, 1), scene, parent, true);
+  meshes.push(axisLine);
+
+  const material = createAxisMaterial(
+    'z_cone_material',
+    AXIS_COLORS.z.diffuse,
+    AXIS_COLORS.z.emissive,
+    scene,
+  );
+  const cone = MeshBuilder.CreateCylinder(
+    'z_cone_axis',
+    {
+      height: AXIS_CONFIG.arrow.height,
+      diameterTop: 0,
+      diameterBottom: AXIS_CONFIG.arrow.diameter,
+    },
+    scene,
+  );
+  cone.position = new Vector3(0, 0, AXIS_CONFIG.length - AXIS_CONFIG.arrow.height / 8);
+  cone.rotation.x = Math.PI / 2;
+  cone.material = material;
+  cone.isPickable = false;
+  cone.parent = parent;
+  meshes.push(cone);
+
+  return meshes;
+}
+
+export function createAxisIndicator(scene: Scene, parent: TransformNode): Mesh[] {
+  const meshes: Mesh[] = [];
+
+  // X-axis: Red line (East/West) - double-sided, no arrow tip
+  const xAxis = createAxisLine('x', AXIS_COLORS.x, new Vector3(1, 0, 0), scene, parent, true);
+
+  // Y-axis: Green line (Up) - single-sided, no arrow tip
+  const yAxis = createAxisLine('y', AXIS_COLORS.y, new Vector3(0, 1, 0), scene, parent, false);
+
+  // Z-axis: Blue arrow (North/South) - double-sided line WITH arrow tip on North
+  const zAxisMeshes = createNorthArrow(scene, parent);
+
+  meshes.push(xAxis, yAxis, ...zAxisMeshes);
+
+  return meshes;
+}

--- a/packages/inspector/src/lib/babylon/decentraland/layout-manager.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/layout-manager.ts
@@ -1,18 +1,10 @@
-import type {
-  AbstractMesh,
-  ArcRotateCamera,
-  IAxisDragGizmo,
-  Mesh,
-  Scene,
-  StandardMaterial,
-} from '@babylonjs/core';
+import type { AbstractMesh, ArcRotateCamera, Mesh, Scene } from '@babylonjs/core';
 import {
   Axis,
   BoundingBox,
   BoundingInfo,
   Color3,
   MeshBuilder,
-  PositionGizmo,
   Space,
   TransformNode,
   Vector3,
@@ -21,20 +13,7 @@ import { GridMaterial } from '@babylonjs/materials';
 import { memoize } from '../../logic/once';
 import type { Layout } from '../../utils/layout';
 import { PARCEL_SIZE, GROUND_MESH_PREFIX } from '../../utils/scene';
-
-function disableGizmo(gizmo: IAxisDragGizmo) {
-  gizmo.dragBehavior.detach();
-  copyColors(gizmo.disableMaterial, gizmo.hoverMaterial);
-  copyColors(gizmo.disableMaterial, gizmo.coloredMaterial);
-}
-
-function copyColors(source: StandardMaterial, target: StandardMaterial) {
-  target.diffuseColor = source.diffuseColor;
-  target.ambientColor = source.ambientColor;
-  target.emissiveColor = source.emissiveColor;
-  target.specularColor = source.specularColor;
-  target.alpha = source.alpha;
-}
+import { createAxisIndicator } from './axis-indicator';
 
 function center(scene: Scene, layout: Layout) {
   if (!scene.activeCamera) return;
@@ -56,12 +35,9 @@ export const getLayoutManager = memoize((scene: Scene) => {
   let layout: Layout | null = null;
 
   const layoutNode = new TransformNode('layout', scene);
-  const positionGizmo = new PositionGizmo(undefined, 0.5);
-  positionGizmo.attachedNode = layoutNode;
 
-  disableGizmo(positionGizmo.xGizmo);
-  disableGizmo(positionGizmo.yGizmo);
-  disableGizmo(positionGizmo.zGizmo);
+  // Create custom axis indicator with North arrow
+  createAxisIndicator(scene, layoutNode);
 
   const grid = new GridMaterial('layout_grid', scene);
   grid.gridRatio = 1;


### PR DESCRIPTION
# fix: custom axis indicator with north sign arrow

## Context and Problem Statement
When editing your scene in the Creator Hub, it's not clear which way is up. Sometimes you need to know this information because you want to align the entrance with a road, or with another adjacent scene, etc.

## Solution
- Axis indicator updated, colors added (matches the axis helper in top right).
- North indicator sign with arrow

## Testing

- [x] Test axis indicator in the origin corner of the scene

## Screenshots
<img width="449" height="306" alt="image" src="https://github.com/user-attachments/assets/345a48be-d544-4f8f-848f-cc987d9d2ec7" />

closes: #505 
