### PR TITLE
fix: custom code detection updated

### DIFF
--- a/packages/creator-hub/shared/scene-parser.ts
+++ b/packages/creator-hub/shared/scene-parser.ts
@@ -16,7 +16,7 @@ function getScriptCustomCode(content: string): ScriptParseResult {
       plugins: ['typescript'],
     });
 
-    const defaultImports = new Set(['@dcl/sdk/math', '@dcl/sdk/ecs']);
+    const defaultImports = new Set(['@dcl/sdk/math', '@dcl/sdk/ecs', './ui']);
 
     for (const statement of ast.program.body) {
       // Check for non-default imports

--- a/packages/creator-hub/shared/tests/scene-parser.spec.ts
+++ b/packages/creator-hub/shared/tests/scene-parser.spec.ts
@@ -73,6 +73,49 @@ describe('when parsing scene files', () => {
     });
   });
 
+  describe('and the scene matches the new empty template', () => {
+    let sceneContent: string;
+
+    beforeEach(() => {
+      sceneContent = `
+        import {} from '@dcl/sdk/math'
+        import { engine } from '@dcl/sdk/ecs'
+        import { setupUi } from './ui'
+
+        export function main() {
+            // uncomment the line below to initialize UI from ui.tsx
+            //setupUi()
+
+            // your scene code here
+        }
+      `;
+    });
+
+    it('should not detect custom code', () => {
+      expect(hasCustomCode(sceneContent)).toBe(false);
+    });
+  });
+
+  describe('and the scene has the ui import but setupUi is called in main', () => {
+    let sceneContent: string;
+
+    beforeEach(() => {
+      sceneContent = `
+        import {} from '@dcl/sdk/math'
+        import { engine } from '@dcl/sdk/ecs'
+        import { setupUi } from './ui'
+
+        export function main() {
+            setupUi()
+        }
+      `;
+    });
+
+    it('should detect custom code', () => {
+      expect(hasCustomCode(sceneContent)).toBe(true);
+    });
+  });
+
   describe('and the content is null', () => {
     it('should return false', () => {
       expect(hasCustomCode(null)).toBe(false);


### PR DESCRIPTION
# fix: custom code detection updated

## Context and Problem Statement

This [commit](https://github.com/decentraland/sdk-empty-scene-template/commit/ba09d784a95d6a6793952120e27650ea4c0b90f1) updated the default `src/index.ts` to include import `{ setupUi }` from `'./ui'` as boilerplate. This caused the custom code detector in Creator Hub to incorrectly flag freshly created scenes as having custom code, showing a false warning in the Scene Optimization panel.   

## Solution

This fix adds `'./ui'` to the list of default (template) imports that are ignored during detection. A scene is still correctly flagged as having custom code when the user actually calls `setupUi()` from `main()` (since that produces a real AST statement in the function body) or adds any other non-template import.  

Before (empty scene):

<img width="339" height="448" alt="image" src="https://github.com/user-attachments/assets/6861faf5-8300-47d6-9ebd-7c05310c470a" />


Now (empty scene):

<img width="330" height="360" alt="image" src="https://github.com/user-attachments/assets/e13ca7a7-1e02-47f2-a86d-d6497fbcdc8f" />

