### PR TITLE
Fix: Smart Item dropdown UI overlap

### DIFF
--- a/packages/inspector/src/components/EntityInspector/GltfNodeModifiersInspector/GltfNodeModifiersInspector.css
+++ b/packages/inspector/src/components/EntityInspector/GltfNodeModifiersInspector/GltfNodeModifiersInspector.css
@@ -1,3 +1,3 @@
-.RightMenu {
+.GltfNodeModifiers .RightMenu {
   min-width: 200px;
 }


### PR DESCRIPTION
# Fix: Smart Item dropdown UI overlap

Closes https://github.com/decentraland/creator-hub/issues/876

## Context and Problem Statement

In Creator Hub, when adding the Admin Tool and selecting "Add Smart Item", the first dropdown has a UI overlap issue: a 3-dots menu (with the "Remove" option) is layered on top of the dropdown.

Additionally, the dropdown is only clickable when hovering over certain parts of the field — except for the arrow icon on the right side, which does not respond to clicks.

## Solution

The issue was caused by colliding css classes.

## Screenshots


https://github.com/user-attachments/assets/58f420b9-a199-4a02-a30c-c94597d6356e


