### PR TITLE
transform feedback while dragging

### DIFF
--- a/packages/inspector/src/hooks/sdk/useComponentInput.ts
+++ b/packages/inspector/src/hooks/sdk/useComponentInput.ts
@@ -235,6 +235,15 @@ export const useMultiComponentInput = <ComponentValueType extends object, InputT
   }
   const sdk = useSdk();
 
+  // During live drag (skipEngineSync events), the inspector engine is NOT
+  // updated, so getComponentValue() returns stale data.  We accumulate
+  // per-entity overrides in this ref so that when multiple entities are
+  // dragged together (events fire synchronously for each entity), we always
+  // merge with the latest values.  The map is cleared when a normal (non-
+  // skipEngineSync) event arrives, meaning the engine is back in sync.
+  const liveDragOverridesRef = useRef(new Map<Entity, ComponentValueType>());
+  const pendingLiveDragMergeRef = useRef(false);
+
   // Get initial merged value from all entities
   const initialEntityValues = getEntityAndComponentValue(entities, component);
   const initialMergedValue = useMemo(
@@ -249,6 +258,13 @@ export const useMultiComponentInput = <ComponentValueType extends object, InputT
   const [value, setMergeValue] = useState(initialMergedValue);
   const [isValid, setIsValid] = useState(true);
   const [isFocused, setIsFocused] = useState(false);
+
+  // Refs for values accessed inside the microtask-deferred live drag merge,
+  // so the closure always reads the latest state.
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const isFocusedRef = useRef(isFocused);
+  isFocusedRef.current = isFocused;
 
   // Handle input updates
   const handleUpdate = useCallback(
@@ -319,17 +335,42 @@ export const useMultiComponentInput = <ComponentValueType extends object, InputT
 
       if (!isRelevantUpdate) return;
 
-      const updatedEntityValues = getEntityAndComponentValue(entities, component);
-      const newMergedValue = mergeComponentValues(
-        updatedEntityValues.map(([_, component]) => component),
-        fromComponentValueToInput,
+      if (event.skipEngineSync) {
+        // Live drag: engine was NOT updated, so we can't trust getComponentValue.
+        // Store the override — all N entity events fire synchronously, so we
+        // defer the expensive merge to a single microtask after the batch.
+        liveDragOverridesRef.current.set(event.entity, event.value as ComponentValueType);
+        if (!pendingLiveDragMergeRef.current) {
+          pendingLiveDragMergeRef.current = true;
+          queueMicrotask(() => {
+            pendingLiveDragMergeRef.current = false;
+            const componentValues = entities.map(
+              entity =>
+                liveDragOverridesRef.current.get(entity) ??
+                (getComponentValue(entity, component) as ComponentValueType),
+            );
+            const newMergedValue = mergeComponentValues(componentValues, fromComponentValueToInput);
+            if (hasDiff(valueRef.current, newMergedValue, 2) && !isFocusedRef.current) {
+              setMergeValue(newMergedValue);
+            }
+          });
+        }
+        return;
+      }
+
+      // Normal event: engine is in sync, clear any stale overrides.
+      liveDragOverridesRef.current.clear();
+      const componentValues = getEntityAndComponentValue(entities, component).map(
+        ([_, compValue]) => compValue,
       );
 
-      if (!hasDiff(value, newMergedValue, 2) || isFocused) return;
+      const newMergedValue = mergeComponentValues(componentValues, fromComponentValueToInput);
+
+      if (!hasDiff(valueRef.current, newMergedValue, 2) || isFocusedRef.current) return;
 
       setMergeValue(newMergedValue);
     },
-    [entities, component, fromComponentValueToInput, value, isFocused, ...deps],
+    [entities, component, fromComponentValueToInput, ...deps],
   );
 
   useEffect(() => {

--- a/packages/inspector/src/lib/babylon/decentraland/GizmoManager.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/GizmoManager.ts
@@ -7,6 +7,7 @@ import {
 } from '@babylonjs/core';
 import { Vector3 as DclVector3 } from '@dcl/ecs-math';
 import { GizmoType } from '../../utils/gizmo';
+import { suppressCrdtUpdates, resumeCrdtUpdates } from '../../sdk/crdt-update-guard';
 import type { SceneContext } from './SceneContext';
 import type { EcsEntity } from './EcsEntity';
 import { GizmoType as TransformerType } from './gizmos/types';
@@ -24,6 +25,34 @@ export function createGizmoManager(context: SceneContext) {
   let isEnabled = true;
   let currentTransformer: IGizmoTransformer | null = null;
   let isUpdatingFromGizmo = false;
+  let liveDragCallback: ((entities: EcsEntity[]) => void) | null = null;
+  let isDragInProgress = false;
+
+  function notifyLiveDrag() {
+    if (!isDragInProgress) {
+      isDragInProgress = true;
+      // Suppress renderer engine CRDT updates during drag to prevent
+      // intermediate undo entries from async message round-trips.
+      suppressCrdtUpdates(context.engine);
+    }
+    liveDragCallback?.(selectedEntities);
+  }
+
+  function endDragSuppression() {
+    if (isDragInProgress) {
+      isDragInProgress = false;
+      resumeCrdtUpdates(context.engine);
+    }
+  }
+
+  function dispatchAndClearFlag(): void {
+    try {
+      endDragSuppression();
+      void context.operations.dispatch();
+    } finally {
+      isUpdatingFromGizmo = false;
+    }
+  }
 
   // Spawn point gizmo state
   let attachedSpawnPointIndex: number | null = null;
@@ -256,11 +285,6 @@ export function createGizmoManager(context: SceneContext) {
     }
   }
 
-  function dispatchAndClearFlag(): void {
-    void context.operations.dispatch();
-    isUpdatingFromGizmo = false;
-  }
-
   function updateSnap() {
     if (currentTransformer && 'setSnapDistance' in currentTransformer) {
       if (gizmoManager.rotationGizmoEnabled) {
@@ -288,6 +312,7 @@ export function createGizmoManager(context: SceneContext) {
     setEnabled(value: boolean) {
       isEnabled = value;
       if (!isEnabled) {
+        endDragSuppression();
         gizmoManager.attachToNode(null);
       }
     },
@@ -307,6 +332,7 @@ export function createGizmoManager(context: SceneContext) {
       return selectedEntities[0];
     },
     removeEntity(entity: EcsEntity) {
+      endDragSuppression();
       selectedEntities = selectedEntities.filter(e => e.entityId !== entity.entityId);
       if (selectedEntities.length === 0 && attachedSpawnPointIndex === null) {
         gizmoManager.attachToNode(null);
@@ -327,6 +353,11 @@ export function createGizmoManager(context: SceneContext) {
       return [GizmoType.FREE, GizmoType.POSITION, GizmoType.ROTATION, GizmoType.SCALE] as const;
     },
     setGizmoType(type: GizmoType) {
+      // Safety: ensure suppression is lifted before switching gizmo types.
+      // If a drag is interrupted (e.g. gizmo switch mid-drag), endDragSuppression
+      // would never be called from the drag-end callback.
+      endDragSuppression();
+
       // Then disable all Babylon gizmos
       gizmoManager.positionGizmoEnabled = false;
       gizmoManager.rotationGizmoEnabled = false;
@@ -345,7 +376,11 @@ export function createGizmoManager(context: SceneContext) {
           activateTransformer(positionTransformer, snapManager.getPositionSnap());
           // Set up callbacks for ECS updates
           if ('setUpdateCallbacks' in positionTransformer) {
-            positionTransformer.setUpdateCallbacks(updateEntityPosition, dispatchAndClearFlag);
+            positionTransformer.setUpdateCallbacks(
+              updateEntityPosition,
+              dispatchAndClearFlag,
+              notifyLiveDrag,
+            );
           }
           break;
         }
@@ -359,6 +394,7 @@ export function createGizmoManager(context: SceneContext) {
               updateEntityPosition,
               dispatchAndClearFlag,
               context,
+              notifyLiveDrag,
             );
           }
           break;
@@ -368,7 +404,11 @@ export function createGizmoManager(context: SceneContext) {
           activateTransformer(scaleTransformer, snapManager.getScaleSnap());
           // Set up callbacks for ECS updates
           if ('setUpdateCallbacks' in scaleTransformer) {
-            scaleTransformer.setUpdateCallbacks(updateEntityScale, dispatchAndClearFlag);
+            scaleTransformer.setUpdateCallbacks(
+              updateEntityScale,
+              dispatchAndClearFlag,
+              notifyLiveDrag,
+            );
           }
           break;
         }
@@ -381,7 +421,11 @@ export function createGizmoManager(context: SceneContext) {
           }
           // Set up callbacks for ECS updates
           if ('setUpdateCallbacks' in freeTransformer) {
-            freeTransformer.setUpdateCallbacks(updateEntityPosition, dispatchAndClearFlag);
+            freeTransformer.setUpdateCallbacks(
+              updateEntityPosition,
+              dispatchAndClearFlag,
+              notifyLiveDrag,
+            );
           }
           // Set up callback to update gizmo position after drag ends
           if ('setOnDragEndCallback' in freeTransformer) {
@@ -415,6 +459,9 @@ export function createGizmoManager(context: SceneContext) {
       if (selectedEntities.length > 0) {
         updateGizmoTransform();
       }
+    },
+    setLiveDragCallback(cb: (entities: EcsEntity[]) => void) {
+      liveDragCallback = cb;
     },
     /**
      * Attaches the position gizmo to a spawn point transform node
@@ -561,6 +608,7 @@ export function createGizmoManager(context: SceneContext) {
     },
     detachFromSpawnPoint() {
       if (attachedSpawnPointIndex === null) return;
+      endDragSuppression();
 
       if (attachedSpawnPointTarget === 'cameraTarget') {
         context.spawnPoints.setCameraTargetOutOfBoundsVisible(attachedSpawnPointIndex, false);

--- a/packages/inspector/src/lib/sdk/connect-stream.ts
+++ b/packages/inspector/src/lib/sdk/connect-stream.ts
@@ -5,6 +5,7 @@ import type { CrdtStreamMessage } from '../data-layer/remote-data-layer';
 import type { DataLayerRpcClient } from '../data-layer/types';
 import { consumeAllMessagesInto } from '../logic/consume-stream';
 import { serializeCrdtMessages } from './crdt-logger';
+import { isCrdtUpdateSuppressed } from './crdt-update-guard';
 
 export function connectCrdtToEngine(
   engine: IEngine,
@@ -38,7 +39,13 @@ export function connectCrdtToEngine(
       );
     }
     transport.onmessage!(message);
-    void engine.update(1);
+    // During gizmo drag, skip engine.update() on the renderer engine to prevent
+    // intermediate CRDT messages from creating unwanted undo entries.
+    // Messages are still buffered by the transport and will be processed when
+    // engine.update() runs at drag end (via dispatch).
+    if (!isCrdtUpdateSuppressed(engine)) {
+      void engine.update(1);
+    }
   }
 
   consumeAllMessagesInto(dataLayerStream(outgoingMessagesStream), onMessage).catch(e => {

--- a/packages/inspector/src/lib/sdk/crdt-update-guard.ts
+++ b/packages/inspector/src/lib/sdk/crdt-update-guard.ts
@@ -1,0 +1,22 @@
+import type { IEngine } from '@dcl/ecs';
+/**
+ * Tracks which engines should skip CRDT updates (engine.update calls from
+ * incoming data-layer messages).  Used during gizmo drag to prevent
+ * intermediate round-trips that create unwanted undo entries.
+ *
+ * A WeakSet is used so entries are automatically cleaned up if the engine
+ * is garbage-collected, and we avoid mutating frozen engine objects.
+ */
+const suppressedEngines = new WeakSet<IEngine>();
+
+export function suppressCrdtUpdates(engine: IEngine) {
+  suppressedEngines.add(engine);
+}
+
+export function resumeCrdtUpdates(engine: IEngine) {
+  suppressedEngines.delete(engine);
+}
+
+export function isCrdtUpdateSuppressed(engine: IEngine): boolean {
+  return suppressedEngines.has(engine);
+}


### PR DESCRIPTION
Context
When using move/rotate/scale gizmos, the Transform inspector panel only updates its position/rotation/scale values when the mouse is released (drag end). The user wants to see live value updates during drag. This must not affect undo/redo (each drag should remain a single undo entry) and must not significantly impact performance.

Root Cause
The system has two engines: a renderer engine (Babylon/3D scene) and an inspector engine (React UI). They sync via CRDT messages through a data layer. Currently:

During drag: gizmos update Babylon entity positions visually AND update the renderer engine's ECS (for Rotation/Scale/Free gizmos) or only Babylon positions (for Position gizmo)
At drag end: dispatch() → engine.update() → CRDT messages sent to data layer → data layer syncs to inspector engine → inspector engine emits change events → React UI updates
The data layer creates one undo entry per transaction (per engine.update() call)
So the inspector UI only updates at drag end because CRDT sync only happens at drag end.

Approach
Add a live drag notification mechanism that directly updates the inspector engine's components and emits change events during drag, bypassing the CRDT pipeline entirely. This avoids undo entries while giving the UI live values.


Changes made across 7 files:
Gizmo classes (4 files) - Added onLiveDragUpdate callback that fires during each drag frame:

[PositionGizmo.ts](vscode-webview://192g7arhglapelpn819ncbssts69v7qmiointn3c4rodmo84dlk6/packages/inspector/src/lib/babylon/decentraland/gizmos/PositionGizmo.ts) - Also added updateEntitiesInRealTime() call during drag (was previously only at drag end)
[RotationGizmo.ts](vscode-webview://192g7arhglapelpn819ncbssts69v7qmiointn3c4rodmo84dlk6/packages/inspector/src/lib/babylon/decentraland/gizmos/RotationGizmo.ts) - Added callback after existing per-frame entity rotation updates
[ScaleGizmo.ts](vscode-webview://192g7arhglapelpn819ncbssts69v7qmiointn3c4rodmo84dlk6/packages/inspector/src/lib/babylon/decentraland/gizmos/ScaleGizmo.ts) - Added callback in axis drag, plane drag, and uniform scale handlers
[FreeGizmo.ts](vscode-webview://192g7arhglapelpn819ncbssts69v7qmiointn3c4rodmo84dlk6/packages/inspector/src/lib/babylon/decentraland/gizmos/FreeGizmo.ts) - Added callback after moveEntitiesToPivot
[GizmoManager.ts](vscode-webview://192g7arhglapelpn819ncbssts69v7qmiointn3c4rodmo84dlk6/packages/inspector/src/lib/babylon/decentraland/GizmoManager.ts) - Added liveDragCallback + notifyLiveDrag() function, passes it to all gizmo setUpdateCallbacks, and exposes setLiveDragCallback() method

[context.ts](vscode-webview://192g7arhglapelpn819ncbssts69v7qmiointn3c4rodmo84dlk6/packages/inspector/src/lib/sdk/context.ts) - Wires the callback: during gizmo drag, reads transform from the renderer engine, updates the inspector engine's Transform component in-place, and emits change events on the SDK event emitter

How it works:
During drag: inspector engine component is updated directly + change events emitted → React hooks pick up the new values → UI updates live
The useComponentValue state→engine sync is a no-op because isComponentEqual returns true (we pre-updated the inspector component)
No engine.update() or CRDT messages during drag → no undo entries created
At drag end: normal dispatch() flow creates exactly one undo entry for the entire drag