### PR TITLE
After duplicating keep same gizmo as before

### DIFF
--- a/packages/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/inspector/src/components/Renderer/Renderer.tsx
@@ -104,8 +104,12 @@ const Renderer: React.FC = () => {
     const camera = sdk.scene.activeCamera!;
     camera.detachControl();
     const selectedEntitites = sdk.operations.getSelectedEntities();
+    const preferredGizmo =
+      selectedEntitites.length > 0
+        ? sdk.components.Selection.getOrNull(selectedEntitites[0])?.gizmo
+        : undefined;
     sdk.operations.removeSelectedEntities();
-    selectedEntitites.forEach(entity => sdk.operations.duplicateEntity(entity));
+    selectedEntitites.forEach(entity => sdk.operations.duplicateEntity(entity, preferredGizmo));
     void sdk.operations.dispatch();
     setTimeout(() => {
       camera.attachControl(canvasRef.current, true);
@@ -120,8 +124,13 @@ const Renderer: React.FC = () => {
 
   const pasteSelectedEntities = useCallback(() => {
     if (!sdk) return;
+    const selectedEntities = sdk.operations.getSelectedEntities();
+    const preferredGizmo =
+      selectedEntities.length > 0
+        ? sdk.components.Selection.getOrNull(selectedEntities[0])?.gizmo
+        : undefined;
     sdk.operations.removeSelectedEntities();
-    copyEntities.forEach(entity => sdk.operations.duplicateEntity(entity));
+    copyEntities.forEach(entity => sdk.operations.duplicateEntity(entity, preferredGizmo));
     void sdk.operations.dispatch();
   }, [sdk, copyEntities]);
 

--- a/packages/inspector/src/components/Tree/Tree.tsx
+++ b/packages/inspector/src/components/Tree/Tree.tsx
@@ -13,6 +13,7 @@ import { Edit as EditInput } from './Edit';
 import { DropType, calculateDropType } from './utils';
 import { useSdk } from '../../hooks/sdk/useSdk';
 import { useAppSelector } from '../../redux/hooks';
+import { GizmoType } from '../../lib/utils/gizmo';
 import { getEntitiesOutOfBoundaries } from '../../redux/scene-metrics';
 import { InfoTooltip } from '../ui';
 
@@ -44,7 +45,7 @@ type Props<T> = {
   onRename: (value: T, label: string) => void;
   onAddChild: (value: T, label: string) => void;
   onRemove: (value: T) => void;
-  onDuplicate: (value: T) => void;
+  onDuplicate: (value: T, preferredGizmo?: GizmoType) => void;
   getDragContext?: () => unknown;
   dndType?: string;
   onLastSelectedChange?: (value: T) => void;
@@ -284,15 +285,19 @@ export function Tree<T>() {
       const handleDuplicate = () => {
         if (isEntity && sdk) {
           const selectedEntities = sdk.operations.getSelectedEntities();
+          const preferredGizmo =
+            selectedEntities.length > 0
+              ? sdk.components.Selection.getOrNull(selectedEntities[0])?.gizmo
+              : undefined;
           sdk.operations.removeSelectedEntities();
           if (selectedEntities.length > 1) {
             selectedEntities.forEach(entity => {
               if (typeof entity === typeof value) {
-                onDuplicate(entity as T);
+                onDuplicate(entity as T, preferredGizmo);
               }
             });
           } else {
-            onDuplicate(value);
+            onDuplicate(value, preferredGizmo);
           }
         } else {
           onDuplicate(value);

--- a/packages/inspector/src/hooks/sdk/useTree.ts
+++ b/packages/inspector/src/hooks/sdk/useTree.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState, useEffect } from 'react';
 import type { Entity } from '@dcl/ecs';
 
+import type { GizmoType } from '../../lib/utils/gizmo';
 import {
   CAMERA,
   findParent,
@@ -160,9 +161,9 @@ export const useTree = () => {
   );
 
   const duplicate = useCallback(
-    async (entity: Entity) => {
+    async (entity: Entity, preferredGizmo?: GizmoType) => {
       if (entity === ROOT || !sdk) return;
-      sdk.operations.duplicateEntity(entity);
+      sdk.operations.duplicateEntity(entity, preferredGizmo);
       await sdk.operations.dispatch();
       handleUpdate();
     },

--- a/packages/inspector/src/lib/sdk/operations/duplicate-entity.ts
+++ b/packages/inspector/src/lib/sdk/operations/duplicate-entity.ts
@@ -9,12 +9,13 @@ import type { EditorComponents, Node } from '../components';
 import { EditorComponentNames } from '../components';
 import { createEnumEntityId } from '../enum-entity';
 import { getNodes, pushChildToNodes } from '../nodes';
+import type { GizmoType } from '../../utils/gizmo';
 import updateSelectedEntity from './update-selected-entity';
 import { generateUniqueName } from './add-child';
 
 export function duplicateEntity(engine: IEngine) {
   const enumEntityId = createEnumEntityId(engine);
-  return function duplicateEntity(entity: Entity) {
+  return function duplicateEntity(entity: Entity, preferredGizmo?: GizmoType) {
     const Transform = engine.getComponent(TransformEngine.componentId) as typeof TransformEngine;
     const Nodes = engine.getComponent(EditorComponentNames.Nodes) as EditorComponents['Nodes'];
     const Triggers = engine.getComponent(
@@ -64,7 +65,7 @@ export function duplicateEntity(engine: IEngine) {
     // This creates only ONE undo operation for all node changes, instead of one per entity.
     Nodes.createOrReplace(engine.RootEntity, { value: newNodes as Node[] });
 
-    updateSelectedEntity(engine)(cloned, true);
+    updateSelectedEntity(engine)(cloned, true, preferredGizmo);
     return cloned;
   };
 }

--- a/packages/inspector/src/lib/sdk/operations/update-selected-entity.ts
+++ b/packages/inspector/src/lib/sdk/operations/update-selected-entity.ts
@@ -21,7 +21,11 @@ function isAncestorOf(ancestorId: Entity, targetId: Entity, nodes: Node[]): bool
 }
 
 export function updateSelectedEntity(engine: IEngine) {
-  return function updateSelectedEntity(entity: Entity, multiple: boolean = false) {
+  return function updateSelectedEntity(
+    entity: Entity,
+    multiple: boolean = false,
+    preferredGizmo?: GizmoType,
+  ) {
     let gizmo = GizmoType.FREE;
     let deletedSelection = false;
 
@@ -56,8 +60,8 @@ export function updateSelectedEntity(engine: IEngine) {
     if (multiple && Selection.has(entity)) {
       Selection.deleteFrom(entity);
     } else if (!Selection.has(entity) || deletedSelection) {
-      // then select new entity
-      Selection.createOrReplace(entity, { gizmo });
+      // then select new entity (preserve preferred gizmo when provided, e.g. after duplicate)
+      Selection.createOrReplace(entity, { gizmo: preferredGizmo ?? gizmo });
     }
 
     store.dispatch(clearError());


### PR DESCRIPTION
## Fix: Preserve gizmo tool after duplicate/paste

**Problem**
After duplicating one or more entities (context menu or Ctrl/Cmd+D), or pasting,
the tool always switched to free-move. The active tool (rotate/scale/position)
should stay the same.

**Cause**
Duplicate/paste flows called `removeSelectedEntities()` before running
`duplicateEntity()`. When `updateSelectedEntity(cloned, true)` ran, there were
no selected entities left, so it never read a previous gizmo and kept the
default `GizmoType.FREE`.

**Changes**
- **update-selected-entity.ts**: Add optional 3rd arg `preferredGizmo`. When
  creating selection, use `preferredGizmo ?? gizmo` so the caller can pass the
  current tool when there’s no previous selection.
- **duplicate-entity.ts**: Add optional 2nd arg `preferredGizmo` and pass it to
  `updateSelectedEntity(engine)(cloned, true, preferredGizmo)`.
- **Tree.tsx**: Before `removeSelectedEntities()`, read gizmo from the first
  selected entity and pass it into `onDuplicate(value, preferredGizmo)` (and
  for multi-selection).
- **useTree.ts**: `duplicate` accepts optional 2nd param `preferredGizmo` and
  forwards it to `duplicateEntity(entity, preferredGizmo)`.
- **Renderer.tsx**: For Duplicate (Ctrl/Cmd+D) and Paste (Ctrl/Cmd+V), read
  current gizmo from the first selected entity before clearing selection, then
  pass it into each `duplicateEntity(entity, preferredGizmo)`.

Duplicate and paste now keep the current tool (move/rotate/scale/free-move).