### PR TITLE
refactor: useComponentInput/useMultiComponentInput options object for…

### DIFF
--- a/packages/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.tsx
@@ -35,8 +35,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
     AudioSource,
     fromAudioSource,
     toAudioSource,
-    handleInputValidation,
-    [files],
+    { validateInput: handleInputValidation, deps: [files] },
   );
 
   const handleRemove = useCallback(async () => {

--- a/packages/inspector/src/components/EntityInspector/AudioStreamInspector/AudioStreamInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/AudioStreamInspector/AudioStreamInspector.tsx
@@ -24,7 +24,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
     AudioStream,
     fromAudioStream,
     toAudioStream,
-    handleInputValidation,
+    { validateInput: handleInputValidation },
   );
 
   const handleRemove = useCallback(async () => {

--- a/packages/inspector/src/components/EntityInspector/AvatarAttachInspector/AvatarAttachInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/AvatarAttachInspector/AvatarAttachInspector.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-
+import { AvatarAnchorPointType } from '@dcl/ecs';
 import { withSdk } from '../../../hoc/withSdk';
 import { useAllEntitiesHaveComponent } from '../../../hooks/sdk/useHasComponent';
 import { useMultiComponentInput } from '../../../hooks/sdk/useComponentInput';
@@ -11,7 +11,6 @@ import { InfoTooltip } from '../../ui/InfoTooltip';
 import { Block } from '../../Block';
 import { Container } from '../../Container';
 import { Dropdown } from '../../ui/Dropdown';
-import { AvatarAnchorPointType } from '@dcl/ecs';
 import { fromAvatarAttach, toAvatarAttach, isValidInput } from './utils';
 import type { Props } from './types';
 
@@ -54,7 +53,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
     AvatarAttach,
     fromAvatarAttach,
     toAvatarAttach,
-    isValidInput,
+    { validateInput: isValidInput },
   );
 
   const handleRemove = useCallback(async () => {

--- a/packages/inspector/src/components/EntityInspector/BillboardInspector/BillboardInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/BillboardInspector/BillboardInspector.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-
+import { BillboardMode } from '@dcl/ecs';
 import { withSdk } from '../../../hoc/withSdk';
 import { useAllEntitiesHaveComponent } from '../../../hooks/sdk/useHasComponent';
 import { useMultiComponentInput } from '../../../hooks/sdk/useComponentInput';
@@ -11,7 +11,6 @@ import { InfoTooltip } from '../../ui/InfoTooltip';
 import { Block } from '../../Block';
 import { Container } from '../../Container';
 import { Dropdown } from '../../ui/Dropdown';
-import { BillboardMode } from '@dcl/ecs';
 import { fromBillboard, toBillboard, isValidInput } from './utils';
 import type { Props } from './types';
 
@@ -33,7 +32,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
     Billboard,
     fromBillboard,
     toBillboard,
-    isValidInput,
+    { validateInput: isValidInput },
   );
 
   const handleRemove = useCallback(async () => {

--- a/packages/inspector/src/components/EntityInspector/CounterBarInspector/CounterBarInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/CounterBarInspector/CounterBarInspector.tsx
@@ -15,13 +15,9 @@ import './CounterBarInspector.css';
 export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
   const { CounterBar } = sdk.components;
 
-  const { getInputProps } = useComponentInput(
-    entity,
-    CounterBar,
-    fromCounterBar,
-    toCounterBar,
-    isValidInput,
-  );
+  const { getInputProps } = useComponentInput(entity, CounterBar, fromCounterBar, toCounterBar, {
+    validateInput: isValidInput,
+  });
 
   const hasCounterBar = useHasComponent(entity, CounterBar);
 

--- a/packages/inspector/src/components/EntityInspector/CounterInspector/CounterInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/CounterInspector/CounterInspector.tsx
@@ -11,7 +11,7 @@ import { withSdk } from '../../../hoc/withSdk';
 import { Container } from '../../Container';
 import { TextField, InfoTooltip } from '../../ui';
 import { fromCounter, isValidInput, toCounter } from './utils';
-import { Props } from './types';
+import type { Props } from './types';
 
 import './CounterInspector.css';
 
@@ -19,13 +19,9 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
   const { Counter, GltfContainer } = sdk.components;
 
   const hasCounter = useHasComponent(entity, Counter);
-  const { getInputProps } = useComponentInput(
-    entity,
-    Counter,
-    fromCounter,
-    toCounter,
-    isValidInput,
-  );
+  const { getInputProps } = useComponentInput(entity, Counter, fromCounter, toCounter, {
+    validateInput: isValidInput,
+  });
 
   const handleRemove = useCallback(async () => {
     sdk.operations.removeComponent(entity, Counter);

--- a/packages/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
@@ -25,14 +25,10 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
     ({ src }: { src: string }) => !!files && isValidInput(files, src),
     [files],
   );
-  const { getInputProps, isValid } = useComponentInput(
-    entity,
-    GltfContainer,
-    fromGltf,
-    toGltf,
-    handleInputValidation,
-    [files],
-  );
+  const { getInputProps, isValid } = useComponentInput(entity, GltfContainer, fromGltf, toGltf, {
+    validateInput: handleInputValidation,
+    deps: [files],
+  });
 
   const handleRemove = useCallback(async () => {
     const { VisibilityComponent, MeshCollider } = sdk.components;

--- a/packages/inspector/src/components/EntityInspector/GltfNodeModifiersInspector/GltfNodeModifiersInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/GltfNodeModifiersInspector/GltfNodeModifiersInspector.tsx
@@ -34,7 +34,7 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
     GltfNodeModifiers,
     fromComponent,
     toComponent,
-    isValidInput,
+    { validateInput: isValidInput },
   );
 
   const [componentValue] = useComponentValue<PBGltfNodeModifiers>(entity, GltfNodeModifiers);

--- a/packages/inspector/src/components/EntityInspector/LightSourceInspector/LightSourceInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/LightSourceInspector/LightSourceInspector.tsx
@@ -26,7 +26,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
     LightSource,
     fromComponent,
     toComponent,
-    isValidInput,
+    { validateInput: isValidInput },
   );
 
   const handleRemove = useCallback(async () => {

--- a/packages/inspector/src/components/EntityInspector/MaterialInspector/MaterialInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/MaterialInspector/MaterialInspector.tsx
@@ -16,13 +16,9 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
 
   const allEntitiesHaveMaterial = useAllEntitiesHaveComponent(entities, Material);
 
-  const { getInputProps } = useMultiComponentInput(
-    entities,
-    Material,
-    fromMaterial,
-    toMaterial,
-    isValidMaterial,
-  );
+  const { getInputProps } = useMultiComponentInput(entities, Material, fromMaterial, toMaterial, {
+    validateInput: isValidMaterial,
+  });
 
   const handleRemove = useCallback(async () => {
     for (const entity of entities) {

--- a/packages/inspector/src/components/EntityInspector/MeshColliderInspector/MeshColliderInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/MeshColliderInspector/MeshColliderInspector.tsx
@@ -21,7 +21,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
     MeshCollider,
     fromMeshCollider,
     toMeshCollider,
-    isValidInput,
+    { validateInput: isValidInput },
   );
 
   const handleRemove = useCallback(async () => {

--- a/packages/inspector/src/components/EntityInspector/MeshRendererInspector/MeshRendererInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/MeshRendererInspector/MeshRendererInspector.tsx
@@ -8,7 +8,7 @@ import { Container } from '../../Container';
 import { TextField, Dropdown, InfoTooltip } from '../../ui';
 import { fromMeshRenderer, toMeshRenderer, isValidInput, SHAPES } from './utils';
 
-import { Props, MeshType } from './types';
+import { type Props, MeshType } from './types';
 
 export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
   const { MeshRenderer } = sdk.components;
@@ -19,7 +19,7 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
     MeshRenderer,
     fromMeshRenderer,
     toMeshRenderer,
-    isValidInput,
+    { validateInput: isValidInput },
   );
 
   const handleRemove = useCallback(async () => {

--- a/packages/inspector/src/components/EntityInspector/NftShapeInspector/NftShapeInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/NftShapeInspector/NftShapeInspector.tsx
@@ -31,13 +31,9 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
   const hasNftShape = useHasComponent(entity, NftShape);
   const handleInputValidation = useCallback(({ urn }: { urn: string }) => isValidInput(urn), []);
   const [touchedFields, setTouchedFields] = useState({ contract: false, token: false });
-  const { getInputProps } = useComponentInput(
-    entity,
-    NftShape,
-    fromNftShape,
-    toNftShape,
-    handleInputValidation,
-  );
+  const { getInputProps } = useComponentInput(entity, NftShape, fromNftShape, toNftShape, {
+    validateInput: handleInputValidation,
+  });
   const color = getInputProps('color');
   const style = getInputProps('style');
   const urnField = getInputProps('urn');

--- a/packages/inspector/src/components/EntityInspector/PlaceholderInspector/PlaceholderInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/PlaceholderInspector/PlaceholderInspector.tsx
@@ -28,8 +28,7 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
     Placeholder,
     fromPlaceholder,
     toPlaceholder,
-    handleInputValidation,
-    [files],
+    { validateInput: handleInputValidation, deps: [files] },
   );
 
   const handleRemove = useCallback(async () => {

--- a/packages/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -100,7 +100,9 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
 
   const hasScene = useHasComponent(entity, Scene);
   const imageOptions = useAssetOptions(ACCEPTED_FILE_TYPES['image']);
-  const { getInputProps } = useComponentInput(entity, Scene, fromScene, toScene, isValidInput);
+  const { getInputProps } = useComponentInput(entity, Scene, fromScene, toScene, {
+    validateInput: isValidInput,
+  });
   const nameProps = getInputProps('name');
   const descriptionProps = getInputProps('description');
   const thumbnailProps = getInputProps('thumbnail');

--- a/packages/inspector/src/components/EntityInspector/SmartItemBasicView/v1/CounterBarView/CounterBarView.tsx
+++ b/packages/inspector/src/components/EntityInspector/SmartItemBasicView/v1/CounterBarView/CounterBarView.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { Entity } from '@dcl/ecs';
-import { Action, ActionType, getJson } from '@dcl/asset-packs';
-import { withSdk, WithSdkProps } from '../../../../../hoc/withSdk';
+import type { Entity } from '@dcl/ecs';
+import { type Action, type ActionType, getJson } from '@dcl/asset-packs';
+import { withSdk, type WithSdkProps } from '../../../../../hoc/withSdk';
 import { useComponentInput } from '../../../../../hooks/sdk/useComponentInput';
 import { useHasComponent } from '../../../../../hooks/sdk/useHasComponent';
 import { useArrayState } from '../../../../../hooks/useArrayState';
 import { useComponentValue } from '../../../../../hooks/sdk/useComponentValue';
-import { EditorComponentsTypes } from '../../../../../lib/sdk/components';
-import { ConfigComponentType } from '../../../../../lib/sdk/components/Config';
+import type { EditorComponentsTypes } from '../../../../../lib/sdk/components';
+import type { ConfigComponentType } from '../../../../../lib/sdk/components/Config';
 import { Block } from '../../../../Block';
 import { TextField, ColorField } from '../../../../ui';
 import {
@@ -30,14 +30,14 @@ export default React.memo(
         Counter,
         fromCounter,
         toCounter,
-        isValidCounterInput,
+        { validateInput: isValidCounterInput },
       );
       const { getInputProps: getCounterBarInputProps } = useComponentInput(
         entity,
         CounterBar,
         fromCounterBar,
         toCounterBar,
-        isValidCounterBarInput,
+        { validateInput: isValidCounterBarInput },
       );
       const [actionComponent, setActionComponentValue, isActionComponentEqual] = useComponentValue<
         EditorComponentsTypes['Actions']
@@ -73,7 +73,7 @@ export default React.memo(
 
       const handleUpdateHealthResetAction = useCallback(
         (value: number) => {
-          if (!!availableHealthBarActions.get('reset')) {
+          if (availableHealthBarActions.get('reset')) {
             const [resetActionIdx, resetAction] = availableHealthBarActions.get('reset') as [
               number,
               Action,

--- a/packages/inspector/src/components/EntityInspector/SmartItemBasicView/v1/DefaultBasicViewField/DefaultBasicViewField.tsx
+++ b/packages/inspector/src/components/EntityInspector/SmartItemBasicView/v1/DefaultBasicViewField/DefaultBasicViewField.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback } from 'react';
-import { Entity } from '@dcl/ecs';
+import type { Entity } from '@dcl/ecs';
 import { getValue, setValue } from '../../../../../lib/logic/get-set-value';
 import { withSdk } from '../../../../../hoc/withSdk';
 import { useComponentInput } from '../../../../../hooks/sdk/useComponentInput';
@@ -7,7 +7,12 @@ import { Block } from '../../../../Block';
 import { Container } from '../../../../Container';
 import { TextField, CheckboxField, RangeField } from '../../../../ui';
 import { getComponentByType, isBooleanValue, isTrueValue } from '../../utils';
-import { DefaultBasicViewFieldProps, FieldConfig, FieldComponentType, FieldType } from './types';
+import {
+  type DefaultBasicViewFieldProps,
+  type FieldConfig,
+  FieldComponentType,
+  FieldType,
+} from './types';
 
 import './DefaultBasicViewField.css';
 
@@ -97,20 +102,21 @@ function renderField(entity: Entity, component: any, propName: string, config: F
 
       return setValue(input, propName, converted);
     },
-    // Is valid input
-    (input: Record<string, any>) => {
-      const raw = getValue(input, propName);
+    {
+      validateInput: (input: Record<string, any>) => {
+        const raw = getValue(input, propName);
 
-      switch (config.type) {
-        case FieldType.Number:
-        case FieldType.Decimal:
-        case FieldType.Float:
-          return typeof raw === 'number' || !isNaN(parseFloat(String(raw)));
-        case FieldType.Boolean:
-          return isBooleanValue(raw);
-        default:
-          return true;
-      }
+        switch (config.type) {
+          case FieldType.Number:
+          case FieldType.Decimal:
+          case FieldType.Float:
+            return typeof raw === 'number' || !isNaN(parseFloat(String(raw)));
+          case FieldType.Boolean:
+            return isBooleanValue(raw);
+          default:
+            return true;
+        }
+      },
     },
   );
 

--- a/packages/inspector/src/components/EntityInspector/SmartItemBasicView/v1/NftView/NftView.tsx
+++ b/packages/inspector/src/components/EntityInspector/SmartItemBasicView/v1/NftView/NftView.tsx
@@ -20,13 +20,9 @@ export default React.memo(
     const { NftShape } = sdk.components;
     const handleInputValidation = useCallback(({ urn }: { urn: string }) => isValidInput(urn), []);
     const [touchedFields, setTouchedFields] = useState({ contract: false, token: false });
-    const { getInputProps } = useComponentInput(
-      entity,
-      NftShape,
-      fromNftShape,
-      toNftShape,
-      handleInputValidation,
-    );
+    const { getInputProps } = useComponentInput(entity, NftShape, fromNftShape, toNftShape, {
+      validateInput: handleInputValidation,
+    });
     const color = getInputProps('color');
     const style = getInputProps('style');
     const urnField = getInputProps('urn');

--- a/packages/inspector/src/components/EntityInspector/SmartItemBasicView/v1/VideoView/VideoView.tsx
+++ b/packages/inspector/src/components/EntityInspector/SmartItemBasicView/v1/VideoView/VideoView.tsx
@@ -37,8 +37,7 @@ export default React.memo(
       VideoPlayer,
       fromVideoPlayer,
       toVideoPlayer,
-      handleInputValidation,
-      [files],
+      { validateInput: handleInputValidation, deps: [files] },
     );
 
     const handleDrop = useCallback(async (src: string) => {

--- a/packages/inspector/src/components/EntityInspector/SmartItemBasicView/v2/SmartItemBasicView.tsx
+++ b/packages/inspector/src/components/EntityInspector/SmartItemBasicView/v2/SmartItemBasicView.tsx
@@ -44,24 +44,25 @@ const RegularComponentItemInner = withSdk<{ item: SectionItem; entity: Entity }>
 
         return setValue(input, item.path || '', converted);
       },
-      // Is valid input
-      (input: Record<string, any>) => {
-        const raw = getValue(input, item.path || '');
+      {
+        validateInput: (input: Record<string, any>) => {
+          const raw = getValue(input, item.path || '');
 
-        // Basic type validation
-        if (
-          item.constraints?.format === 'number' ||
-          item.constraints?.min !== undefined ||
-          item.constraints?.max !== undefined
-        ) {
-          return typeof raw === 'number' || !isNaN(parseFloat(String(raw)));
-        }
+          // Basic type validation
+          if (
+            item.constraints?.format === 'number' ||
+            item.constraints?.min !== undefined ||
+            item.constraints?.max !== undefined
+          ) {
+            return typeof raw === 'number' || !isNaN(parseFloat(String(raw)));
+          }
 
-        if (item.constraints?.format === 'boolean') {
-          return isBooleanValue(raw);
-        }
+          if (item.constraints?.format === 'boolean') {
+            return isBooleanValue(raw);
+          }
 
-        return true;
+          return true;
+        },
       },
     );
 

--- a/packages/inspector/src/components/EntityInspector/TextShapeInspector/TextShapeInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/TextShapeInspector/TextShapeInspector.tsx
@@ -21,7 +21,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
     TextShape,
     fromTextShape,
     toTextShape,
-    isValidInput,
+    { validateInput: isValidInput },
   );
 
   const handleRemove = useCallback(async () => {

--- a/packages/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
@@ -28,7 +28,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
     Transform,
     fromTransform,
     toTransform(transform, config),
-    isValidNumericInput,
+    { validateInput: isValidNumericInput },
   );
   const { getInputProps: getConfigProps } = useComponentInput(
     entity,

--- a/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/VideoPlayerInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/VideoPlayerInspector.tsx
@@ -34,8 +34,7 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
     VideoPlayer,
     fromVideoPlayer,
     toVideoPlayer,
-    () => true,
-    [files],
+    { deps: [files] },
   );
 
   const handleRemove = useCallback(async () => {

--- a/packages/inspector/src/components/EntityInspector/VisibilityComponentInspector/VisibilityComponentInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/VisibilityComponentInspector/VisibilityComponentInspector.tsx
@@ -1,6 +1,4 @@
 import { useCallback } from 'react';
-import type { Entity } from '@dcl/ecs';
-
 import { withSdk } from '../../../hoc/withSdk';
 import { useAllEntitiesHaveComponent } from '../../../hooks/sdk/useHasComponent';
 import { useMultiComponentInput } from '../../../hooks/sdk/useComponentInput';
@@ -34,7 +32,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
     VisibilityComponent,
     fromVisibility,
     toVisibility,
-    isValidInput,
+    { validateInput: isValidInput },
   );
 
   // Handlers

--- a/packages/inspector/src/hooks/sdk/useComponentInput.ts
+++ b/packages/inspector/src/hooks/sdk/useComponentInput.ts
@@ -34,14 +34,22 @@ export function isValidNumericInput(input: Input[keyof Input]): boolean {
   return input.length > 0 && !isNaN(Number(input));
 }
 
+export type UseComponentInputOptions<InputType extends Input> = {
+  validateInput?: (input: InputType) => boolean;
+  deps?: unknown[];
+  tolerance?: number;
+};
+
 export const useComponentInput = <ComponentValueType extends object, InputType extends Input>(
   entity: Entity,
   component: Component<ComponentValueType>,
   fromComponentValueToInput: (componentValue: ComponentValueType) => InputType,
   fromInputToComponentValue: (input: InputType) => ComponentValueType,
-  validateInput: (input: InputType) => boolean = () => true,
-  deps: unknown[] = [],
-  tolerance: number = 2, // floating-point tolerance for comparisons (default: 2 decimal places)
+  {
+    validateInput = () => true,
+    deps = [],
+    tolerance = 2,
+  }: UseComponentInputOptions<InputType> = {},
 ) => {
   // Create a normalization function that handles the round-trip transformation
   const normalizeForComparison = useCallback(
@@ -219,8 +227,7 @@ export const useMultiComponentInput = <ComponentValueType extends object, InputT
   component: Component<ComponentValueType>,
   fromComponentValueToInput: (componentValue: ComponentValueType) => InputType,
   fromInputToComponentValue: (input: InputType) => ComponentValueType,
-  validateInput: (input: InputType) => boolean = () => true,
-  deps: unknown[] = [],
+  { validateInput = () => true, deps = [] }: UseComponentInputOptions<InputType> = {},
 ) => {
   // If there's only one entity, use the single entity version just to be safe for now
   if (entities.length === 1) {
@@ -229,8 +236,10 @@ export const useMultiComponentInput = <ComponentValueType extends object, InputT
       component,
       fromComponentValueToInput,
       fromInputToComponentValue,
-      validateInput,
-      deps,
+      {
+        validateInput,
+        deps,
+      },
     );
   }
   const sdk = useSdk();


### PR DESCRIPTION
## Context

The useComponentInput hook currently uses positional parameters for optional arguments (validateInput, deps, tolerance). While these have default values, we must pass all preceding parameters to use later ones, leading to boilerplate code like () => true and [] just to access the tolerance parameter.

## Solution

Refactor the hook to accept an optional options object as the 5th parameter instead of individual positional parameters.

closes: #893 