### PR TITLE
virtual width & height and remove scaleFactor

### DIFF
--- a/packages/asset-packs/src/admin-toolkit-ui/Active.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/Active.tsx
@@ -5,14 +5,13 @@ import { clearInterval, setInterval } from './utils';
 import { COLORS } from './VideoControl';
 
 interface LoadingProps {
-  scaleFactor: number;
   engine: IEngine;
   width?: number;
   height?: number;
   uiTransform?: UiTransformProps;
 }
 
-export function Active({ scaleFactor, engine, width = 8, height = 8, uiTransform }: LoadingProps) {
+export function Active({ engine, width = 8, height = 8, uiTransform }: LoadingProps) {
   let frame = 0;
   const [_frame, setFrame] = ReactEcs.useState(0);
 
@@ -40,10 +39,10 @@ export function Active({ scaleFactor, engine, width = 8, height = 8, uiTransform
     >
       <UiEntity
         uiTransform={{
-          width: width * scaleFactor,
-          height: height * scaleFactor,
-          borderRadius: (width / 2) * scaleFactor,
-          margin: { right: 8 * scaleFactor },
+          width,
+          height,
+          borderRadius: width / 2,
+          margin: { right: 8 },
         }}
         uiBackground={{
           color: _frame === 1 ? COLORS.SUCCESS : Color4.fromHexString('#43404A'),
@@ -52,7 +51,7 @@ export function Active({ scaleFactor, engine, width = 8, height = 8, uiTransform
       <Label
         value="<b>Active</b>"
         color={COLORS.SUCCESS}
-        fontSize={16 * scaleFactor}
+        fontSize={16}
       />
     </UiEntity>
   );

--- a/packages/asset-packs/src/admin-toolkit-ui/Button.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/Button.tsx
@@ -6,7 +6,6 @@ import ReactEcs, {
   UiBackgroundProps,
 } from '@dcl/react-ecs';
 import { Color4 } from '@dcl/sdk/math';
-import { scaleFactor } from '.';
 
 export const BTN_BACKGROUND_COLOR = {
   primary: {
@@ -129,8 +128,8 @@ export const Button = (props: CompositeButtonProps) => {
     <UiEntity
       uiTransform={{
         borderColor: buttonState.borderColor(variant),
-        borderWidth: 2 * scaleFactor,
-        borderRadius: 12 * scaleFactor,
+        borderWidth: 2,
+        borderRadius: 12,
         ...uiTransform,
       }}
       uiBackground={{

--- a/packages/asset-packs/src/admin-toolkit-ui/Card.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/Card.tsx
@@ -2,11 +2,9 @@ import ReactEcs, { UiEntity, UiTransformProps } from '@dcl/react-ecs';
 import { containerBackgroundColor } from '.';
 
 export function Card({
-  scaleFactor,
   children,
   uiTransform,
 }: {
-  scaleFactor: number;
   children?: ReactEcs.JSX.Element;
   uiTransform?: UiTransformProps;
 }) {
@@ -14,18 +12,18 @@ export function Card({
     <UiEntity
       uiTransform={{
         width: '100%',
-        borderRadius: 12 * scaleFactor,
+        borderRadius: 12,
         margin: {
-          top: 10 * scaleFactor,
+          top: 10,
           right: 0,
           bottom: 0,
           left: 0,
         },
         padding: {
-          top: 32 * scaleFactor,
-          right: 32 * scaleFactor,
-          bottom: 32 * scaleFactor,
-          left: 32 * scaleFactor,
+          top: 32,
+          right: 32,
+          bottom: 32,
+          left: 32,
         },
         ...uiTransform,
       }}

--- a/packages/asset-packs/src/admin-toolkit-ui/Error.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/Error.tsx
@@ -3,14 +3,13 @@ import ReactEcs, { UiEntity, Label, UiTransformProps } from '@dcl/react-ecs';
 import { CONTENT_URL } from './constants';
 
 interface ErrorProps {
-  scaleFactor: number;
   text: string;
   uiTransform?: UiTransformProps;
 }
 
 export const ERROR_ICON = `${CONTENT_URL}/admin_toolkit/assets/icons/error.png`;
 
-export function Error({ scaleFactor, text, uiTransform }: ErrorProps) {
+export function Error({ text, uiTransform }: ErrorProps) {
   return (
     <UiEntity
       uiTransform={{
@@ -18,16 +17,16 @@ export function Error({ scaleFactor, text, uiTransform }: ErrorProps) {
         flexDirection: 'row',
         justifyContent: 'center',
         alignItems: 'center',
-        margin: { top: 10 * scaleFactor },
+        margin: { top: 10 },
         width: '100%',
         ...uiTransform,
       }}
     >
       <UiEntity
         uiTransform={{
-          width: 25 * scaleFactor,
-          height: 25 * scaleFactor,
-          margin: { right: 10 * scaleFactor },
+          width: 25,
+          height: 25,
+          margin: { right: 10 },
           flexShrink: 0,
         }}
         uiBackground={{
@@ -44,7 +43,7 @@ export function Error({ scaleFactor, text, uiTransform }: ErrorProps) {
         }}
         value={`<b>${text}</b>`}
         color={Color4.Red()}
-        fontSize={14 * scaleFactor}
+        fontSize={14}
       />
     </UiEntity>
   );

--- a/packages/asset-packs/src/admin-toolkit-ui/Header.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/Header.tsx
@@ -2,23 +2,22 @@ import { Color4 } from '@dcl/sdk/math';
 import ReactEcs, { UiEntity, Label } from '@dcl/react-ecs';
 
 type Props = {
-  scaleFactor: number;
   iconSrc: string;
   title: string;
 };
 
-export function Header({ scaleFactor, iconSrc, title }: Props) {
+export function Header({ iconSrc, title }: Props) {
   return (
     <UiEntity
       uiTransform={{
         flexDirection: 'row',
-        margin: { bottom: 10 * scaleFactor },
+        margin: { bottom: 10 },
         alignItems: 'center',
         height: 'auto',
       }}
     >
       <UiEntity
-        uiTransform={{ width: 30 * scaleFactor, height: 30 * scaleFactor }}
+        uiTransform={{ width: 30, height: 30 }}
         uiBackground={{
           textureMode: 'stretch',
           texture: {
@@ -29,13 +28,13 @@ export function Header({ scaleFactor, iconSrc, title }: Props) {
       <UiEntity
         uiText={{
           value: `<b>${title}</b>`,
-          fontSize: 24 * scaleFactor,
+          fontSize: 24,
           color: Color4.White(),
           textAlign: 'top-left' as const,
           textWrap: 'wrap' as const,
         }}
         uiTransform={{
-          margin: { bottom: 2 * scaleFactor, left: 10 * scaleFactor },
+          margin: { bottom: 2, left: 10 },
         }}
       />
     </UiEntity>

--- a/packages/asset-packs/src/admin-toolkit-ui/Loading.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/Loading.tsx
@@ -4,20 +4,13 @@ import ReactEcs, { UiEntity, UiTransformProps } from '@dcl/react-ecs';
 import { clearInterval, setInterval } from './utils';
 
 interface LoadingProps {
-  scaleFactor: number;
   engine: IEngine;
   width?: number;
   height?: number;
   uiTransform?: UiTransformProps;
 }
 
-export function LoadingDots({
-  scaleFactor,
-  uiTransform,
-  engine,
-  width = 10,
-  height = 10,
-}: LoadingProps) {
+export function LoadingDots({ uiTransform, engine, width = 10, height = 10 }: LoadingProps) {
   let __frame = 0;
   const [frame, setFrame] = ReactEcs.useState(0);
 
@@ -47,10 +40,10 @@ export function LoadingDots({
         <UiEntity
           key={`dot-${i}`}
           uiTransform={{
-            width: width * scaleFactor,
-            height: height * scaleFactor,
-            borderRadius: (width / 2) * scaleFactor,
-            margin: { right: 8 * scaleFactor },
+            width,
+            height,
+            borderRadius: width / 2,
+            margin: { right: 8 },
           }}
           uiBackground={{
             color: frame >= i ? Color4.fromHexString('#FF2D55') : Color4.fromHexString('#43404A'),

--- a/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/AddUserInput.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/AddUserInput.tsx
@@ -16,7 +16,6 @@ export enum PermissionType {
 }
 
 type Props = {
-  scaleFactor: number;
   type: PermissionType;
   sceneAdmins: SceneAdmin[];
 };
@@ -30,11 +29,11 @@ function isAddress(value: string) {
   return value.length > 15;
 }
 
-export function AddUserInput({ scaleFactor, type, sceneAdmins }: Props) {
+export function AddUserInput({ type, sceneAdmins }: Props) {
   const [error, setError] = ReactEcs.useState('');
   const [loading, setLoading] = ReactEcs.useState(false);
   const [inputValue, setInputValue] = ReactEcs.useState('');
-  const styles = getAddUserInputStyles(scaleFactor);
+  const styles = getAddUserInputStyles();
   const colors = getAddUserInputColors();
   const backgrounds = getAddUserInputBackgrounds();
 
@@ -81,11 +80,11 @@ export function AddUserInput({ scaleFactor, type, sceneAdmins }: Props) {
     <UiEntity uiTransform={styles.container}>
       <Label
         value={type === PermissionType.ADMIN ? '<b>Add an Admin</b>' : '<b>Ban User from Scene</b>'}
-        fontSize={18 * scaleFactor}
+        fontSize={18}
         color={colors.white}
         uiTransform={styles.title}
       />
-      {type === PermissionType.BAN && <BanUserDescription scaleFactor={scaleFactor} />}
+      {type === PermissionType.BAN && <BanUserDescription />}
       <UiEntity>
         <Input
           onChange={value => {
@@ -93,7 +92,7 @@ export function AddUserInput({ scaleFactor, type, sceneAdmins }: Props) {
             setInputValue(value);
           }}
           value={inputValue}
-          fontSize={14 * scaleFactor}
+          fontSize={14}
           placeholder={'Enter a NAME or wallet address'}
           uiBackground={backgrounds.input}
           uiTransform={{
@@ -108,7 +107,7 @@ export function AddUserInput({ scaleFactor, type, sceneAdmins }: Props) {
               : 'moderation_control_ban_user'
           }
           value={type === PermissionType.ADMIN ? '<b>Add</b>' : '<b>Ban</b>'}
-          fontSize={18 * scaleFactor}
+          fontSize={18}
           uiTransform={styles.button}
           color={type === PermissionType.BAN ? colors.white : undefined}
           onMouseDown={handleSubmit}
@@ -127,7 +126,7 @@ export function AddUserInput({ scaleFactor, type, sceneAdmins }: Props) {
           <UiEntity
             uiText={{
               value: error,
-              fontSize: 14 * scaleFactor,
+              fontSize: 14,
               color: colors.red,
               textAlign: 'top-left',
             }}

--- a/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/BanUserDescription.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/BanUserDescription.tsx
@@ -1,13 +1,9 @@
 import ReactEcs, { UiEntity } from '@dcl/react-ecs';
 import { getAddUserInputStyles, getBanUserTextStyles } from './styles/AddUserInputStyles';
 
-type Props = {
-  scaleFactor: number;
-};
-
-export function BanUserDescription({ scaleFactor }: Props) {
-  const styles = getAddUserInputStyles(scaleFactor);
-  const textStyles = getBanUserTextStyles(scaleFactor);
+export function BanUserDescription() {
+  const styles = getAddUserInputStyles();
+  const textStyles = getBanUserTextStyles();
 
   return (
     <UiEntity uiTransform={styles.bannedInfoContainer}>

--- a/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/RemoveAdminConfirmation.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/RemoveAdminConfirmation.tsx
@@ -9,15 +9,7 @@ import { LoadingDots } from '../Loading';
 import { Error } from '../Error';
 import { fetchSceneAdmins } from '..';
 
-export function RemoveAdminConfirmation({
-  scaleFactor,
-  admin,
-  engine,
-}: {
-  scaleFactor: number;
-  admin: SceneAdmin;
-  engine: IEngine;
-}) {
+export function RemoveAdminConfirmation({ admin, engine }: { admin: SceneAdmin; engine: IEngine }) {
   const [isLoading, setIsLoading] = ReactEcs.useState(false);
   const [error, setError] = ReactEcs.useState('');
 
@@ -33,9 +25,9 @@ export function RemoveAdminConfirmation({
     >
       <UiEntity
         uiTransform={{
-          width: 675 * scaleFactor,
-          minHeight: 279 * scaleFactor,
-          padding: 24 * scaleFactor,
+          width: 675,
+          minHeight: 279,
+          padding: 24,
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
@@ -44,30 +36,30 @@ export function RemoveAdminConfirmation({
         }}
         uiBackground={{ color: Color4.Black() }}
       >
-        <UiEntity uiTransform={{ flexDirection: 'row', maxWidth: 675 * scaleFactor }}>
+        <UiEntity uiTransform={{ flexDirection: 'row', maxWidth: 675 }}>
           <Label
             value={`Are you sure you want to remove `}
-            fontSize={18 * scaleFactor}
+            fontSize={18}
             color={Color4.White()}
           />
           <Label
             value={`<b>${admin.name || (admin.address ? `${admin.address.substring(0, 6)}...${admin.address.substring(admin.address.length - 4)}` : '')}</b>`}
-            fontSize={18 * scaleFactor}
+            fontSize={18}
             color={Color4.fromHexString('#FF2D55')}
           />
           <Label
             value={` from the Admin list?`}
-            fontSize={18 * scaleFactor}
+            fontSize={18}
             color={Color4.White()}
           />
         </UiEntity>
 
         <Label
           value="If you proceed, they will lose access to tehe Admin Tools for this scene."
-          fontSize={14 * scaleFactor}
+          fontSize={14}
           color={Color4.Gray()}
           uiTransform={{
-            margin: { top: 12 * scaleFactor, bottom: 24 * scaleFactor },
+            margin: { top: 12, bottom: 24 },
           }}
         />
 
@@ -85,15 +77,15 @@ export function RemoveAdminConfirmation({
               id="cancel-remove"
               value="<b>Cancel</b>"
               variant="primary"
-              fontSize={16 * scaleFactor}
+              fontSize={16}
               color={Color4.Black()}
               uiTransform={{
-                width: 90 * scaleFactor,
-                height: 40 * scaleFactor,
+                width: 90,
+                height: 40,
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
-                margin: { right: 30 * scaleFactor, left: 30 * scaleFactor },
+                margin: { right: 30, left: 30 },
               }}
               onMouseDown={() => {
                 moderationControlState.adminToRemove = undefined;
@@ -105,11 +97,11 @@ export function RemoveAdminConfirmation({
               id="confirm-remove"
               value={'<b>Remove</b>'}
               variant="primary"
-              fontSize={16 * scaleFactor}
+              fontSize={16}
               color={Color4.White()}
               uiTransform={{
-                width: 160 * scaleFactor,
-                height: 40 * scaleFactor,
+                width: 160,
+                height: 40,
                 justifyContent: 'center',
                 alignItems: 'center',
               }}
@@ -130,16 +122,10 @@ export function RemoveAdminConfirmation({
             />
           )}
         </UiEntity>
-        {isLoading && (
-          <LoadingDots
-            scaleFactor={scaleFactor}
-            engine={engine}
-          />
-        )}
+        {isLoading && <LoadingDots engine={engine} />}
         {error && (
           <Error
-            uiTransform={{ margin: { top: 16 * scaleFactor } }}
-            scaleFactor={scaleFactor}
+            uiTransform={{ margin: { top: 16 } }}
             text={error}
           />
         )}

--- a/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/UsersList.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/UsersList.tsx
@@ -22,7 +22,6 @@ export enum UserListType {
 }
 
 type ModalUserListProps = {
-  scaleFactor: number;
   users: SceneAdmin[] | SceneBanUser[];
   engine: IEngine;
   type: UserListType;
@@ -75,9 +74,9 @@ const closeModal = (type: UserListType) => {
   }
 };
 
-export function ModalUserList({ scaleFactor, users, engine, type }: ModalUserListProps) {
+export function ModalUserList({ users, engine, type }: ModalUserListProps) {
   const [page, setPage] = ReactEcs.useState(1);
-  const styles = getModalStyles(scaleFactor);
+  const styles = getModalStyles();
   const backgrounds = getModalBackgrounds();
   const colors = getModalColors();
 
@@ -118,7 +117,6 @@ export function ModalUserList({ scaleFactor, users, engine, type }: ModalUserLis
   if (moderationControlState.adminToRemove) {
     return (
       <RemoveAdminConfirmation
-        scaleFactor={scaleFactor}
         admin={moderationControlState.adminToRemove}
         engine={engine}
       />
@@ -144,12 +142,12 @@ export function ModalUserList({ scaleFactor, users, engine, type }: ModalUserLis
             />
             <Label
               value={getModalTitle(type)}
-              fontSize={24 * scaleFactor}
+              fontSize={24}
               color={colors.white}
             />
             <Label
               value={getCounterText(type, users.length)}
-              fontSize={16 * scaleFactor}
+              fontSize={16}
               color={colors.gray}
               uiTransform={styles.usersCount}
             />
@@ -158,7 +156,7 @@ export function ModalUserList({ scaleFactor, users, engine, type }: ModalUserLis
               onlyIcon
               icon={ICONS.CLOSE}
               variant="secondary"
-              fontSize={20 * scaleFactor}
+              fontSize={20}
               uiTransform={styles.closeButton}
               iconTransform={styles.closeIcon}
               onMouseDown={() => closeModal(type)}
@@ -188,7 +186,7 @@ export function ModalUserList({ scaleFactor, users, engine, type }: ModalUserLis
                         <UiEntity uiTransform={styles.nameContainer}>
                           <Label
                             value={`<b>${user.name}</b>`}
-                            fontSize={14 * scaleFactor}
+                            fontSize={14}
                             color={colors.white}
                           />
                           {!user.name.includes('#') && (
@@ -209,7 +207,7 @@ export function ModalUserList({ scaleFactor, users, engine, type }: ModalUserLis
                                       ?.charAt(0)
                                       .toUpperCase() + ('role' in user ? user.role?.slice(1) : '')
                                   }</b>`}
-                                  fontSize={12 * scaleFactor}
+                                  fontSize={12}
                                   color={colors.black}
                                 />
                               </UiEntity>
@@ -217,7 +215,7 @@ export function ModalUserList({ scaleFactor, users, engine, type }: ModalUserLis
                         </UiEntity>
                       )}
                       <Label
-                        fontSize={(user.name ? 12 : 14) * scaleFactor}
+                        fontSize={user.name ? 12 : 14}
                         value={user.name ? getUserAddress(user) : getUserAddress(user)}
                         color={user.name ? colors.addressGray : colors.white}
                       />
@@ -228,7 +226,7 @@ export function ModalUserList({ scaleFactor, users, engine, type }: ModalUserLis
                       id={`${type}-action-${index}`}
                       value={getActionButtonText(type)}
                       variant="text"
-                      fontSize={14 * scaleFactor}
+                      fontSize={14}
                       color={colors.removeRed}
                       labelTransform={styles.removeButton}
                       onMouseDown={() => handleRemoveUser(user)}
@@ -251,7 +249,7 @@ export function ModalUserList({ scaleFactor, users, engine, type }: ModalUserLis
               value="Prev"
               variant="secondary"
               disabled={page <= 1}
-              fontSize={18 * scaleFactor}
+              fontSize={18}
               icon={ICONS.BACK}
               iconTransform={styles.prevIcon}
               iconBackground={{ color: getPaginationColor(page <= 1) }}
@@ -262,14 +260,14 @@ export function ModalUserList({ scaleFactor, users, engine, type }: ModalUserLis
             />
             <Label
               value={`${page} / ${Math.ceil(users.length / USERS_PER_PAGE)}`}
-              fontSize={14 * scaleFactor}
+              fontSize={14}
               color={colors.white}
             />
             <Button
               id="next"
               value="<b>Next</b>"
               variant="secondary"
-              fontSize={18 * scaleFactor}
+              fontSize={18}
               iconRight={ICONS.NEXT}
               iconRightTransform={styles.nextIcon}
               labelTransform={styles.nextLabel}
@@ -288,7 +286,7 @@ export function ModalUserList({ scaleFactor, users, engine, type }: ModalUserLis
           <UiEntity uiTransform={styles.messageContainer}>
             <Label
               value={moderationControlState.unbanMessage}
-              fontSize={14 * scaleFactor}
+              fontSize={14}
               color={Color4.White()}
               uiTransform={styles.messageLabel}
             />

--- a/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/index.tsx
@@ -3,7 +3,6 @@ import { Color4 } from '@dcl/ecs-math';
 import ReactEcs, { UiEntity } from '@dcl/react-ecs';
 
 import { Header } from '../Header';
-import { getScaleUIFactor } from '../../ui';
 import { AddUserInput, PermissionType } from './AddUserInput';
 import { Button } from '../Button';
 import { GetPlayerDataRes } from '../../types';
@@ -48,20 +47,17 @@ export const moderationControlState: State = {
 };
 
 export function ModerationControl({ engine, player, sceneAdmins }: Props) {
-  const scaleFactor = getScaleUIFactor(engine);
-  const styles = getModerationControlStyles(scaleFactor);
+  const styles = getModerationControlStyles();
   const colors = getModerationControlColors();
 
   return (
-    <Card scaleFactor={scaleFactor}>
+    <Card>
       <UiEntity uiTransform={styles.container}>
         <Header
           iconSrc={MODERATION_CONTROL_ICON}
           title="PERMISSIONS & MODERATION"
-          scaleFactor={scaleFactor}
         />
         <AddUserInput
-          scaleFactor={scaleFactor}
           type={PermissionType.ADMIN}
           sceneAdmins={sceneAdmins}
         />
@@ -69,7 +65,7 @@ export function ModerationControl({ engine, player, sceneAdmins }: Props) {
           variant="secondary"
           id="moderation_control_admin_list"
           value="<b>View Admin List</b>"
-          fontSize={18 * scaleFactor}
+          fontSize={18}
           color={colors.white}
           uiTransform={styles.viewListButton}
           icon={VERIFIED_USER_ICON}
@@ -78,7 +74,6 @@ export function ModerationControl({ engine, player, sceneAdmins }: Props) {
         />
         <UiEntity uiTransform={styles.divider} />
         <AddUserInput
-          scaleFactor={scaleFactor}
           type={PermissionType.BAN}
           sceneAdmins={sceneAdmins}
         />
@@ -86,7 +81,7 @@ export function ModerationControl({ engine, player, sceneAdmins }: Props) {
           variant="secondary"
           id="moderation_control_ban_list"
           value="<b>View Ban List</b>"
-          fontSize={18 * scaleFactor}
+          fontSize={18}
           color={colors.white}
           uiTransform={styles.viewListButton}
           icon={BAN_USER_ICON}

--- a/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/styles/AddUserInputStyles.ts
+++ b/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/styles/AddUserInputStyles.ts
@@ -4,25 +4,25 @@ import { CONTENT_URL } from '../../constants';
 
 const ERROR_ICON = `${CONTENT_URL}/admin_toolkit/assets/icons/error.png`;
 
-export const getAddUserInputStyles = (scaleFactor: number): Record<string, UiTransformProps> => ({
+export const getAddUserInputStyles = (): Record<string, UiTransformProps> => ({
   container: {
     display: 'flex',
     flexDirection: 'column',
-    margin: { bottom: 8 * scaleFactor },
+    margin: { bottom: 8 },
   },
   title: {
-    margin: { bottom: 8 * scaleFactor },
+    margin: { bottom: 8 },
   },
   input: {
     width: '100%',
-    borderWidth: 4 * scaleFactor,
-    borderRadius: 8 * scaleFactor,
-    height: 48 * scaleFactor,
+    borderWidth: 4,
+    borderRadius: 8,
+    height: 48,
   },
   button: {
-    margin: { left: 10 * scaleFactor },
-    minWidth: 96 * scaleFactor,
-    height: 48 * scaleFactor,
+    margin: { left: 10 },
+    minWidth: 96,
+    height: 48,
     alignItems: 'center',
     justifyContent: 'center',
     padding: 0,
@@ -33,24 +33,24 @@ export const getAddUserInputStyles = (scaleFactor: number): Record<string, UiTra
     alignItems: 'center',
     justifyContent: 'flex-start',
     height: 'auto',
-    margin: { top: 4 * scaleFactor },
+    margin: { top: 4 },
   },
   errorIcon: {
-    width: 16 * scaleFactor,
-    height: 16 * scaleFactor,
-    margin: { right: 8 * scaleFactor },
+    width: 16,
+    height: 16,
+    margin: { right: 8 },
   },
   bannedInfoContainer: {
     display: 'flex',
     flexDirection: 'column',
-    margin: { bottom: 8 * scaleFactor },
+    margin: { bottom: 8 },
     padding: {
-      top: 4 * scaleFactor,
-      bottom: 8 * scaleFactor,
+      top: 4,
+      bottom: 8,
     },
   },
   marginBottomMedium: {
-    margin: { bottom: 4 * scaleFactor },
+    margin: { bottom: 4 },
   },
 });
 
@@ -71,8 +71,8 @@ export const getAddUserInputBackgrounds = () => ({
   },
 });
 
-export const getBanUserTextStyles = (scaleFactor: number) => ({
-  fontSize: 14 * scaleFactor,
+export const getBanUserTextStyles = () => ({
+  fontSize: 14,
   color: Color4.White(),
   textAlign: 'top-left' as const,
 });

--- a/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/styles/ModerationControlStyles.ts
+++ b/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/styles/ModerationControlStyles.ts
@@ -1,28 +1,26 @@
 import { Color4 } from '@dcl/ecs-math';
 import type { UiTransformProps } from '@dcl/react-ecs';
 
-export const getModerationControlStyles = (
-  scaleFactor: number,
-): Record<string, UiTransformProps> => ({
+export const getModerationControlStyles = (): Record<string, UiTransformProps> => ({
   container: {
     width: '100%',
     height: '100%',
     flexDirection: 'column',
   },
   viewListButton: {
-    width: 220 * scaleFactor,
-    height: 42 * scaleFactor,
+    width: 220,
+    height: 42,
     alignItems: 'center',
     justifyContent: 'center',
-    margin: { top: 16 * scaleFactor },
+    margin: { top: 16 },
   },
   viewListIcon: {
-    width: 25 * scaleFactor,
-    height: 25 * scaleFactor,
-    margin: { right: 10 * scaleFactor },
+    width: 25,
+    height: 25,
+    margin: { right: 10 },
   },
   divider: {
-    margin: { top: 16 * scaleFactor, bottom: 16 * scaleFactor },
+    margin: { top: 16, bottom: 16 },
     width: '100%',
     height: 1,
     borderWidth: 1,

--- a/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/styles/UsersListStyles.ts
+++ b/packages/asset-packs/src/admin-toolkit-ui/ModerationControl/styles/UsersListStyles.ts
@@ -8,7 +8,7 @@ const ICONS = {
   BAN: `${CONTENT_URL}/admin_toolkit/assets/icons/ban.png`,
 };
 
-export const getModalStyles = (scaleFactor: number): Record<string, UiTransformProps> => ({
+export const getModalStyles = (): Record<string, UiTransformProps> => ({
   overlay: {
     width: '100%',
     height: '100%',
@@ -19,14 +19,14 @@ export const getModalStyles = (scaleFactor: number): Record<string, UiTransformP
     flexDirection: 'row',
   },
   container: {
-    width: 675 * scaleFactor,
-    maxHeight: 679 * scaleFactor,
-    minHeight: 479 * scaleFactor,
-    padding: 20 * scaleFactor,
+    width: 675,
+    maxHeight: 679,
+    minHeight: 479,
+    padding: 20,
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'space-between',
-    borderRadius: 12 * scaleFactor,
+    borderRadius: 12,
   },
   content: {
     display: 'flex',
@@ -36,15 +36,15 @@ export const getModalStyles = (scaleFactor: number): Record<string, UiTransformP
   header: {
     justifyContent: 'flex-start',
     alignItems: 'center',
-    margin: { bottom: 24 * scaleFactor },
+    margin: { bottom: 24 },
   },
   headerIcon: {
-    width: 30 * scaleFactor,
-    height: 30 * scaleFactor,
-    margin: { right: 10 * scaleFactor },
+    width: 30,
+    height: 30,
+    margin: { right: 10 },
   },
   usersCount: {
-    margin: { left: 8 * scaleFactor },
+    margin: { left: 8 },
   },
   closeButton: {
     position: { right: 0 },
@@ -52,13 +52,13 @@ export const getModalStyles = (scaleFactor: number): Record<string, UiTransformP
     borderColor: Color4.Clear(),
   },
   closeIcon: {
-    width: 32 * scaleFactor,
-    height: 32 * scaleFactor,
+    width: 32,
+    height: 32,
   },
   listContainer: {
     flexDirection: 'column',
     width: '100%',
-    margin: { top: 16 * scaleFactor },
+    margin: { top: 16 },
   },
   userItem: {
     display: 'flex',
@@ -68,9 +68,9 @@ export const getModalStyles = (scaleFactor: number): Record<string, UiTransformP
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    height: 48 * scaleFactor,
-    padding: { left: 8 * scaleFactor, right: 8 * scaleFactor },
-    margin: { top: 4 * scaleFactor, bottom: 4 * scaleFactor },
+    height: 48,
+    padding: { left: 8, right: 8 },
+    margin: { top: 4, bottom: 4 },
   },
   userInfo: {
     display: 'flex',
@@ -81,11 +81,11 @@ export const getModalStyles = (scaleFactor: number): Record<string, UiTransformP
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    margin: { right: 10 * scaleFactor },
+    margin: { right: 10 },
   },
   personIcon: {
-    width: 28 * scaleFactor,
-    height: 28 * scaleFactor,
+    width: 28,
+    height: 28,
   },
   userDetails: {
     display: 'flex',
@@ -97,25 +97,25 @@ export const getModalStyles = (scaleFactor: number): Record<string, UiTransformP
     alignItems: 'center',
   },
   verifiedIcon: {
-    width: 14 * scaleFactor,
-    height: 14 * scaleFactor,
+    width: 14,
+    height: 14,
   },
   roleBadge: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     width: 'auto',
-    height: 20 * scaleFactor,
+    height: 20,
     padding: {
-      left: 4 * scaleFactor,
+      left: 4,
     },
-    margin: { left: 8 * scaleFactor },
-    borderRadius: 4 * scaleFactor,
+    margin: { left: 8 },
+    borderRadius: 4,
   },
   removeButton: {
     margin: {
-      left: 10 * scaleFactor,
-      right: 10 * scaleFactor,
+      left: 10,
+      right: 10,
     },
   },
   divider: {
@@ -126,41 +126,41 @@ export const getModalStyles = (scaleFactor: number): Record<string, UiTransformP
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    margin: { top: 20 * scaleFactor },
-    padding: { left: 10 * scaleFactor, right: 10 * scaleFactor },
+    margin: { top: 20 },
+    padding: { left: 10, right: 10 },
   },
   paginationButton: {
-    height: 42 * scaleFactor,
+    height: 42,
     alignItems: 'center',
   },
   prevIcon: {
-    width: 25 * scaleFactor,
-    height: 25 * scaleFactor,
-    margin: { left: 8 * scaleFactor },
+    width: 25,
+    height: 25,
+    margin: { left: 8 },
   },
   prevLabel: {
-    margin: { right: 10 * scaleFactor },
+    margin: { right: 10 },
   },
   nextIcon: {
-    width: 25 * scaleFactor,
-    height: 25 * scaleFactor,
-    margin: { right: 8 * scaleFactor },
+    width: 25,
+    height: 25,
+    margin: { right: 8 },
   },
   nextLabel: {
-    margin: { left: 10 * scaleFactor },
+    margin: { left: 10 },
   },
   messageContainer: {
     width: '100%',
     justifyContent: 'center',
     alignItems: 'center',
-    margin: { top: 16 * scaleFactor },
+    margin: { top: 16 },
   },
   messageLabel: {
     padding: {
-      top: 8 * scaleFactor,
-      bottom: 8 * scaleFactor,
-      left: 16 * scaleFactor,
-      right: 16 * scaleFactor,
+      top: 8,
+      bottom: 8,
+      left: 16,
+      right: 16,
     },
   },
 });

--- a/packages/asset-packs/src/admin-toolkit-ui/RewardsControl.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/RewardsControl.tsx
@@ -2,7 +2,6 @@ import { Entity, IEngine } from '@dcl/ecs';
 import ReactEcs, { UiEntity, Label, Dropdown } from '@dcl/react-ecs';
 import { Color4 } from '@dcl/sdk/math';
 import { AdminTools, getActionEvents, getComponents, getPayload, Action } from '../definitions';
-import { getScaleUIFactor } from '../ui';
 import { Button } from './Button';
 import { CONTENT_URL } from './constants';
 import { State } from './types';
@@ -33,7 +32,6 @@ function getRewardItems(engine: IEngine): NonNullable<AdminTools['rewardsControl
 }
 
 export function RewardsControl({ engine, state }: { engine: IEngine; state: State }) {
-  const scaleFactor = getScaleUIFactor(engine);
   const rewardItems = getRewardItems(engine);
 
   return (
@@ -48,12 +46,12 @@ export function RewardsControl({ engine, state }: { engine: IEngine; state: Stat
       <UiEntity
         uiTransform={{
           flexDirection: 'row',
-          margin: { bottom: 32 * scaleFactor },
-          height: 30 * scaleFactor,
+          margin: { bottom: 32 },
+          height: 30,
         }}
       >
         <UiEntity
-          uiTransform={{ width: 30 * scaleFactor, height: 30 * scaleFactor }}
+          uiTransform={{ width: 30, height: 30 }}
           uiBackground={{
             color: Color4.White(),
             textureMode: 'stretch',
@@ -62,7 +60,7 @@ export function RewardsControl({ engine, state }: { engine: IEngine; state: Stat
         />
         <Label
           value="<b>AIRDROPS</b>"
-          fontSize={24 * scaleFactor}
+          fontSize={24}
           color={Color4.White()}
         />
       </UiEntity>
@@ -70,14 +68,14 @@ export function RewardsControl({ engine, state }: { engine: IEngine; state: Stat
       <UiEntity
         uiTransform={{
           flexDirection: 'column',
-          margin: { bottom: 32 * scaleFactor },
+          margin: { bottom: 32 },
         }}
       >
         <Label
           value="<b>Selected Airdrop</b>"
-          fontSize={16 * scaleFactor}
+          fontSize={16}
           color={Color4.White()}
-          uiTransform={{ margin: { bottom: 16 * scaleFactor } }}
+          uiTransform={{ margin: { bottom: 16 } }}
         />
 
         <Dropdown
@@ -93,10 +91,10 @@ export function RewardsControl({ engine, state }: { engine: IEngine; state: Stat
           selectedIndex={state.rewardsControl.selectedRewardItem ?? -1}
           onChange={idx => (state.rewardsControl.selectedRewardItem = idx)}
           textAlign="middle-left"
-          fontSize={14 * scaleFactor}
+          fontSize={14}
           uiTransform={{
             width: '100%',
-            height: 40 * scaleFactor,
+            height: 40,
           }}
           uiBackground={{ color: Color4.White() }}
           color={Color4.Black()}
@@ -106,25 +104,25 @@ export function RewardsControl({ engine, state }: { engine: IEngine; state: Stat
       <UiEntity uiTransform={{ flexDirection: 'column' }}>
         <Label
           value="<b>Actions</b>"
-          fontSize={16 * scaleFactor}
+          fontSize={16}
           color={Color4.White()}
-          uiTransform={{ margin: { bottom: 16 * scaleFactor } }}
+          uiTransform={{ margin: { bottom: 16 } }}
         />
 
         <UiEntity uiTransform={{ flexDirection: 'row' }}>
           <Button
             id="rewards_control_release"
             value="<b>Release</b>"
-            fontSize={16 * scaleFactor}
+            fontSize={16}
             uiTransform={{
-              margin: { right: 16 * scaleFactor },
+              margin: { right: 16 },
               alignItems: 'center',
               justifyContent: 'center',
             }}
             icon={ICONS.SEND}
             iconTransform={{
-              height: 25 * scaleFactor,
-              width: 25 * scaleFactor,
+              height: 25,
+              width: 25,
             }}
             onMouseDown={() => handleRelease(engine, state)}
             disabled={state.rewardsControl.selectedRewardItem === undefined}
@@ -132,7 +130,7 @@ export function RewardsControl({ engine, state }: { engine: IEngine; state: Stat
           <Button
             id="rewards_control_clear"
             value="<b>Clear</b>"
-            fontSize={16 * scaleFactor}
+            fontSize={16}
             onMouseDown={() => handleClear(engine, state)}
             disabled={state.rewardsControl.selectedRewardItem === undefined}
           />

--- a/packages/asset-packs/src/admin-toolkit-ui/SmartItemsControl.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/SmartItemsControl.tsx
@@ -3,7 +3,6 @@ import ReactEcs, { Dropdown, Label, UiEntity } from '@dcl/react-ecs';
 import { Color4 } from '@dcl/sdk/math';
 import { Action, AdminTools, getActionEvents, getComponents, getPayload } from '../definitions';
 import { getExplorerComponents } from '../components';
-import { getScaleUIFactor } from '../ui';
 import { Button } from './Button';
 import { CONTENT_URL } from './constants';
 import { State } from './types';
@@ -102,22 +101,20 @@ function SmartItemSelector({
   selectedIndex: number | undefined;
   onSelect: (idx: number) => void;
 }) {
-  const scaleFactor = getScaleUIFactor(engine);
-
   return (
     <UiEntity
       key="SmartItemsControlDropdownWrapper"
       uiTransform={{
         flexDirection: 'column',
-        margin: { bottom: 32 * scaleFactor },
+        margin: { bottom: 32 },
       }}
     >
       <Label
         value="<b>Selected Smart Item</b>"
-        fontSize={16 * scaleFactor}
+        fontSize={16}
         color={Color4.White()}
         uiTransform={{
-          margin: { bottom: 16 * scaleFactor },
+          margin: { bottom: 16 },
         }}
       />
       <Dropdown
@@ -130,9 +127,9 @@ function SmartItemSelector({
         selectedIndex={selectedIndex ?? -1}
         onChange={onSelect}
         textAlign="middle-left"
-        fontSize={14 * scaleFactor}
+        fontSize={14}
         uiTransform={{
-          height: 40 * scaleFactor,
+          height: 40,
           width: '100%',
         }}
         uiBackground={{ color: Color4.White() }}
@@ -155,21 +152,19 @@ function ActionSelector({
   disabled: boolean;
   onChange: (idx: number) => void;
 }) {
-  const scaleFactor = getScaleUIFactor(engine);
-
   return (
     <UiEntity
       uiTransform={{
         flexDirection: 'column',
-        margin: { bottom: 32 * scaleFactor },
+        margin: { bottom: 32 },
       }}
     >
       <Label
         value="<b>Actions</b>"
-        fontSize={16 * scaleFactor}
+        fontSize={16}
         color={Color4.White()}
         uiTransform={{
-          margin: { bottom: 16 * scaleFactor },
+          margin: { bottom: 16 },
         }}
       />
       {actions.length ? (
@@ -181,9 +176,9 @@ function ActionSelector({
           onChange={onChange}
           disabled={disabled}
           textAlign="middle-left"
-          fontSize={14 * scaleFactor}
+          fontSize={14}
           uiTransform={{
-            height: 40 * scaleFactor,
+            height: 40,
             width: '100%',
           }}
           uiBackground={{
@@ -211,8 +206,6 @@ function ActionButtons({
   actions: Action[];
   selectedAction: Action | undefined;
 }) {
-  const scaleFactor = getScaleUIFactor(engine);
-
   const selectedSmartItem =
     state.smartItemsControl.selectedSmartItem !== undefined
       ? smartItems[state.smartItemsControl.selectedSmartItem]
@@ -232,14 +225,14 @@ function ActionButtons({
         id="smart_items_control_restart"
         value="<b>Play Action</b>"
         variant="text"
-        fontSize={16 * scaleFactor}
+        fontSize={16}
         color={Color4.White()}
         uiTransform={{
-          margin: { right: 8 * scaleFactor },
-          height: 40 * scaleFactor,
+          margin: { right: 8 },
+          height: 40,
         }}
         labelTransform={{
-          margin: { left: 10 * scaleFactor, right: 10 * scaleFactor },
+          margin: { left: 10, right: 10 },
         }}
         disabled={!selectedSmartItem || !selectedAction}
         onMouseDown={() => {
@@ -252,13 +245,13 @@ function ActionButtons({
         id="smart_items_control_hide_show"
         value={`<b>${isVisible ? 'Hide' : 'Show'} Entity</b>`}
         variant="text"
-        fontSize={16 * scaleFactor}
+        fontSize={16}
         color={Color4.White()}
         onMouseDown={() => handleHideShowEntity(engine, state, smartItems)}
         disabled={!selectedSmartItem}
-        uiTransform={{ margin: { right: 8 * scaleFactor } }}
+        uiTransform={{ margin: { right: 8 } }}
         labelTransform={{
-          margin: { left: 10 * scaleFactor, right: 10 * scaleFactor },
+          margin: { left: 10, right: 10 },
         }}
       />
     </UiEntity>
@@ -285,10 +278,8 @@ export function SmartItemsControl({ engine, state }: { engine: IEngine; state: S
           return action.name === (stateSelectedAction ?? selectedSmartItem.defaultAction);
         })
       : undefined;
-  const scaleFactor = getScaleUIFactor(engine);
-
   return (
-    <Card scaleFactor={scaleFactor}>
+    <Card>
       <UiEntity
         key="SmartItemsControl"
         uiTransform={{
@@ -300,7 +291,6 @@ export function SmartItemsControl({ engine, state }: { engine: IEngine; state: S
         <Header
           iconSrc={ICONS.SMART_ITEM_CONTROL}
           title="SMART ITEM ACTIONS"
-          scaleFactor={scaleFactor}
         />
 
         <SmartItemSelector

--- a/packages/asset-packs/src/admin-toolkit-ui/TextAnnouncements.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/TextAnnouncements.tsx
@@ -1,7 +1,6 @@
 import { IEngine } from '@dcl/ecs';
 import ReactEcs, { Label, UiEntity } from '@dcl/react-ecs';
 import { getComponents } from '../definitions';
-import { getScaleUIFactor } from '../ui';
 import { CONTENT_URL } from './constants';
 import { State } from './types';
 
@@ -15,7 +14,6 @@ let textAnnouncementsHidden: Set<string> = new Set();
 export function TextAnnouncements({ engine, state }: { engine: IEngine; state: State }) {
   const { TextAnnouncements } = getComponents(engine);
   const textAnnouncements = TextAnnouncements.getOrNull(state.adminToolkitUiEntity);
-  const scaleFactor = getScaleUIFactor(engine);
 
   if (!textAnnouncements?.text || textAnnouncementsHidden.has(textAnnouncements.id)) {
     return null;
@@ -37,16 +35,16 @@ export function TextAnnouncements({ engine, state }: { engine: IEngine; state: S
         uiTransform={{
           display: 'flex',
           flexDirection: 'column',
-          height: 150 * scaleFactor,
-          width: 400 * scaleFactor,
+          height: 150,
+          width: 400,
           margin: {
-            bottom: 10 * scaleFactor,
+            bottom: 10,
           },
           padding: {
-            top: 10 * scaleFactor,
-            bottom: 10 * scaleFactor,
-            left: 10 * scaleFactor,
-            right: 10 * scaleFactor,
+            top: 10,
+            bottom: 10,
+            left: 10,
+            right: 10,
           },
         }}
         uiBackground={{ color: { r: 0.15, g: 0.15, b: 0.15, a: 0.95 } }}
@@ -55,8 +53,8 @@ export function TextAnnouncements({ engine, state }: { engine: IEngine; state: S
           uiTransform={{
             alignSelf: 'center',
             justifyContent: 'center',
-            height: 50 * scaleFactor,
-            width: 50 * scaleFactor,
+            height: 50,
+            width: 50,
           }}
           uiBackground={{
             texture: {
@@ -71,7 +69,7 @@ export function TextAnnouncements({ engine, state }: { engine: IEngine; state: S
             alignItems: 'center',
             justifyContent: 'center',
           }}
-          fontSize={18 * scaleFactor}
+          fontSize={18}
           value={textAnnouncements.text}
         />
         {textAnnouncements.author ? (
@@ -80,19 +78,19 @@ export function TextAnnouncements({ engine, state }: { engine: IEngine; state: S
               alignItems: 'flex-end',
               justifyContent: 'flex-end',
             }}
-            fontSize={14 * scaleFactor}
+            fontSize={14}
             color={{ r: 0.7, g: 0.7, b: 0.7, a: 1 }}
             value={`- ${textAnnouncements.author}`}
           />
         ) : null}
         <UiEntity
           uiTransform={{
-            height: 24 * scaleFactor,
-            width: 24 * scaleFactor,
+            height: 24,
+            width: 24,
             positionType: 'absolute',
             position: {
-              top: 5 * scaleFactor,
-              right: 5 * scaleFactor,
+              top: 5,
+              right: 5,
             },
           }}
           uiBackground={{

--- a/packages/asset-packs/src/admin-toolkit-ui/TextAnnouncementsControl.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/TextAnnouncementsControl.tsx
@@ -2,7 +2,6 @@ import { IEngine } from '@dcl/ecs';
 import ReactEcs, { Label, UiEntity, Input } from '@dcl/react-ecs';
 import { Color4 } from '@dcl/sdk/math';
 import { getComponents } from '../definitions';
-import { getScaleUIFactor } from '../ui';
 import { GetPlayerDataRes } from '../types';
 import { Button } from './Button';
 import { CONTENT_URL } from './constants';
@@ -28,10 +27,8 @@ export function TextAnnouncementsControl({
   state: State;
   player?: GetPlayerDataRes | null;
 }) {
-  const scaleFactor = getScaleUIFactor(engine);
-
   return (
-    <Card scaleFactor={scaleFactor}>
+    <Card>
       <UiEntity
         uiTransform={{
           width: '100%',
@@ -42,15 +39,14 @@ export function TextAnnouncementsControl({
         {/* Header */}
         <Header
           iconSrc={ICONS.TEXT_ANNOUNCEMENT_CONTROL}
-          scaleFactor={scaleFactor}
           title="TEXT ANNOUNCEMENTS"
         />
         <UiEntity uiTransform={{ flexDirection: 'column' }}>
           <Label
             value="<b>Message window</b>"
-            fontSize={16 * scaleFactor}
+            fontSize={16}
             color={Color4.White()}
-            uiTransform={{ margin: { bottom: 16 * scaleFactor } }}
+            uiTransform={{ margin: { bottom: 16 } }}
           />
 
           <Input
@@ -60,25 +56,25 @@ export function TextAnnouncementsControl({
             onChange={value => {
               state.textAnnouncementControl.text = value;
             }}
-            fontSize={16 * scaleFactor}
+            fontSize={16}
             placeholder={'Write your announcement here'}
             placeholderColor={Color4.create(160 / 255, 155 / 255, 168 / 255, 1)}
             color={Color4.Black()}
             uiBackground={{ color: Color4.White() }}
             uiTransform={{
               width: '100%',
-              height: 80 * scaleFactor,
-              margin: { bottom: 16 * scaleFactor },
+              height: 80,
+              margin: { bottom: 16 },
             }}
           />
 
           <UiEntity
             uiTransform={{
               width: '100%',
-              height: 40 * scaleFactor,
+              height: 40,
               flexDirection: 'row',
               margin: {
-                bottom: 10 * scaleFactor,
+                bottom: 10,
                 top: 0,
                 right: 0,
                 left: 0,
@@ -87,7 +83,7 @@ export function TextAnnouncementsControl({
           >
             <Label
               value={`${state.textAnnouncementControl.text?.length ?? 0} / 90`}
-              fontSize={14 * scaleFactor}
+              fontSize={14}
               color={Color4.create(187 / 255, 187 / 255, 187 / 255, 1)}
               uiTransform={{ flexGrow: 1 }}
               textAlign="top-left"
@@ -96,11 +92,11 @@ export function TextAnnouncementsControl({
               id="text_announcement_control_clear"
               value="<b>Clear Announcements</b>"
               variant="text"
-              fontSize={16 * scaleFactor}
+              fontSize={16}
               color={Color4.White()}
               uiTransform={{
-                height: 40 * scaleFactor,
-                margin: { right: 8 * scaleFactor },
+                height: 40,
+                margin: { right: 8 },
               }}
               onMouseDown={() => {
                 handleClearTextAnnouncement(engine, state);
@@ -110,11 +106,11 @@ export function TextAnnouncementsControl({
               id="text_announcement_control_share"
               value="<b>Share</b>"
               variant="primary"
-              fontSize={16 * scaleFactor}
+              fontSize={16}
               labelTransform={{
-                margin: { left: 20 * scaleFactor, right: 20 * scaleFactor },
+                margin: { left: 20, right: 20 },
               }}
-              uiTransform={{ height: 40 * scaleFactor }}
+              uiTransform={{ height: 40 }}
               onMouseDown={() => {
                 handleSendTextAnnouncement(
                   engine,
@@ -127,12 +123,12 @@ export function TextAnnouncementsControl({
           </UiEntity>
         </UiEntity>
 
-        <UiEntity uiTransform={{ minHeight: 30 * scaleFactor }}>
+        <UiEntity uiTransform={{ minHeight: 30 }}>
           <UiEntity
             uiTransform={{
               display: ANNOUNCEMENT_STATE !== undefined ? 'flex' : 'none',
-              width: 30 * scaleFactor,
-              height: 30 * scaleFactor,
+              width: 30,
+              height: 30,
             }}
             uiBackground={{
               texture: { src: ICONS.CHECK },
@@ -144,7 +140,7 @@ export function TextAnnouncementsControl({
               display: ANNOUNCEMENT_STATE !== undefined ? 'flex' : 'none',
             }}
             value={`Message ${ANNOUNCEMENT_STATE === 'sent' ? 'sent' : 'cleared'}!`}
-            fontSize={14 * scaleFactor}
+            fontSize={14}
             color={Color4.create(187 / 255, 187 / 255, 187 / 255, 1)}
           />
         </UiEntity>

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/DclCast/DclCastInfo.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/DclCast/DclCastInfo.tsx
@@ -17,14 +17,12 @@ const ICONS = {
 };
 
 const DclCastInfo = ({
-  scaleFactor,
   state,
   engine,
   onResetRoomId,
   entity,
   video,
 }: {
-  scaleFactor: number;
   state: State;
   engine: IEngine;
   onResetRoomId: () => Promise<void>;
@@ -32,7 +30,7 @@ const DclCastInfo = ({
   video: DeepReadonlyObject<PBVideoPlayer> | undefined;
 }) => {
   const controls = createVideoPlayerControls(entity, engine);
-  const styles = getDclCastStyles(scaleFactor);
+  const styles = getDclCastStyles();
   const colors = getDclCastColors();
   const backgrounds = getDclCastBackgrounds();
   return (
@@ -42,12 +40,12 @@ const DclCastInfo = ({
           <UiEntity uiTransform={styles.columnFlexStart}>
             <Label
               value={'<b>Room ID</b>'}
-              fontSize={24 * scaleFactor}
+              fontSize={24}
               color={Color4.White()}
             />
             <Label
               value={`Expires in ${state.videoControl.dclCast?.expiresInDays} days`}
-              fontSize={14 * scaleFactor}
+              fontSize={14}
               color={colors.gray}
               uiTransform={styles.marginTopSmall}
             />
@@ -57,7 +55,7 @@ const DclCastInfo = ({
               id="dcl_cast_deactivate"
               value="<b>Deactivate</b>"
               variant="text"
-              fontSize={16 * scaleFactor}
+              fontSize={16}
               color={colors.white}
               uiTransform={styles.activateButton}
               onMouseDown={() => {
@@ -71,7 +69,7 @@ const DclCastInfo = ({
               value="<b>Activate</b>"
               labelTransform={styles.activateButtonLabel}
               uiTransform={styles.activateButton}
-              fontSize={16 * scaleFactor}
+              fontSize={16}
               uiBackground={backgrounds.success}
               color={colors.black}
               onMouseDown={() => {
@@ -91,13 +89,13 @@ const DclCastInfo = ({
             >
               <Label
                 value={'<b>Cast speakers</b>'}
-                fontSize={18 * scaleFactor}
+                fontSize={18}
                 color={colors.white}
               />
               <UiEntity
                 uiText={{
                   value: 'This link grants streaming access.',
-                  fontSize: 14 * scaleFactor,
+                  fontSize: 14,
                   color: colors.gray,
                   textAlign: 'top-left',
                 }}
@@ -107,7 +105,7 @@ const DclCastInfo = ({
               id="dcl_cast_copy_stream_link"
               value="<b>Copy Link</b>"
               variant="text"
-              fontSize={18 * scaleFactor}
+              fontSize={18}
               color={colors.white}
               iconRight={ICONS.COPY_TO_CLIPBOARD_ICON}
               iconRightTransform={styles.iconSmall}
@@ -126,13 +124,13 @@ const DclCastInfo = ({
             <UiEntity uiTransform={styles.textInfoContainer}>
               <Label
                 value={'<b>Viewers</b>'}
-                fontSize={18 * scaleFactor}
+                fontSize={18}
                 color={colors.white}
               />
               <UiEntity
                 uiText={{
                   value: 'This link grants viewing access.',
-                  fontSize: 14 * scaleFactor,
+                  fontSize: 14,
                   color: colors.gray,
                   textAlign: 'top-left',
                 }}
@@ -142,7 +140,7 @@ const DclCastInfo = ({
               id="dcl_cast_copy_watcher_link"
               value="<b>Copy Link</b>"
               variant="text"
-              fontSize={18 * scaleFactor}
+              fontSize={18}
               color={colors.white}
               iconRight={ICONS.COPY_TO_CLIPBOARD_ICON}
               iconRightTransform={styles.iconSmall}
@@ -170,7 +168,7 @@ const DclCastInfo = ({
             id="dcl_cast_reset_room_id"
             value="<b>Reset Room</b>"
             variant="text"
-            fontSize={16 * scaleFactor}
+            fontSize={16}
             color={colors.danger}
             uiTransform={styles.resetButton}
             onMouseDown={onResetRoomId}

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/DclCast/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/DclCast/index.tsx
@@ -2,8 +2,6 @@ import ReactEcs, { UiEntity } from '@dcl/react-ecs';
 import { DeepReadonlyObject, Entity, IEngine, PBVideoPlayer } from '@dcl/ecs';
 import { Color4 } from '@dcl/sdk/math';
 
-import { getScaleUIFactor } from '../../../ui';
-
 import { getDclCastInfo, resetStreamKey } from '../api';
 import { CONTENT_URL } from '../../constants';
 import { State } from '../../types';
@@ -43,9 +41,8 @@ const DclCast = ({
   entity: Entity;
   video: DeepReadonlyObject<PBVideoPlayer> | undefined;
 }) => {
-  const scaleFactor = getScaleUIFactor(engine);
   const { VideoControlState } = getComponents(engine);
-  const styles = getDclCastStyles(scaleFactor);
+  const styles = getDclCastStyles();
   const colors = getDclCastColors();
   const [isLoading, setIsLoading] = ReactEcs.useState(false);
   const [error, setError] = ReactEcs.useState(false);
@@ -86,14 +83,13 @@ const DclCast = ({
       <Header
         iconSrc={ICONS.DCL_CAST_ICON}
         title="DCL Cast"
-        scaleFactor={scaleFactor}
       />
       <UiEntity uiTransform={styles.fullWidthWithBottomMargin}>
         <UiEntity
           uiText={{
             value:
               'Use a browser-based DCL Cast room to easily stream camera and screen feed to a screen in your scene.',
-            fontSize: 16 * scaleFactor,
+            fontSize: 16,
             color: Color4.fromHexString('#A09BA8'),
 
             textAlign: 'top-left',
@@ -104,8 +100,7 @@ const DclCast = ({
       </UiEntity>
       {isLoading && (
         <LoadingDots
-          uiTransform={{ minHeight: 400 * scaleFactor }}
-          scaleFactor={scaleFactor}
+          uiTransform={{ minHeight: 400 }}
           engine={engine}
         />
       )}
@@ -114,15 +109,15 @@ const DclCast = ({
           <UiEntity
             uiText={{
               value: '<b>Failed to fetch DCL Cast info</b>',
-              fontSize: 16 * scaleFactor,
+              fontSize: 16,
               color: Color4.White(),
             }}
-            uiTransform={{ margin: { bottom: 8 * scaleFactor } }}
+            uiTransform={{ margin: { bottom: 8 } }}
           />
           <UiEntity
             uiText={{
               value: 'Please retry.',
-              fontSize: 16 * scaleFactor,
+              fontSize: 16,
               color: Color4.Gray(),
             }}
           />
@@ -130,7 +125,7 @@ const DclCast = ({
             id="dcl_cast_retry"
             value="<b>Retry</b>"
             variant="secondary"
-            fontSize={16 * scaleFactor}
+            fontSize={16}
             color={colors.white}
             onMouseDown={() => {
               handleGetDclCastInfo(state);
@@ -142,7 +137,6 @@ const DclCast = ({
 
       {!isLoading && !error && (
         <DclCastInfo
-          scaleFactor={scaleFactor}
           state={state}
           entity={entity}
           engine={engine}

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/DclCast/styles.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/DclCast/styles.tsx
@@ -1,7 +1,7 @@
 import { Color4 } from '@dcl/sdk/math';
 import { UiTransformProps } from '@dcl/react-ecs';
 
-export const getDclCastStyles = (scaleFactor: number): Record<string, UiTransformProps> => ({
+export const getDclCastStyles = (): Record<string, UiTransformProps> => ({
   fullContainer: {
     flexDirection: 'column',
     width: '100%',
@@ -10,7 +10,7 @@ export const getDclCastStyles = (scaleFactor: number): Record<string, UiTransfor
 
   fullWidthWithBottomMargin: {
     width: '100%',
-    margin: { bottom: 24 * scaleFactor },
+    margin: { bottom: 24 },
   },
 
   rowSpaceBetween: {
@@ -60,33 +60,33 @@ export const getDclCastStyles = (scaleFactor: number): Record<string, UiTransfor
   columnWithMarginTop: {
     display: 'flex',
     flexDirection: 'column',
-    margin: { top: 8 * scaleFactor },
+    margin: { top: 8 },
   },
 
   marginBottomSmall: {
-    margin: { bottom: 8 * scaleFactor },
+    margin: { bottom: 8 },
   },
 
   marginTopSmall: {
-    margin: { top: -4 * scaleFactor },
+    margin: { top: -4 },
   },
 
   marginRightSmall: {
-    margin: { right: 4 * scaleFactor },
+    margin: { right: 4 },
   },
 
   mainBorderedContainer: {
     width: '100%',
     height: '100%',
-    borderWidth: 2 * scaleFactor,
+    borderWidth: 2,
     borderColor: Color4.fromHexString('#716B7C'),
     flexDirection: 'column',
-    borderRadius: 12 * scaleFactor,
+    borderRadius: 12,
     padding: {
-      left: 16 * scaleFactor,
-      right: 16 * scaleFactor,
-      top: 24 * scaleFactor,
-      bottom: 8 * scaleFactor,
+      left: 16,
+      right: 16,
+      top: 24,
+      bottom: 8,
     },
   },
 
@@ -96,60 +96,60 @@ export const getDclCastStyles = (scaleFactor: number): Record<string, UiTransfor
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
-    margin: { bottom: 18 * scaleFactor },
+    margin: { bottom: 18 },
   },
 
   activateButton: {
-    minWidth: 120 * scaleFactor,
-    height: 42 * scaleFactor,
-    padding: { left: 8 * scaleFactor, right: 8 * scaleFactor },
+    minWidth: 120,
+    height: 42,
+    padding: { left: 8, right: 8 },
   },
 
   activateButtonLabel: {
-    margin: { left: 20 * scaleFactor, right: 20 * scaleFactor },
+    margin: { left: 20, right: 20 },
   },
 
   retryButton: {
-    margin: { top: 16 * scaleFactor },
+    margin: { top: 16 },
     padding: {
-      top: 8 * scaleFactor,
-      bottom: 8 * scaleFactor,
-      left: 16 * scaleFactor,
-      right: 16 * scaleFactor,
+      top: 8,
+      bottom: 8,
+      left: 16,
+      right: 16,
     },
   },
 
   resetButton: {
-    margin: { right: 8 * scaleFactor, top: 20 * scaleFactor },
-    padding: { left: 8 * scaleFactor, right: 8 * scaleFactor },
-    height: 42 * scaleFactor,
+    margin: { right: 8, top: 20 },
+    padding: { left: 8, right: 8 },
+    height: 42,
   },
 
   copyLinkButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    borderRadius: 8 * scaleFactor,
+    borderRadius: 8,
     padding: {
-      top: 4 * scaleFactor,
-      bottom: 4 * scaleFactor,
-      left: 8 * scaleFactor,
-      right: 8 * scaleFactor,
+      top: 4,
+      bottom: 4,
+      left: 8,
+      right: 8,
     },
   },
 
   iconSmall: {
-    width: 20 * scaleFactor,
-    height: 20 * scaleFactor,
+    width: 20,
+    height: 20,
   },
 
   loadingContainer: {
-    minHeight: 400 * scaleFactor,
+    minHeight: 400,
   },
 
   separatorLine: {
-    margin: { top: 16 * scaleFactor, bottom: 16 * scaleFactor },
+    margin: { top: 16, bottom: 16 },
     width: '100%',
-    height: 1 * scaleFactor,
+    height: 1,
     borderWidth: 1,
     borderColor: Color4.fromHexString('#43404A'),
   },
@@ -157,7 +157,7 @@ export const getDclCastStyles = (scaleFactor: number): Record<string, UiTransfor
   textInfoContainer: {
     display: 'flex',
     flexDirection: 'column',
-    margin: { bottom: 4 * scaleFactor },
+    margin: { bottom: 4 },
   },
 
   rowWithBottomMargin: {
@@ -166,7 +166,7 @@ export const getDclCastStyles = (scaleFactor: number): Record<string, UiTransfor
     alignItems: 'center',
     justifyContent: 'space-between',
     width: '100%',
-    margin: { bottom: 8 * scaleFactor },
+    margin: { bottom: 8 },
   },
 });
 

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/DeleteStreamKey.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/DeleteStreamKey.tsx
@@ -10,12 +10,10 @@ import { getComponents } from '../../../definitions';
 import { state } from '../..';
 
 export function DeleteStreamKeyConfirmation({
-  scaleFactor,
   engine,
   onCancel,
   onReset,
 }: {
-  scaleFactor: number;
   engine: IEngine;
   onCancel(): void;
   onReset(): void;
@@ -27,26 +25,26 @@ export function DeleteStreamKeyConfirmation({
   return (
     <UiEntity
       uiTransform={{
-        minHeight: 479 * scaleFactor,
+        minHeight: 479,
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        borderRadius: 12 * scaleFactor,
+        borderRadius: 12,
       }}
     >
       <Label
         value="<b>Are you sure you want to reset your Stream Key?</b>"
-        fontSize={16 * scaleFactor}
+        fontSize={16}
         color={Color4.fromHexString('#FCFCFC')}
       />
 
       <Label
         value="Active streams using this stream key will be disconnected."
-        fontSize={14 * scaleFactor}
+        fontSize={14}
         color={Color4.fromHexString('#FFFFFFB2')}
         uiTransform={{
-          margin: { top: 6 * scaleFactor, bottom: 24 * scaleFactor },
+          margin: { top: 6, bottom: 24 },
         }}
       />
 
@@ -64,15 +62,15 @@ export function DeleteStreamKeyConfirmation({
             id="stream_key_cancel_remove"
             value="<b>Cancel</b>"
             variant="primary"
-            fontSize={18 * scaleFactor}
+            fontSize={18}
             color={Color4.Black()}
             uiTransform={{
-              width: 90 * scaleFactor,
-              height: 40 * scaleFactor,
+              width: 90,
+              height: 40,
               display: 'flex',
               justifyContent: 'center',
               alignItems: 'center',
-              margin: { right: 30 * scaleFactor, left: 30 * scaleFactor },
+              margin: { right: 30, left: 30 },
             }}
             onMouseDown={() => onCancel()}
           />
@@ -82,11 +80,11 @@ export function DeleteStreamKeyConfirmation({
             id="stream_key_confirm_remove"
             value={'<b>Reset</b>'}
             variant="primary"
-            fontSize={18 * scaleFactor}
+            fontSize={18}
             color={Color4.White()}
             uiTransform={{
-              padding: 8 * scaleFactor,
-              height: 40 * scaleFactor,
+              padding: 8,
+              height: 40,
               justifyContent: 'center',
               alignItems: 'center',
             }}
@@ -107,18 +105,8 @@ export function DeleteStreamKeyConfirmation({
           />
         )}
       </UiEntity>
-      {isLoading && (
-        <LoadingDots
-          scaleFactor={scaleFactor}
-          engine={engine}
-        />
-      )}
-      {error && (
-        <Error
-          scaleFactor={scaleFactor}
-          text={error}
-        />
-      )}
+      {isLoading && <LoadingDots engine={engine} />}
+      {error && <Error text={error} />}
     </UiEntity>
   );
 }

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/GenerateStreamKey.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/GenerateStreamKey.tsx
@@ -9,11 +9,9 @@ import { getComponents } from '../../../definitions';
 import { state } from '../..';
 
 export function GenerateStreamKey({
-  scaleFactor,
   engine,
   onGenerate,
 }: {
-  scaleFactor: number;
   engine: IEngine;
   onGenerate: () => void;
 }) {
@@ -25,22 +23,19 @@ export function GenerateStreamKey({
     <UiEntity
       uiTransform={{
         width: '100%',
-        height: 460 * scaleFactor,
+        height: 460,
         justifyContent: 'center',
         alignItems: 'center',
       }}
     >
       {loading ? (
         <UiEntity uiTransform={{ flexDirection: 'column' }}>
-          <LoadingDots
-            scaleFactor={scaleFactor}
-            engine={engine}
-          />
+          <LoadingDots engine={engine} />
           <Label
             value="Generating your Stream Key"
             color={Color4.fromHexString('#A09BA8')}
-            fontSize={16 * scaleFactor}
-            uiTransform={{ margin: { top: 16 * scaleFactor } }}
+            fontSize={16}
+            uiTransform={{ margin: { top: 16 } }}
           />
         </UiEntity>
       ) : (
@@ -49,11 +44,11 @@ export function GenerateStreamKey({
             <Button
               id="video_control_live_generate_key"
               value="<b>Get Stream Key</b>"
-              fontSize={18 * scaleFactor}
+              fontSize={18}
               uiTransform={{
-                height: 52 * scaleFactor,
-                padding: 16 * scaleFactor,
-                margin: { bottom: 16 * scaleFactor },
+                height: 52,
+                padding: 16,
+                margin: { bottom: 16 },
               }}
               onMouseDown={async () => {
                 setLoading(true);
@@ -71,9 +66,8 @@ export function GenerateStreamKey({
           </UiEntity>
           {error && (
             <Error
-              scaleFactor={scaleFactor}
               text={error}
-              uiTransform={{ margin: { top: 16 * scaleFactor } }}
+              uiTransform={{ margin: { top: 16 } }}
             />
           )}
         </UiEntity>

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/ShowStreamKey.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/ShowStreamKey.tsx
@@ -26,7 +26,6 @@ const STREAM_KEY_INTERVAL_ACTION = 'video_control_stream_key_interval';
 const RTMP_SERVER_URL = 'rtmps://dcl.rtmp.livekit.cloud/x';
 
 export function ShowStreamKey({
-  scaleFactor,
   engine,
   video,
   entity,
@@ -34,7 +33,6 @@ export function ShowStreamKey({
   endsAt,
 }: {
   endsAt: number;
-  scaleFactor: number;
   engine: IEngine;
   entity: Entity;
   video: DeepReadonlyObject<PBVideoPlayer> | undefined;
@@ -80,17 +78,17 @@ export function ShowStreamKey({
       <Label
         value="<b>RTMP Server</b>"
         color={Color4.White()}
-        fontSize={16 * scaleFactor}
+        fontSize={16}
         uiTransform={{
-          margin: { top: 16 * scaleFactor, bottom: 8 * scaleFactor },
+          margin: { top: 16, bottom: 8 },
         }}
       />
       <UiEntity
         uiTransform={{
           width: '100%',
-          margin: { bottom: 8 * scaleFactor, top: 8 * scaleFactor },
-          height: 42 * scaleFactor,
-          borderRadius: 12 * scaleFactor,
+          margin: { bottom: 8, top: 8 },
+          height: 42,
+          borderRadius: 12,
           flexDirection: 'row',
           justifyContent: 'space-between',
           alignItems: 'center',
@@ -98,8 +96,8 @@ export function ShowStreamKey({
         uiBackground={{ color: Color4.White() }}
       >
         <Label
-          uiTransform={{ margin: { left: 16 * scaleFactor } }}
-          fontSize={16 * scaleFactor}
+          uiTransform={{ margin: { left: 16 } }}
+          fontSize={16}
           value={`<b>${RTMP_SERVER_URL}</b>`}
           color={Color4.fromHexString('#A09BA8')}
         />
@@ -107,10 +105,10 @@ export function ShowStreamKey({
           id="video_control_copy_rtmp_server"
           value="<b>Copy</b>"
           variant="primary"
-          fontSize={16 * scaleFactor}
+          fontSize={16}
           uiTransform={{
-            margin: { right: 8 * scaleFactor },
-            padding: { left: 8 * scaleFactor, right: 8 * scaleFactor },
+            margin: { right: 8 },
+            padding: { left: 8, right: 8 },
           }}
           onMouseDown={async () => {
             copyToClipboard({ text: RTMP_SERVER_URL });
@@ -120,17 +118,17 @@ export function ShowStreamKey({
       <Label
         value="<b>Stream Key</b>"
         color={Color4.White()}
-        fontSize={16 * scaleFactor}
+        fontSize={16}
         uiTransform={{
-          margin: { top: 16 * scaleFactor, bottom: 8 * scaleFactor },
+          margin: { top: 16, bottom: 8 },
         }}
       />
       <UiEntity
         uiTransform={{
           width: '100%',
-          margin: { bottom: 8 * scaleFactor, top: 8 * scaleFactor },
-          height: 42 * scaleFactor,
-          borderRadius: 12 * scaleFactor,
+          margin: { bottom: 8, top: 8 },
+          height: 42,
+          borderRadius: 12,
           flexDirection: 'row',
           justifyContent: 'space-between',
           alignItems: 'center',
@@ -147,21 +145,18 @@ export function ShowStreamKey({
           {loading ? (
             <UiEntity
               uiTransform={{
-                margin: { left: 16 * scaleFactor },
+                margin: { left: 16 },
               }}
             >
-              <LoadingDots
-                scaleFactor={scaleFactor}
-                engine={engine}
-              />
+              <LoadingDots engine={engine} />
             </UiEntity>
           ) : (
             <Label
               uiTransform={{
-                margin: { left: 16 * scaleFactor },
+                margin: { left: 16 },
                 flexShrink: 1,
               }}
-              fontSize={16 * scaleFactor}
+              fontSize={16}
               value={`<b>${showStreamkey && streamKey ? streamKey : '************'}</b>`}
               color={Color4.fromHexString('#A09BA8')}
             />
@@ -177,9 +172,9 @@ export function ShowStreamKey({
         >
           <UiEntity
             uiTransform={{
-              width: 25 * scaleFactor,
-              height: 25 * scaleFactor,
-              margin: { right: 10 * scaleFactor },
+              width: 25,
+              height: 25,
+              margin: { right: 10 },
             }}
             uiBackground={{
               textureMode: 'stretch',
@@ -206,11 +201,11 @@ export function ShowStreamKey({
             id="video_control_copy_stream_key"
             value="<b>Copy</b>"
             variant="primary"
-            fontSize={16 * scaleFactor}
+            fontSize={16}
             uiTransform={{
-              margin: { right: 8 * scaleFactor },
-              padding: { left: 8 * scaleFactor, right: 8 * scaleFactor },
-              minWidth: 60 * scaleFactor,
+              margin: { right: 8 },
+              padding: { left: 8, right: 8 },
+              minWidth: 60,
             }}
             onMouseDown={async () => {
               if (streamKey) {
@@ -232,8 +227,8 @@ export function ShowStreamKey({
       <UiEntity
         uiTransform={{
           width: '100%',
-          height: 4 * scaleFactor,
-          margin: { top: 8 * scaleFactor },
+          height: 4,
+          margin: { top: 8 },
           display: streamKey && timeRemaining > 0 && showStreamkey ? 'flex' : 'none',
         }}
         uiBackground={{ color: Color4.fromHexString('#FFFFFF1A') }}
@@ -250,10 +245,10 @@ export function ShowStreamKey({
       <UiEntity
         uiTransform={{
           width: '100%',
-          height: 40 * scaleFactor,
+          height: 40,
           flexDirection: 'row',
           justifyContent: 'space-between',
-          margin: { top: 10 * scaleFactor, bottom: 16 * scaleFactor },
+          margin: { top: 10, bottom: 16 },
         }}
       >
         {endsAt > Date.now() ? (
@@ -261,28 +256,28 @@ export function ShowStreamKey({
             <Label
               value="Stream expires in:"
               color={Color4.fromHexString('#FFFFFFB2')}
-              fontSize={14 * scaleFactor}
+              fontSize={14}
             />
             <Label
               value={formatTimeRemaining(endsAt)}
               color={Color4.fromHexString('#FFFFFFB2')}
-              fontSize={14 * scaleFactor}
+              fontSize={14}
             />
           </UiEntity>
         ) : (
           <UiEntity
             uiTransform={{
               flexDirection: 'row',
-              margin: { right: 10 * scaleFactor },
+              margin: { right: 10 },
               borderWidth: 2,
               borderColor: Color4.Green(),
             }}
           >
             <UiEntity
               uiTransform={{
-                width: 15 * scaleFactor,
-                height: 15 * scaleFactor,
-                margin: { right: 4 * scaleFactor, top: 4 * scaleFactor },
+                width: 15,
+                height: 15,
+                margin: { right: 4, top: 4 },
               }}
               uiBackground={{
                 textureMode: 'stretch',
@@ -292,7 +287,7 @@ export function ShowStreamKey({
               }}
             />
             <Label
-              fontSize={14 * scaleFactor}
+              fontSize={14}
               textAlign="middle-left"
               color={Color4.fromHexString('#FF0000')}
               value="Stream timed out. Please restart stream in broadcasting software."
@@ -304,12 +299,12 @@ export function ShowStreamKey({
             id="video_control_share_screen_clear"
             value="<b>Deactivate</b>"
             variant="text"
-            fontSize={16 * scaleFactor}
+            fontSize={16}
             color={Color4.White()}
             uiTransform={{
-              minWidth: 120 * scaleFactor,
-              margin: { right: 8 * scaleFactor },
-              padding: { left: 8 * scaleFactor, right: 8 * scaleFactor },
+              minWidth: 120,
+              margin: { right: 8 },
+              padding: { left: 8, right: 8 },
             }}
             onMouseDown={() => {
               controls.setSource('');
@@ -321,12 +316,12 @@ export function ShowStreamKey({
             id="video_control_share_screen_share"
             value="<b>Activate</b>"
             labelTransform={{
-              margin: { left: 20 * scaleFactor, right: 20 * scaleFactor },
+              margin: { left: 20, right: 20 },
             }}
             uiTransform={{
-              minWidth: 120 * scaleFactor,
+              minWidth: 120,
             }}
-            fontSize={16 * scaleFactor}
+            fontSize={16}
             uiBackground={{ color: COLORS.SUCCESS }}
             color={Color4.Black()}
             onMouseDown={() => {
@@ -347,11 +342,11 @@ export function ShowStreamKey({
           id="video_control_reset_stream_key"
           value="<b>Reset Stream Key</b>"
           variant="text"
-          fontSize={16 * scaleFactor}
+          fontSize={16}
           color={Color4.fromHexString('#FB3B3B')}
           uiTransform={{
-            margin: { right: 8 * scaleFactor, top: 20 * scaleFactor },
-            padding: { left: 8 * scaleFactor, right: 8 * scaleFactor },
+            margin: { right: 8, top: 20 },
+            padding: { left: 8, right: 8 },
           }}
           onMouseDown={() => onReset()}
         />

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/index.tsx
@@ -18,12 +18,10 @@ export const STREAMING_SUPPORT_URL = 'https://docs.decentraland.org//creator/edi
 
 export function LiveStream({
   engine,
-  scaleFactor,
   entity,
   video,
 }: {
   engine: IEngine;
-  scaleFactor: number;
   entity: Entity;
   video: DeepReadonlyObject<PBVideoPlayer> | undefined;
 }) {
@@ -54,7 +52,6 @@ export function LiveStream({
   if (showResetStreamKey) {
     return (
       <DeleteStreamKeyConfirmation
-        scaleFactor={scaleFactor}
         engine={engine}
         onCancel={() => setResetStreamKey(false)}
         onReset={() => {
@@ -70,13 +67,12 @@ export function LiveStream({
         <Header
           iconSrc={ICONS.LIVE_SOURCE}
           title="Stream"
-          scaleFactor={scaleFactor}
         />
         <UiEntity
           onMouseDown={() => openExternalUrl({ url: STREAMING_SUPPORT_URL })}
           uiTransform={{
-            width: 25 * scaleFactor,
-            height: 25 * scaleFactor,
+            width: 25,
+            height: 25,
             alignItems: 'center',
           }}
           uiBackground={{
@@ -92,18 +88,16 @@ export function LiveStream({
         textAlign="middle-left"
         value="Use the RTMP server and stream key below in your broadcasting software to start streaming to this screen."
         color={Color4.fromHexString('#A09BA8')}
-        fontSize={16 * scaleFactor}
+        fontSize={16}
       />
       {loading ? (
         <LoadingDots
-          uiTransform={{ minHeight: 400 * scaleFactor }}
-          scaleFactor={scaleFactor}
+          uiTransform={{ minHeight: 400 }}
           engine={engine}
         />
       ) : hasStreamKey ? (
         <ShowStreamKey
           endsAt={streamKeyEndsAt ?? 0}
-          scaleFactor={scaleFactor}
           engine={engine}
           entity={entity}
           video={video}
@@ -111,14 +105,13 @@ export function LiveStream({
         />
       ) : (
         <GenerateStreamKey
-          scaleFactor={scaleFactor}
           engine={engine}
           onGenerate={() => setHasStreamKey(true)}
         />
       )}
       {!hasStreamKey && (
         <Label
-          fontSize={14 * scaleFactor}
+          fontSize={14}
           color={Color4.fromHexString('#FF2D55')}
           value="Do not share your stream key with anyone, and be careful not to display it on screen while streaming."
         />

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/VideoUrl.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/VideoUrl.tsx
@@ -16,12 +16,10 @@ export const HELP_ICON = `${CONTENT_URL}/admin_toolkit/assets/icons/help.png`;
 
 export function VideoControlURL({
   engine,
-  scaleFactor,
   video,
   entity,
 }: {
   engine: IEngine;
-  scaleFactor: number;
   entity: Entity;
   video: DeepReadonlyObject<PBVideoPlayer> | undefined;
 }) {
@@ -38,13 +36,12 @@ export function VideoControlURL({
         <Header
           iconSrc={ICONS.VIDEO_SOURCE}
           title="Video URL"
-          scaleFactor={scaleFactor}
         />
         <UiEntity
           onMouseDown={() => openExternalUrl({ url: VIDEO_PLAYER_HELP_URL })}
           uiTransform={{
-            width: 25 * scaleFactor,
-            height: 25 * scaleFactor,
+            width: 25,
+            height: 25,
             alignItems: 'center',
           }}
           uiBackground={{
@@ -57,21 +54,21 @@ export function VideoControlURL({
       <Label
         value="Play videos from Vimeo by pasting a video URL below."
         color={Color4.fromHexString('#A09BA8')}
-        fontSize={16 * scaleFactor}
+        fontSize={16}
       />
       <Label
         value="<b>Video URL<b>"
         color={Color4.White()}
-        fontSize={16 * scaleFactor}
+        fontSize={16}
         uiTransform={{
-          margin: { top: 16 * scaleFactor, bottom: 8 * scaleFactor },
+          margin: { top: 16, bottom: 8 },
         }}
       />
 
       <Input
         onChange={setVideoURL}
         value={videoURL}
-        fontSize={16 * scaleFactor}
+        fontSize={16}
         textAlign="middle-left"
         placeholder="Paste your video URL"
         placeholderColor={Color4.create(160 / 255, 155 / 255, 168 / 255, 1)}
@@ -81,17 +78,17 @@ export function VideoControlURL({
           borderRadius: 12,
           borderColor: Color4.White(),
           width: '100%',
-          height: 80 * scaleFactor,
+          height: 80,
         }}
       />
 
       <UiEntity
         uiTransform={{
           width: '100%',
-          height: 40 * scaleFactor,
+          height: 40,
           flexDirection: 'row',
           justifyContent: 'flex-end',
-          margin: { top: 10 * scaleFactor },
+          margin: { top: 10 },
         }}
       >
         {video?.src && isVideoUrl(video.src) && (
@@ -99,11 +96,11 @@ export function VideoControlURL({
             id="video_control_share_screen_clear"
             value="<b>Deactivate</b>"
             variant="text"
-            fontSize={16 * scaleFactor}
+            fontSize={16}
             color={Color4.White()}
             uiTransform={{
-              margin: { right: 8 * scaleFactor },
-              padding: { left: 8 * scaleFactor, right: 8 * scaleFactor },
+              margin: { right: 8 },
+              padding: { left: 8, right: 8 },
             }}
             onMouseDown={() => {
               controls.setSource('');
@@ -120,9 +117,9 @@ export function VideoControlURL({
                 : '<b>Activate</b>'
             }
             labelTransform={{
-              margin: { left: 6 * scaleFactor, right: 6 * scaleFactor },
+              margin: { left: 6, right: 6 },
             }}
-            fontSize={16 * scaleFactor}
+            fontSize={16}
             uiBackground={{
               color: isVideoUrl(videoURL) ? COLORS.SUCCESS : Color4.fromHexString('#274431'),
             }}
@@ -136,36 +133,36 @@ export function VideoControlURL({
 
       <Label
         value="<b>Video Playback</b>"
-        fontSize={16 * scaleFactor}
+        fontSize={16}
         color={Color4.White()}
-        uiTransform={{ margin: { bottom: 10 * scaleFactor } }}
+        uiTransform={{ margin: { bottom: 10 } }}
       />
 
       <UiEntity
         uiTransform={{
           flexDirection: 'row',
           width: '100%',
-          margin: { bottom: 10 * scaleFactor },
+          margin: { bottom: 10 },
         }}
       >
         <Button
           disabled={!isActive}
           id="video_control_play"
           value="<b>Play</b>"
-          fontSize={18 * scaleFactor}
-          labelTransform={{ margin: { right: 10 * scaleFactor } }}
+          fontSize={18}
+          labelTransform={{ margin: { right: 10 } }}
           uiTransform={{
-            margin: { top: 0, right: 16 * scaleFactor, bottom: 0, left: 0 },
-            height: 42 * scaleFactor,
-            minWidth: 69 * scaleFactor,
+            margin: { top: 0, right: 16, bottom: 0, left: 0 },
+            height: 42,
+            minWidth: 69,
             alignItems: 'center',
             justifyContent: 'center',
             padding: 0,
           }}
           icon={ICONS.PLAY_BUTTON}
           iconTransform={{
-            width: 35 * scaleFactor,
-            height: 35 * scaleFactor,
+            width: 35,
+            height: 35,
           }}
           onMouseDown={() => {
             controls.play();
@@ -175,14 +172,14 @@ export function VideoControlURL({
           disabled={!isActive}
           id="video_control_pause"
           value="<b>Pause</b>"
-          fontSize={18 * scaleFactor}
+          fontSize={18}
           labelTransform={{
-            margin: { left: 6 * scaleFactor, right: 6 * scaleFactor },
+            margin: { left: 6, right: 6 },
           }}
           uiTransform={{
-            margin: { top: 0, right: 16 * scaleFactor, bottom: 0, left: 0 },
-            height: 42 * scaleFactor,
-            minWidth: 78 * scaleFactor,
+            margin: { top: 0, right: 16, bottom: 0, left: 0 },
+            height: 42,
+            minWidth: 78,
             alignItems: 'center',
             justifyContent: 'center',
             padding: 0,
@@ -196,13 +193,13 @@ export function VideoControlURL({
           id="video_control_restart"
           value="<b>Restart</b>"
           labelTransform={{
-            margin: { left: 6 * scaleFactor, right: 6 * scaleFactor },
+            margin: { left: 6, right: 6 },
           }}
-          fontSize={18 * scaleFactor}
+          fontSize={18}
           uiTransform={{
-            margin: { top: 0, right: 16 * scaleFactor, bottom: 0, left: 0 },
-            height: 42 * scaleFactor,
-            minWidth: 88 * scaleFactor,
+            margin: { top: 0, right: 16, bottom: 0, left: 0 },
+            height: 42,
+            minWidth: 88,
             alignItems: 'center',
             justifyContent: 'center',
             padding: 0,
@@ -217,14 +214,14 @@ export function VideoControlURL({
           onlyIcon
           variant={video?.loop ? 'primary' : 'secondary'}
           uiTransform={{
-            height: 42 * scaleFactor,
-            width: 49 * scaleFactor,
+            height: 42,
+            width: 49,
             alignItems: 'center',
             justifyContent: 'center',
             padding: 0,
           }}
           icon={ICONS.LOOP}
-          iconTransform={{ width: 25 * scaleFactor, height: 25 * scaleFactor }}
+          iconTransform={{ width: 25, height: 25 }}
           iconBackground={{
             color: !video?.loop ? Color4.White() : Color4.Black(),
           }}

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/VolumeControl.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/VolumeControl.tsx
@@ -1,7 +1,6 @@
 import { DeepReadonlyObject, Entity, IEngine, PBVideoPlayer } from '@dcl/ecs';
 import ReactEcs, { Label, UiEntity } from '@dcl/react-ecs';
 import { Color4 } from '@dcl/ecs-math';
-import { getScaleUIFactor } from '../../ui';
 import { Button } from '../Button';
 import { createVideoPlayerControls, getAdminToolkitVideoControl } from './utils';
 import { COLORS, DEFAULT_VOLUME, ICONS, VOLUME_STEP } from '.';
@@ -17,7 +16,6 @@ export function VideoControlVolume({
   entity: Entity;
   video: DeepReadonlyObject<PBVideoPlayer> | undefined;
 }) {
-  const scaleFactor = getScaleUIFactor(engine);
   const controls = createVideoPlayerControls(entity, engine);
   const videoControl = getAdminToolkitVideoControl(engine);
   const isSoundDisabled = videoControl?.disableVideoPlayersSound;
@@ -25,12 +23,12 @@ export function VideoControlVolume({
 
   if (isSoundDisabled) {
     return (
-      <UiEntity uiTransform={{ margin: { top: 4 * scaleFactor } }}>
+      <UiEntity uiTransform={{ margin: { top: 4 } }}>
         <UiEntity
           uiTransform={{
-            width: 24 * scaleFactor,
-            height: 24 * scaleFactor,
-            margin: { right: 8 * scaleFactor },
+            width: 24,
+            height: 24,
+            margin: { right: 8 },
           }}
           uiBackground={{
             textureMode: 'stretch',
@@ -43,13 +41,13 @@ export function VideoControlVolume({
         <Label
           value="Sound is disabled for all screens"
           color={Color4.fromHexString('#A09BA8')}
-          fontSize={14 * scaleFactor}
+          fontSize={14}
         />
         <UiEntity
           uiTransform={{
-            width: 25 * scaleFactor,
-            height: 25 * scaleFactor,
-            margin: { left: 8 * scaleFactor },
+            width: 25,
+            height: 25,
+            margin: { left: 8 },
           }}
           uiBackground={{
             textureMode: 'stretch',
@@ -67,15 +65,15 @@ export function VideoControlVolume({
     <UiEntity
       uiTransform={{
         flexDirection: 'column',
-        margin: { top: 16 * scaleFactor },
+        margin: { top: 16 },
       }}
     >
       <Label
         value={label}
-        fontSize={16 * scaleFactor}
+        fontSize={16}
         color={COLORS.WHITE}
         uiTransform={{
-          margin: { top: 0, right: 0, bottom: 10 * scaleFactor, left: 0 },
+          margin: { top: 0, right: 0, bottom: 10, left: 0 },
         }}
       />
 
@@ -87,10 +85,10 @@ export function VideoControlVolume({
         <Button
           id="video_control_volume_minus"
           value="Minus"
-          fontSize={14 * scaleFactor}
+          fontSize={14}
           uiTransform={{
-            margin: { top: 0, right: 16 * scaleFactor, bottom: 0, left: 0 },
-            width: 49 * scaleFactor,
+            margin: { top: 0, right: 16, bottom: 0, left: 0 },
+            width: 49,
             alignItems: 'center',
             justifyContent: 'center',
             padding: 0,
@@ -98,37 +96,37 @@ export function VideoControlVolume({
           icon={ICONS.VOLUME_MINUS_BUTTON}
           onlyIcon={true}
           iconTransform={{
-            width: 25 * scaleFactor,
-            height: 25 * scaleFactor,
+            width: 25,
+            height: 25,
           }}
           onMouseDown={() => controls.setVolume(-VOLUME_STEP)}
           disabled={isSoundDisabled || !video?.volume}
         />
         <Label
           value={volumePercentage}
-          fontSize={18 * scaleFactor}
+          fontSize={18}
           color={COLORS.GRAY}
           uiTransform={{
-            margin: { top: 0, right: 16 * scaleFactor, bottom: 0, left: 0 },
+            margin: { top: 0, right: 16, bottom: 0, left: 0 },
             alignItems: 'center',
             justifyContent: 'center',
             padding: 0,
-            width: 60 * scaleFactor,
+            width: 60,
           }}
         />
         <Button
           id="video_control_volume_plus"
           value="Plus"
-          fontSize={14 * scaleFactor}
+          fontSize={14}
           icon={ICONS.VOLUME_PLUS_BUTTON}
           onlyIcon={true}
           iconTransform={{
-            width: 25 * scaleFactor,
-            height: 25 * scaleFactor,
+            width: 25,
+            height: 25,
           }}
           uiTransform={{
-            margin: { top: 0, right: 16 * scaleFactor, bottom: 0, left: 0 },
-            width: 49 * scaleFactor,
+            margin: { top: 0, right: 16, bottom: 0, left: 0 },
+            width: 49,
             alignItems: 'center',
             justifyContent: 'center',
             padding: 0,
@@ -139,8 +137,8 @@ export function VideoControlVolume({
         <Button
           id="video_control_volume_mute"
           variant={!video?.volume ? 'primary' : 'secondary'}
-          fontSize={18 * scaleFactor}
-          iconTransform={{ width: 24 * scaleFactor, height: 24 * scaleFactor }}
+          fontSize={18}
+          iconTransform={{ width: 24, height: 24 }}
           onlyIcon
           icon={ICONS.MUTE}
           iconBackground={{
@@ -149,8 +147,8 @@ export function VideoControlVolume({
           uiTransform={{
             borderColor: Color4.fromHexString('#FCFCFC'),
             borderWidth: 2,
-            width: 49 * scaleFactor,
-            height: 42 * scaleFactor,
+            width: 49,
+            height: 42,
             alignItems: 'center',
             justifyContent: 'center',
             padding: 0,

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/index.tsx
@@ -1,7 +1,6 @@
 import { IEngine } from '@dcl/ecs';
 import ReactEcs, { Label, UiEntity, Dropdown } from '@dcl/react-ecs';
 import { Color4 } from '@dcl/sdk/math';
-import { getScaleUIFactor } from '../../ui';
 import { Button } from '../Button';
 import { CONTENT_URL } from '../constants';
 import { State } from '../types';
@@ -48,7 +47,6 @@ export const COLORS = {
 // Main component
 export function VideoControl({ engine, state }: { engine: IEngine; state: State }) {
   const [selectedEntity, selectedVideo] = useSelectedVideoPlayer(engine) ?? [];
-  const scaleFactor = getScaleUIFactor(engine);
   const videoPlayers = getVideoPlayers(engine);
   const [selected, setSelected] = ReactEcs.useState<'video-url' | 'live' | 'dcl-cast' | undefined>(
     undefined,
@@ -67,13 +65,12 @@ export function VideoControl({ engine, state }: { engine: IEngine; state: State 
   return (
     <UiEntity uiTransform={{ flexDirection: 'column', width: '100%', height: '100%' }}>
       <Card
-        scaleFactor={scaleFactor}
         uiTransform={{
           padding: {
-            top: 32 * scaleFactor,
-            right: 32 * scaleFactor,
+            top: 32,
+            right: 32,
             bottom: 0,
-            left: 32 * scaleFactor,
+            left: 32,
           },
         }}
       >
@@ -88,21 +85,20 @@ export function VideoControl({ engine, state }: { engine: IEngine; state: State 
           <Header
             iconSrc={ICONS.VIDEO_CONTROL}
             title="<b>VIDEO SCREENS</b>"
-            scaleFactor={scaleFactor}
           />
           {videoPlayers.length > 1 && (
             <Label
               value="<b>Current Screen</b>"
-              fontSize={16 * scaleFactor}
+              fontSize={16}
               color={Color4.White()}
-              uiTransform={{ margin: { bottom: 16 * scaleFactor } }}
+              uiTransform={{ margin: { bottom: 16 } }}
             />
           )}
 
           <UiEntity
             uiTransform={{
               flexDirection: 'column',
-              margin: { bottom: 16 * scaleFactor },
+              margin: { bottom: 16 },
             }}
           >
             {videoPlayers.length > 1 && (
@@ -115,9 +111,9 @@ export function VideoControl({ engine, state }: { engine: IEngine; state: State 
                   selectedIndex={state.videoControl.selectedVideoPlayer ?? 0}
                   onChange={idx => (state.videoControl.selectedVideoPlayer = idx)}
                   textAlign="middle-left"
-                  fontSize={16 * scaleFactor}
+                  fontSize={16}
                   uiTransform={{
-                    margin: { right: 8 * scaleFactor },
+                    margin: { right: 8 },
                     width: '100%',
                   }}
                   uiBackground={{ color: Color4.White() }}
@@ -125,16 +121,16 @@ export function VideoControl({ engine, state }: { engine: IEngine; state: State 
               </UiEntity>
             )}
             <Label
-              fontSize={16 * scaleFactor}
+              fontSize={16}
               value="<b>Media Source</b>"
               color={Color4.White()}
               uiTransform={{
-                margin: { bottom: 2 * scaleFactor, top: 16 * scaleFactor },
+                margin: { bottom: 2, top: 16 },
               }}
             />
             <UiEntity
               uiTransform={{
-                margin: { top: 10 * scaleFactor },
+                margin: { top: 10 },
                 flexDirection: 'row',
                 width: '100%',
                 justifyContent: 'space-between',
@@ -151,7 +147,6 @@ export function VideoControl({ engine, state }: { engine: IEngine; state: State 
                   value="<b>VIDEO URL</b>"
                   icon={ICONS.VIDEO_SOURCE}
                   onClick={() => setSelected('video-url')}
-                  scaleFactor={scaleFactor}
                   selected={selected === 'video-url'}
                   active={selectedVideo && isVideoUrl(selectedVideo.src)}
                 />
@@ -167,7 +162,6 @@ export function VideoControl({ engine, state }: { engine: IEngine; state: State 
                   value="<b>DCL CAST</b>"
                   icon={ICONS.DCL_CAST_SOURCE}
                   onClick={() => setSelected('dcl-cast')}
-                  scaleFactor={scaleFactor}
                   selected={selected === 'dcl-cast'}
                   active={selectedVideo && isDclCast(selectedVideo.src)}
                 />
@@ -184,7 +178,6 @@ export function VideoControl({ engine, state }: { engine: IEngine; state: State 
                   icon={ICONS.LIVE_SOURCE}
                   onClick={() => setSelected('live')}
                   active={selectedVideo && isLiveStream(selectedVideo.src)}
-                  scaleFactor={scaleFactor}
                   selected={selected === 'live'}
                 />
               </UiEntity>
@@ -193,11 +186,10 @@ export function VideoControl({ engine, state }: { engine: IEngine; state: State 
         </UiEntity>
       </Card>
       {selected && selectedEntity && (
-        <Card scaleFactor={scaleFactor}>
+        <Card>
           {selected === 'video-url' && (
             <VideoControlURL
               engine={engine}
-              scaleFactor={scaleFactor}
               entity={selectedEntity}
               video={selectedVideo}
             />
@@ -205,7 +197,6 @@ export function VideoControl({ engine, state }: { engine: IEngine; state: State 
           {selected === 'live' && (
             <LiveStream
               engine={engine}
-              scaleFactor={scaleFactor}
               entity={selectedEntity}
               video={selectedVideo}
             />
@@ -229,13 +220,12 @@ interface Props {
   value: string;
   onClick(): void;
   selected: boolean;
-  scaleFactor: number;
   icon: string;
   engine: IEngine;
   active?: boolean;
 }
 
-function CustomButton({ active, scaleFactor, value, id, onClick, icon, selected, engine }: Props) {
+function CustomButton({ active, value, id, onClick, icon, selected, engine }: Props) {
   return (
     <UiEntity uiTransform={{ flexDirection: 'column', height: '100%', width: '100%' }}>
       <UiEntity uiTransform={{ width: '100%' }}>
@@ -243,12 +233,12 @@ function CustomButton({ active, scaleFactor, value, id, onClick, icon, selected,
           id={id}
           onMouseDown={onClick}
           value={value}
-          fontSize={14 * scaleFactor}
+          fontSize={14}
           icon={icon}
           iconTransform={{
-            width: 24 * scaleFactor,
-            height: 24 * scaleFactor,
-            margin: { right: 8 * scaleFactor },
+            width: 24,
+            height: 24,
+            margin: { right: 8 },
           }}
           color={selected ? Color4.Black() : Color4.fromHexString('#FCFCFC')}
           iconBackground={{
@@ -259,23 +249,22 @@ function CustomButton({ active, scaleFactor, value, id, onClick, icon, selected,
           }}
           uiTransform={{
             padding: {
-              top: 6 * scaleFactor,
-              bottom: 6 * scaleFactor,
+              top: 6,
+              bottom: 6,
             },
-            borderRadius: 6 * scaleFactor,
+            borderRadius: 6,
             alignItems: 'center',
             justifyContent: 'center',
             width: '100%',
-            height: 36 * scaleFactor,
+            height: 36,
           }}
         />
       </UiEntity>
 
       {active && (
         <Active
-          scaleFactor={scaleFactor}
           engine={engine}
-          uiTransform={{ width: '100%', margin: { top: 6 * scaleFactor } }}
+          uiTransform={{ width: '100%', margin: { top: 6 } }}
         />
       )}
     </UiEntity>

--- a/packages/asset-packs/src/admin-toolkit-ui/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/index.tsx
@@ -2,7 +2,6 @@ import { Color4 } from '@dcl/sdk/math';
 import ReactEcs, { Label, Button as DCLButton, UiEntity, ReactBasedUiSystem } from '@dcl/react-ecs';
 import { Entity, IEngine, PointerEventsSystem } from '@dcl/ecs';
 import { getComponents, GetPlayerDataRes, IPlayersHelper, ISDKHelpers } from '../definitions';
-import { getScaleUIFactor } from '../ui';
 import { VideoControl } from './VideoControl';
 import { TextAnnouncementsControl } from './TextAnnouncementsControl';
 import { SmartItemsControl } from './SmartItemsControl';
@@ -21,7 +20,7 @@ import { ModalUserList, UserListType } from './ModerationControl/UsersList';
 import { isPreview } from './fetch-utils';
 
 export const nextTickFunctions: (() => void)[] = [];
-export let scaleFactor: number;
+const ADMIN_TOOLKIT_VIRTUAL_UI_SIZE = { virtualWidth: 1920, virtualHeight: 1080 };
 
 export let state: State = {
   adminToolkitUiEntity: 0 as Entity,
@@ -188,8 +187,9 @@ export function createAdminToolkitUI(
   // Initialize admin data before setting up the UI
   initializeAdminData(engine, sdkHelpers).then(() => {
     console.log('createAdminToolkitUI - initialized');
-    reactBasedUiSystem.setUiRenderer(() =>
-      uiComponent(engine, pointerEventsSystem, sdkHelpers, playersHelper),
+    reactBasedUiSystem.setUiRenderer(
+      () => uiComponent(engine, pointerEventsSystem, sdkHelpers, playersHelper),
+      ADMIN_TOOLKIT_VIRTUAL_UI_SIZE,
     );
   });
 }
@@ -216,7 +216,6 @@ const uiComponent = (
   const adminToolkitEntity = getAdminToolkitComponent(engine);
   const player = playersHelper?.getPlayer();
   const isPlayerAdmin = isAllowedAdmin(engine, adminToolkitEntity, player);
-  scaleFactor = getScaleUIFactor(engine);
 
   return [
     <UiEntity
@@ -231,35 +230,35 @@ const uiComponent = (
           uiTransform={{
             positionType: 'absolute',
             flexDirection: 'row',
-            position: { top: 120 * scaleFactor, right: 10 * scaleFactor },
+            position: { top: 120, right: 10 },
           }}
         >
           <UiEntity
             uiTransform={{
               display: state.panelOpen ? 'flex' : 'none',
-              width: 500 * scaleFactor,
+              width: 500,
               pointerFilter: 'block',
               flexDirection: 'column',
-              margin: { right: 8 * scaleFactor },
+              margin: { right: 8 },
             }}
           >
             <UiEntity
               uiTransform={{
                 width: '100%',
-                height: 50 * scaleFactor,
+                height: 50,
                 flexDirection: 'row',
                 alignItems: 'center',
-                borderRadius: 12 * scaleFactor,
+                borderRadius: 12,
                 padding: {
-                  left: 12 * scaleFactor,
-                  right: 12 * scaleFactor,
+                  left: 12,
+                  right: 12,
                 },
               }}
               uiBackground={{ color: containerBackgroundColor }}
             >
               <Label
                 value="ADMIN TOOLS"
-                fontSize={20 * scaleFactor}
+                fontSize={20}
                 color={Color4.create(160, 155, 168, 1)}
                 uiTransform={{ flexGrow: 1 }}
               />
@@ -273,9 +272,9 @@ const uiComponent = (
                     adminToolkitEntity.moderationControl.isEnabled && !isPreview()
                       ? 'flex'
                       : 'none',
-                  width: 49 * scaleFactor,
-                  height: 42 * scaleFactor,
-                  margin: { right: 8 * scaleFactor },
+                  width: 49,
+                  height: 42,
+                  margin: { right: 8 },
                   alignItems: 'center',
                   justifyContent: 'center',
                 }}
@@ -308,9 +307,9 @@ const uiComponent = (
                 onlyIcon
                 uiTransform={{
                   display: adminToolkitEntity.videoControl.isEnabled ? 'flex' : 'none',
-                  width: 49 * scaleFactor,
-                  height: 42 * scaleFactor,
-                  margin: { right: 8 * scaleFactor },
+                  width: 49,
+                  height: 42,
+                  margin: { right: 8 },
                   alignItems: 'center',
                   justifyContent: 'center',
                 }}
@@ -342,9 +341,9 @@ const uiComponent = (
                 onlyIcon
                 uiTransform={{
                   display: adminToolkitEntity.smartItemsControl.isEnabled ? 'flex' : 'none',
-                  width: 49 * scaleFactor,
-                  height: 42 * scaleFactor,
-                  margin: { right: 8 * scaleFactor },
+                  width: 49,
+                  height: 42,
+                  margin: { right: 8 },
                   alignItems: 'center',
                   justifyContent: 'center',
                 }}
@@ -376,9 +375,9 @@ const uiComponent = (
                 onlyIcon
                 uiTransform={{
                   display: adminToolkitEntity.textAnnouncementControl.isEnabled ? 'flex' : 'none',
-                  width: 49 * scaleFactor,
-                  height: 42 * scaleFactor,
-                  margin: { right: 8 * scaleFactor },
+                  width: 49,
+                  height: 42,
+                  margin: { right: 8 },
                   alignItems: 'center',
                   justifyContent: 'center',
                 }}
@@ -428,8 +427,8 @@ const uiComponent = (
           <UiEntity
             uiTransform={{
               display: 'flex',
-              height: 42 * scaleFactor,
-              width: 42 * scaleFactor,
+              height: 42,
+              width: 42,
               alignItems: 'center',
               alignContent: 'center',
               justifyContent: 'center',
@@ -446,8 +445,8 @@ const uiComponent = (
             <DCLButton
               value=""
               uiTransform={{
-                height: 40 * scaleFactor,
-                width: 40 * scaleFactor,
+                height: 40,
+                width: 40,
                 alignItems: 'center',
                 alignContent: 'center',
                 justifyContent: 'center',
@@ -473,7 +472,6 @@ const uiComponent = (
     </UiEntity>,
     moderationControlState.showModalAdminList && (
       <ModalUserList
-        scaleFactor={scaleFactor}
         users={sceneAdminsCache ?? []}
         engine={engine}
         type={UserListType.ADMIN}
@@ -481,7 +479,6 @@ const uiComponent = (
     ),
     moderationControlState.showModalBanList && (
       <ModalUserList
-        scaleFactor={scaleFactor}
         users={sceneBansCache ?? []}
         engine={engine}
         type={UserListType.BAN}

--- a/packages/asset-packs/src/ui.ts
+++ b/packages/asset-packs/src/ui.ts
@@ -14,7 +14,6 @@ import {
 } from '@dcl/ecs';
 import { Color4 } from '@dcl/sdk/math';
 import type { EngineComponents } from './definitions';
-import { getExplorerComponents } from './components';
 import type { ScreenAlignMode } from './enums';
 import { AlignMode, Font } from './enums';
 import { CONTENT_URL } from './admin-toolkit-ui/constants';
@@ -261,17 +260,6 @@ export function removeUiTransformEntities(
   }
 }
 
-export function getScaleUIFactor(engine: IEngine) {
-  const { UiCanvasInformation } = getExplorerComponents(engine);
-  const uiCanvasInfo = UiCanvasInformation.getOrNull(engine.RootEntity);
-
-  if (!uiCanvasInfo) return 1;
-
-  const scaleFactor = Math.min(uiCanvasInfo.width / 1920, uiCanvasInfo.height / 1080);
-
-  return scaleFactor;
-}
-
 const BTN_CLOSE_TEXT_ANNOUNCEMENT = `${CONTENT_URL}/admin_toolkit/assets/icons/text-announcement-close-button.png`;
 
 export function showCaptchaPrompt(
@@ -286,7 +274,6 @@ export function showCaptchaPrompt(
   onSubmit: (inputText: string) => void,
 ) {
   console.log('showCaptchaPrompt');
-  const scaleFactor = getScaleUIFactor(engine);
   // Create UI stack for centering
   const uiStack = engine.addEntity();
   const uiStackTransform = getUITransform(UiTransform, uiStack);
@@ -299,21 +286,21 @@ export function showCaptchaPrompt(
   const containerTransform = getUITransform(
     UiTransform,
     containerEntity,
-    260 * scaleFactor,
-    250 * scaleFactor,
+    260,
+    250,
     YGUnit.YGU_POINT,
   );
   containerTransform.parent = uiStack;
   containerTransform.display = YGDisplay.YGD_FLEX;
   containerTransform.flexDirection = YGFlexDirection.YGFD_COLUMN;
   containerTransform.alignItems = YGAlign.YGA_CENTER;
-  containerTransform.paddingTop = 20 * scaleFactor;
+  containerTransform.paddingTop = 20;
   containerTransform.paddingTopUnit = YGUnit.YGU_POINT;
-  containerTransform.paddingBottom = 20 * scaleFactor;
+  containerTransform.paddingBottom = 20;
   containerTransform.paddingBottomUnit = YGUnit.YGU_POINT;
-  containerTransform.paddingLeft = 20 * scaleFactor;
+  containerTransform.paddingLeft = 20;
   containerTransform.paddingLeftUnit = YGUnit.YGU_POINT;
-  containerTransform.paddingRight = 20 * scaleFactor;
+  containerTransform.paddingRight = 20;
   containerTransform.paddingRightUnit = YGUnit.YGU_POINT;
   containerTransform.pointerFilter = PointerFilterMode.PFM_BLOCK;
 
@@ -330,15 +317,15 @@ export function showCaptchaPrompt(
   const closeButtonTransform = getUITransform(
     UiTransform,
     closeButtonEntity,
-    24 * scaleFactor,
-    24 * scaleFactor,
+    24,
+    24,
     YGUnit.YGU_POINT,
   );
   closeButtonTransform.parent = containerEntity;
   closeButtonTransform.positionType = YGPositionType.YGPT_ABSOLUTE;
-  closeButtonTransform.positionRight = 5 * scaleFactor;
+  closeButtonTransform.positionRight = 5;
   closeButtonTransform.positionRightUnit = YGUnit.YGU_POINT;
-  closeButtonTransform.positionTop = 5 * scaleFactor;
+  closeButtonTransform.positionTop = 5;
   closeButtonTransform.positionTopUnit = YGUnit.YGU_POINT;
   closeButtonTransform.pointerFilter = PointerFilterMode.PFM_BLOCK;
 
@@ -365,62 +352,44 @@ export function showCaptchaPrompt(
 
   // Add title text
   const titleEntity = engine.addEntity();
-  const titleTransform = getUITransform(
-    UiTransform,
-    titleEntity,
-    20 * scaleFactor,
-    200 * scaleFactor,
-    YGUnit.YGU_POINT,
-  );
+  const titleTransform = getUITransform(UiTransform, titleEntity, 20, 200, YGUnit.YGU_POINT);
   titleTransform.parent = containerEntity;
-  titleTransform.marginBottom = 10 * scaleFactor;
+  titleTransform.marginBottom = 10;
   titleTransform.marginBottomUnit = YGUnit.YGU_POINT;
   titleTransform.positionType = YGPositionType.YGPT_ABSOLUTE;
-  titleTransform.positionTop = 30 * scaleFactor;
+  titleTransform.positionTop = 30;
   titleTransform.positionTopUnit = YGUnit.YGU_POINT;
 
   getUIText(
     UiText,
     titleEntity,
     'Enter the captcha',
-    20 * scaleFactor,
-    200 * scaleFactor,
+    20,
+    200,
     TextAlignMode.TAM_MIDDLE_CENTER,
     Color4.White(),
   );
 
   // Add captcha image
   const imageEntity = engine.addEntity();
-  const imageTransform = getUITransform(
-    UiTransform,
-    imageEntity,
-    80 * scaleFactor,
-    200 * scaleFactor,
-    YGUnit.YGU_POINT,
-  );
+  const imageTransform = getUITransform(UiTransform, imageEntity, 80, 200, YGUnit.YGU_POINT);
   imageTransform.parent = containerEntity;
-  imageTransform.marginBottom = 10 * scaleFactor;
+  imageTransform.marginBottom = 10;
   imageTransform.marginBottomUnit = YGUnit.YGU_POINT;
   imageTransform.positionType = YGPositionType.YGPT_ABSOLUTE;
-  imageTransform.positionTop = 60 * scaleFactor;
+  imageTransform.positionTop = 60;
   imageTransform.positionTopUnit = YGUnit.YGU_POINT;
 
   getUIBackground(UiBackground, imageEntity, data.captcha.image, BackgroundTextureMode.STRETCH);
 
   // Add input field
   const inputEntity = engine.addEntity();
-  const inputTransform = getUITransform(
-    UiTransform,
-    inputEntity,
-    50 * scaleFactor,
-    200 * scaleFactor,
-    YGUnit.YGU_POINT,
-  );
+  const inputTransform = getUITransform(UiTransform, inputEntity, 50, 200, YGUnit.YGU_POINT);
   inputTransform.parent = containerEntity;
-  inputTransform.marginBottom = 10 * scaleFactor;
+  inputTransform.marginBottom = 10;
   inputTransform.marginBottomUnit = YGUnit.YGU_POINT;
   inputTransform.positionType = YGPositionType.YGPT_ABSOLUTE;
-  inputTransform.positionTop = 150 * scaleFactor;
+  inputTransform.positionTop = 150;
   inputTransform.positionTopUnit = YGUnit.YGU_POINT;
 
   UiInput.createOrReplace(inputEntity, {
@@ -430,7 +399,7 @@ export function showCaptchaPrompt(
     disabled: false,
     textAlign: TextAlignMode.TAM_MIDDLE_CENTER,
     font: Font.F_MONOSPACE as any,
-    fontSize: 10 * scaleFactor,
+    fontSize: 10,
   });
 
   UiInputResult.createOrReplace(inputEntity, {
@@ -440,18 +409,12 @@ export function showCaptchaPrompt(
 
   // Add submit button
   const buttonEntity = engine.addEntity();
-  const buttonTransform = getUITransform(
-    UiTransform,
-    buttonEntity,
-    30 * scaleFactor,
-    100 * scaleFactor,
-    YGUnit.YGU_POINT,
-  );
+  const buttonTransform = getUITransform(UiTransform, buttonEntity, 30, 100, YGUnit.YGU_POINT);
   buttonTransform.parent = containerEntity;
-  buttonTransform.marginBottom = 10 * scaleFactor;
+  buttonTransform.marginBottom = 10;
   buttonTransform.marginBottomUnit = YGUnit.YGU_POINT;
   buttonTransform.positionType = YGPositionType.YGPT_ABSOLUTE;
-  buttonTransform.positionTop = 210 * scaleFactor;
+  buttonTransform.positionTop = 210;
   buttonTransform.positionTopUnit = YGUnit.YGU_POINT;
   buttonTransform.pointerFilter = PointerFilterMode.PFM_BLOCK;
 
@@ -459,8 +422,8 @@ export function showCaptchaPrompt(
     UiText,
     buttonEntity,
     'Submit',
-    16 * scaleFactor,
-    100 * scaleFactor,
+    16,
+    100,
     TextAlignMode.TAM_MIDDLE_CENTER,
     Color4.White(),
   );


### PR DESCRIPTION
# PR Title

## Context and Problem Statement

Solves this issue
https://github.com/decentraland/unity-explorer/issues/6692

It uses the new vitualWidth and virtualHeight instead of manually calculating a scaleFactor
https://docs.decentraland.org/creator/scenes-sdk7/2d-ui/onscreen-ui#screen-virtual-scale



## Testing

Scene Admin UI should look proportional, and adjust scales well when displayed on different screen sizes, including mac retina screens