### PR TITLE
feat: support jpeg and update asset when already exists in catalog

### DIFF
--- a/packages/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
+++ b/packages/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
@@ -19,7 +19,6 @@ import { type TreeNode } from '../../ProjectAssetExplorer/ProjectView';
 import { type AssetNodeItem } from '../../ProjectAssetExplorer/types';
 
 import { TextField } from '../TextField';
-import { Message, MessageType } from '../Message';
 
 import { type Props } from './types';
 
@@ -220,7 +219,7 @@ const FileUploadField: React.FC<Props> = ({
           label={label}
           onChange={handleChangeTextField}
           value={removeBase(path)}
-          error={!!value && hasError}
+          error={hasError ? error || errorMessage || 'File not valid.' : undefined}
           disabled={disabled}
           debounceTime={200}
           autoSelect
@@ -241,12 +240,6 @@ const FileUploadField: React.FC<Props> = ({
           </button>
         )}
       </div>
-      {hasError && (
-        <Message
-          text={error || errorMessage}
-          type={MessageType.ERROR}
-        />
-      )}
     </div>
   );
 };

--- a/packages/inspector/src/lib/data-layer/host/fs-utils.ts
+++ b/packages/inspector/src/lib/data-layer/host/fs-utils.ts
@@ -59,6 +59,7 @@ export const EXTENSIONS = [
   '.composite.bin',
   '.gltf',
   '.jpg',
+  '.jpeg',
   '.mp3',
   '.ogg',
   '.wav',


### PR DESCRIPTION
# Fix: File system import not updating component when asset already exists

## Problem
When importing an image from the file system that already existed in the asset catalog, the component value wasn't being updated correctly. The `onDrop` callback was firing before the asset catalog had refreshed, causing a race condition.

Additionally, JPEG files (with `.jpeg` extension) were not being recognized by the asset catalog.

## Solution
- Added `assetsRefBeforeImport` ref to track the catalog state before import. The `useEffect` now waits until the catalog reference actually changes (indicating a refresh) before calling `onDrop`. This ensures the PUT_COMPONENT happens only after the import is complete, without relying on arbitrary timeouts.
- Added `.jpeg` to the supported extensions in `fs-utils.ts`
- Fixed duplicate "File not valid" error messages

## Before
https://github.com/user-attachments/assets/689f1a0c-2954-46c2-8fcf-9616990f8ac6

##After
https://github.com/user-attachments/assets/05912ca6-569d-4368-bf3a-c3b1f563d1e6




