### PR TITLE
chore: correct admin tools video-url text-align

### DIFF
--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/VideoUrl.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/VideoUrl.tsx
@@ -72,7 +72,7 @@ export function VideoControlURL({
         onChange={setVideoURL}
         value={videoURL}
         fontSize={16 * scaleFactor}
-        textAlign="top-left"
+        textAlign="middle-left"
         placeholder="Paste your video URL"
         placeholderColor={Color4.create(160 / 255, 155 / 255, 168 / 255, 1)}
         color={isActive ? Color4.Black() : Color4.fromHexString('#A09BA8')}


### PR DESCRIPTION
Corrected text align for admin tools video url ui input.

This is needed because an upcoming many-fixes [PR](https://github.com/decentraland/unity-explorer/pull/6846) for the Explorer fixes a previous issue that made UiInput actually ignore its `text-align`, so we discovered the current `"top-left"` is not the desired position, it's `"middle-left` (what was being applied by default with the bug that made the Explorer ignore that value for UiInput...)