### PR TITLE
fix: publish signal error

### DIFF
--- a/packages/creator-hub/renderer/src/lib/deploy.ts
+++ b/packages/creator-hub/renderer/src/lib/deploy.ts
@@ -44,7 +44,8 @@ export type AssetBundleRegistryResponse = {
 export type ErrorName =
   | 'MAX_RETRIES'
   | 'FETCH_STATUS'
-  | 'FETCH_ERROR'
+  | 'FETCH_TIMEOUT_ERROR'
+  | 'NO_INTERNET_CONNECTION'
   | 'CATALYST_SERVERS_EXHAUSTED'
   | 'DEPLOYMENT_NOT_FOUND'
   | 'DEPLOYMENT_FAILED'

--- a/packages/creator-hub/renderer/src/modules/store/deployment/slice.ts
+++ b/packages/creator-hub/renderer/src/modules/store/deployment/slice.ts
@@ -158,8 +158,16 @@ export const deploy = createAsyncThunk(
           );
         }
 
-        if (isFetchError(error, '*')) {
-          return rejectWithValue(new DeploymentError('FETCH_ERROR', componentsStatus, error));
+        if (isFetchError(error, 'REQUEST_TIMEOUT')) {
+          return rejectWithValue(
+            new DeploymentError('FETCH_TIMEOUT_ERROR', componentsStatus, error),
+          );
+        }
+
+        if (isFetchError(error, 'NO_INTERNET_CONNECTION')) {
+          return rejectWithValue(
+            new DeploymentError('NO_INTERNET_CONNECTION', componentsStatus, error),
+          );
         }
 
         if (retries <= 0) {

--- a/packages/creator-hub/renderer/src/modules/store/deployment/utils.ts
+++ b/packages/creator-hub/renderer/src/modules/store/deployment/utils.ts
@@ -314,8 +314,10 @@ export function translateError(error: SerializedError) {
       return t('modal.publish_project.deploy.deploying.errors.max_retries');
     case 'FETCH_STATUS':
       return t('modal.publish_project.deploy.deploying.errors.fetch_status');
-    case 'FETCH_ERROR':
-      return t('modal.publish_project.deploy.deploying.errors.fetch_error');
+    case 'FETCH_TIMEOUT_ERROR':
+      return t('modal.publish_project.deploy.deploying.errors.fetch_timeout_error');
+    case 'NO_INTERNET_CONNECTION':
+      return t('modal.publish_project.deploy.deploying.errors.no_internet_connection');
     case 'CATALYST_SERVERS_EXHAUSTED':
       return t('modal.publish_project.deploy.deploying.errors.catalyst');
     case 'DEPLOYMENT_NOT_FOUND':

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
@@ -219,6 +219,8 @@
             "details": "Details",
             "code_error": "Your scene code contains one or more errors.\nPlease fix them and try again.",
             "fetch_status": "Failed to fetch deployment information.\nPlease, try again.",
+            "fetch_timeout_error": "Failed to fetch deployment information.\nPlease, check your internet connection and try again.",
+            "no_internet_connection": "No internet connection.\nPlease, check your connection and try again.",
             "catalyst": "Deployment to the Catalyst nodes failed.\nPlease retry or check your internet connection.",
             "max_retries": "Retry limit exceeded.\nPlease, try again later.",
             "not_found": "Something went wrong.\nPlease, try again.",

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/es.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/es.json
@@ -218,6 +218,8 @@
           "errors": {
             "details": "Detalles",
             "fetch_status": "Error al obtener información de la publicación.\nPor favor, inténtalo de nuevo.",
+            "fetch_timeout_error": "Error al obtener información de la publicación.\nPor favor, verifica tu conexión a internet e inténtalo de nuevo.",
+            "no_internet_connection": "No hay conexión a internet.\nPor favor, verifica tu conexión e inténtalo de nuevo.",
             "catalyst": "Error al publicar en los nodos de Catalyst.\nPor favor, inténtalo de nuevo o verifica tu conexión a internet.",
             "max_retries": "Límite de reintentos excedido.\nPor favor, inténtalo de nuevo más tarde.",
             "not_found": "Algo salió mal.\nPor favor, inténtalo de nuevo.",

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/zh.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/zh.json
@@ -215,6 +215,8 @@
           "errors": {
             "details": "详细信息",
             "fetch_status": "获取发布信息失败。\n请重试。",
+            "fetch_timeout_error": "获取发布信息失败。\n请检查您的互联网连接并重试。",
+            "no_internet_connection": "没有互联网连接。\n请检查您的连接并重试。",
             "catalyst": "发布到Catalyst节点失败。\n请重试或检查您的互联网连接。",
             "max_retries": "重试次数超过限制。\n请稍后再试。",
             "not_found": "出了问题。\n请重试。",


### PR DESCRIPTION
# fix: publish signal error

## Context and Problem Statement

Related slack thread: https://decentralandteam.slack.com/archives/C07FAJEQFPE/p1771271148804859

Some people reported us the following error trying to deploy:

<img width="899" height="539" alt="image" src="https://github.com/user-attachments/assets/da98ad15-ad67-44e4-a776-b57b8f2263a1" />

Explanation of the error:
It's just an UI error, the deployment probably completed without errrors. We changed our fetch util some weeks ago and it has a short timeout by default. So when the execute deployment endpoint takes more than 3 secs to answer, the frontend cancells the request and shows this non-helpful error in the UI. But there's no real failure on the deployment process.

## Solution

Increase timeout and show helpful error message.
