### PR TITLE
Multi admin issues

### DIFF
--- a/packages/asset-packs/src/admin-toolkit-ui/LogsControl.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/LogsControl.tsx
@@ -1,0 +1,62 @@
+import type { IEngine } from '@dcl/ecs';
+import ReactEcs, { Label, UiEntity } from '@dcl/react-ecs';
+import { Color4 } from '@dcl/sdk/math';
+
+import { getScaleUIFactor } from '../ui';
+import { Card } from './Card';
+import { Header } from './Header';
+import { CONTENT_URL } from './constants';
+import type { State } from './types';
+
+// Using a generic control icon, we can update this if there's a specific logs icon
+const ICONS = {
+  LOGS_CONTROL: `${CONTENT_URL}/admin_toolkit/assets/icons/admin-panel-control-button.png`,
+} as const;
+
+export function LogsControl({ engine, state }: { engine: IEngine; state: State }) {
+  const scaleFactor = getScaleUIFactor(engine);
+
+  return (
+    <Card scaleFactor={scaleFactor}>
+      <UiEntity
+        key="LogsControl"
+        uiTransform={{
+          height: '100%',
+          width: '100%',
+          flexDirection: 'column',
+        }}
+      >
+        <Header
+          iconSrc={ICONS.LOGS_CONTROL}
+          title="INITIALIZATION LOGS"
+          scaleFactor={scaleFactor}
+        />
+
+        <UiEntity
+          uiTransform={{
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            padding: 8 * scaleFactor,
+            overflow: 'hidden',
+          }}
+        >
+          {state.logs.map((log, index) => (
+            <Label
+              key={`log_${index}`}
+              value={log}
+              fontSize={12 * scaleFactor}
+              color={Color4.White()}
+              uiTransform={{
+                width: '100%',
+                minHeight: 20 * scaleFactor,
+                margin: { bottom: 8 * scaleFactor },
+              }}
+              textAlign="middle-left"
+            />
+          ))}
+        </UiEntity>
+      </UiEntity>
+    </Card>
+  );
+}

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/index.tsx
@@ -38,11 +38,10 @@ export function LiveStream({
     async function streamKeyFn() {
       setLoading(true);
       const [error, data] = await getStreamKey();
-      const videoControlState = VideoControlState.getMutable(state.adminToolkitUiEntity);
       if (error) {
-        videoControlState.endsAt = undefined;
         setHasStreamKey(false);
       } else {
+        const videoControlState = VideoControlState.getMutable(state.adminToolkitUiEntity);
         videoControlState.endsAt = data?.endsAt;
         setHasStreamKey(true);
       }

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/index.tsx
@@ -33,6 +33,13 @@ export function LiveStream({
   const { VideoControlState } = getComponents(engine);
   const videoControlState = VideoControlState.getOrNull(state.adminToolkitUiEntity);
   const streamKeyEndsAt = videoControlState?.endsAt;
+  const [localStreamKeyEndsAt, setLocalStreamKeyEndsAt] = ReactEcs.useState<number | undefined>(
+    streamKeyEndsAt,
+  );
+
+  ReactEcs.useEffect(() => {
+    setLocalStreamKeyEndsAt(streamKeyEndsAt);
+  }, [streamKeyEndsAt]);
 
   ReactEcs.useEffect(() => {
     async function streamKeyFn() {
@@ -41,8 +48,7 @@ export function LiveStream({
       if (error) {
         setHasStreamKey(false);
       } else {
-        const videoControlState = VideoControlState.getMutable(state.adminToolkitUiEntity);
-        videoControlState.endsAt = data?.endsAt;
+        setLocalStreamKeyEndsAt(data?.endsAt);
         setHasStreamKey(true);
       }
       setLoading(false);
@@ -101,7 +107,7 @@ export function LiveStream({
         />
       ) : hasStreamKey ? (
         <ShowStreamKey
-          endsAt={streamKeyEndsAt ?? 0}
+          endsAt={localStreamKeyEndsAt ?? streamKeyEndsAt ?? 0}
           scaleFactor={scaleFactor}
           engine={engine}
           entity={entity}

--- a/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/index.tsx
@@ -37,17 +37,27 @@ export function LiveStream({
     streamKeyEndsAt,
   );
 
+  // localStreamKeyEndsAt mirrors streamKeyEndsAt for display purposes.
+  // Two writers: (1) synced state changes propagate via the effect below,
+  // (2) the mount-time API fetch writes directly to avoid mutating shared state.
+  // synced state takes precedence when it changes (i.e., another admin acted).
   ReactEcs.useEffect(() => {
+    console.log(
+      `[livestream] synced state changed — streamKeyEndsAt=${streamKeyEndsAt}, updating local`,
+    );
     setLocalStreamKeyEndsAt(streamKeyEndsAt);
   }, [streamKeyEndsAt]);
 
   ReactEcs.useEffect(() => {
     async function streamKeyFn() {
+      console.log('[livestream] fetching stream key from API...');
       setLoading(true);
       const [error, data] = await getStreamKey();
       if (error) {
+        console.log('[livestream] ❌ API error fetching stream key:', JSON.stringify(error));
         setHasStreamKey(false);
       } else {
+        console.log(`[livestream] ✅ API returned stream key — endsAt=${data?.endsAt}`);
         setLocalStreamKeyEndsAt(data?.endsAt);
         setHasStreamKey(true);
       }

--- a/packages/asset-packs/src/admin-toolkit-ui/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/index.tsx
@@ -158,52 +158,45 @@ function initTextAnnouncementSync(engine: IEngine) {
   });
 }
 
-// Initialize admin data before UI rendering
-let adminDataInitialized = false;
-export async function initializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelpers) {
-  if (!adminDataInitialized) {
-    const { TextAnnouncements, VideoControlState } = getComponents(engine);
-
-    // Initialize AdminToolkitUiEntity
-    state.adminToolkitUiEntity = getAdminToolkitEntity(engine) ?? engine.addEntity();
-
-    // Initialize TextAnnouncements sync component
-    initTextAnnouncementSync(engine);
-
-    // // Initialize Rewards sync
-    // initRewardsSync(engine, sdkHelpers)
-
-    // Hydration guard: give replicated state time to arrive before creating defaults.
-    const hydrated = await waitForVideoControlStateHydration(
-      engine,
-      VIDEO_CONTROL_HYDRATION_GUARD_MS,
-    );
-    if (!hydrated && !VideoControlState.getOrNull(state.adminToolkitUiEntity)) {
-      VideoControlState.create(state.adminToolkitUiEntity);
-    }
-
-    sdkHelpers?.syncEntity?.(
-      state.adminToolkitUiEntity,
-      [VideoControlState.componentId, TextAnnouncements.componentId],
-      ADMIN_TOOLS_ENTITY,
-    );
-
-    engine.addSystem(() => {
-      if (nextTickFunctions.length > 0) {
-        const nextTick = nextTickFunctions.shift();
-        if (nextTick) {
-          nextTick();
-        }
-      }
-    }, Number.POSITIVE_INFINITY);
-
-    // Initialize scene data
-    await Promise.all([fetchSceneAdmins(), fetchSceneBans()]);
-
-    adminDataInitialized = true;
-
-    console.log('initializeAdminData - initialized');
+let initPromise: Promise<void> | null = null;
+export function initializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelpers) {
+  if (!initPromise) {
+    initPromise = doInitializeAdminData(engine, sdkHelpers);
   }
+  return initPromise;
+}
+
+async function doInitializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelpers) {
+  const { TextAnnouncements, VideoControlState } = getComponents(engine);
+  state.adminToolkitUiEntity = getAdminToolkitEntity(engine) ?? engine.addEntity();
+  initTextAnnouncementSync(engine);
+
+  sdkHelpers?.syncEntity?.(
+    state.adminToolkitUiEntity,
+    [VideoControlState.componentId, TextAnnouncements.componentId],
+    ADMIN_TOOLS_ENTITY,
+  );
+
+  const hydrated = await waitForVideoControlStateHydration(
+    engine,
+    VIDEO_CONTROL_HYDRATION_GUARD_MS,
+  );
+  if (!hydrated && !VideoControlState.getOrNull(state.adminToolkitUiEntity)) {
+    VideoControlState.create(state.adminToolkitUiEntity);
+  }
+
+  engine.addSystem(() => {
+    if (nextTickFunctions.length > 0) {
+      const nextTick = nextTickFunctions.shift();
+      if (nextTick) {
+        nextTick();
+      }
+    }
+  }, Number.POSITIVE_INFINITY);
+
+  await Promise.all([fetchSceneAdmins(), fetchSceneBans()]);
+
+  console.log('initializeAdminData - initialized');
 }
 
 export function createAdminToolkitUI(

--- a/packages/asset-packs/src/admin-toolkit-ui/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/index.tsx
@@ -8,6 +8,7 @@ import { TextAnnouncementsControl } from './TextAnnouncementsControl';
 import { SmartItemsControl } from './SmartItemsControl';
 import { Button } from './Button';
 import { TextAnnouncements } from './TextAnnouncements';
+import { LogsControl } from './LogsControl';
 import { CONTENT_URL } from './constants';
 import { State, TabType, SelectedSmartItem } from './types';
 import {
@@ -48,6 +49,7 @@ export let state: State = {
   rewardsControl: {
     selectedRewardItem: undefined,
   },
+  logs: [],
 };
 
 let sceneAdminsCache: SceneAdmin[] = [];
@@ -166,21 +168,27 @@ export function initializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelpers) {
   return initPromise;
 }
 
+export function pushLog(...args: any[]) {
+  const msg = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+  state.logs.push(msg);
+  console.log(...args);
+}
+
 async function doInitializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelpers) {
-  console.log('🔧 running asset packs local version');
+  pushLog('🔧 running asset packs local version');
   const { TextAnnouncements, VideoControlState } = getComponents(engine);
   state.adminToolkitUiEntity = getAdminToolkitEntity(engine) ?? engine.addEntity();
-  console.log(`[admin-init] entity=${state.adminToolkitUiEntity}`);
+  pushLog(`[admin-init] entity=${state.adminToolkitUiEntity}`);
   initTextAnnouncementSync(engine);
 
   // Register sync BEFORE hydration wait so replicated state can arrive
-  console.log('[admin-init] registering syncEntity...');
+  pushLog('[admin-init] registering syncEntity...');
   sdkHelpers?.syncEntity?.(
     state.adminToolkitUiEntity,
     [VideoControlState.componentId, TextAnnouncements.componentId],
     ADMIN_TOOLS_ENTITY,
   );
-  console.log(
+  pushLog(
     `[admin-init] syncEntity registered. Waiting up to ${VIDEO_CONTROL_HYDRATION_GUARD_MS}ms for hydration...`,
   );
 
@@ -191,21 +199,21 @@ async function doInitializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelpers) 
 
   const existingState = VideoControlState.getOrNull(state.adminToolkitUiEntity);
   if (hydrated) {
-    console.log(
+    pushLog(
       `[admin-init] ✅ hydration SUCCESS — VideoControlState received from network:`,
       JSON.stringify(existingState),
     );
   } else if (existingState) {
-    console.log(
+    pushLog(
       `[admin-init] ⏱️ hydration timed out but VideoControlState already exists:`,
       JSON.stringify(existingState),
     );
   } else {
-    console.log(
+    pushLog(
       '[admin-init] ⚠️ hydration timed out, no VideoControlState found — creating fresh default',
     );
     VideoControlState.create(state.adminToolkitUiEntity);
-    console.log(
+    pushLog(
       '[admin-init] fresh VideoControlState created:',
       JSON.stringify(VideoControlState.getOrNull(state.adminToolkitUiEntity)),
     );
@@ -220,10 +228,10 @@ async function doInitializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelpers) 
     }
   }, Number.POSITIVE_INFINITY);
 
-  console.log('[admin-init] fetching scene admins and bans...');
+  pushLog('[admin-init] fetching scene admins and bans...');
   await Promise.all([fetchSceneAdmins(), fetchSceneBans()]);
 
-  console.log('[admin-init] ✅ fully initialized');
+  pushLog('[admin-init] ✅ fully initialized');
 }
 
 export function createAdminToolkitUI(
@@ -306,7 +314,7 @@ const uiComponent = (
               uiBackground={{ color: containerBackgroundColor }}
             >
               <Label
-                value="ADMIN TOOLS (LOCAL)"
+                value="ADMIN TOOLS (LOCAL POLA)"
                 fontSize={20 * scaleFactor}
                 color={Color4.create(160, 155, 168, 1)}
                 uiTransform={{ flexGrow: 1 }}
@@ -445,6 +453,32 @@ const uiComponent = (
                   }
                 }}
               />
+              <Button
+                id="admin_toolkit_panel_logs_control"
+                variant={state.activeTab === TabType.LOGS_CONTROL ? 'primary' : 'text'}
+                value="Logs"
+                fontSize={12 * scaleFactor}
+                color={state.activeTab === TabType.LOGS_CONTROL ? Color4.Black() : Color4.White()}
+                onlyIcon={false}
+                uiTransform={{
+                  display: 'flex',
+                  width: 49 * scaleFactor,
+                  height: 42 * scaleFactor,
+                  margin: { right: 8 * scaleFactor },
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+                onMouseDown={() => {
+                  if (state.activeTab !== TabType.LOGS_CONTROL) {
+                    state.activeTab = TabType.NONE;
+                    nextTickFunctions.push(() => {
+                      state.activeTab = TabType.LOGS_CONTROL;
+                    });
+                  } else {
+                    state.activeTab = TabType.NONE;
+                  }
+                }}
+              />
             </UiEntity>
             {state.activeTab === TabType.TEXT_ANNOUNCEMENT_CONTROL ? (
               <TextAnnouncementsControl
@@ -470,6 +504,12 @@ const uiComponent = (
                 engine={engine}
                 player={player}
                 sceneAdmins={sceneAdminsCache}
+              />
+            )}
+            {state.activeTab === TabType.LOGS_CONTROL && (
+              <LogsControl
+                engine={engine}
+                state={state}
               />
             )}
           </UiEntity>

--- a/packages/asset-packs/src/admin-toolkit-ui/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/index.tsx
@@ -167,22 +167,48 @@ export function initializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelpers) {
 }
 
 async function doInitializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelpers) {
+  console.log('🔧 running asset packs local version');
   const { TextAnnouncements, VideoControlState } = getComponents(engine);
   state.adminToolkitUiEntity = getAdminToolkitEntity(engine) ?? engine.addEntity();
+  console.log(`[admin-init] entity=${state.adminToolkitUiEntity}`);
   initTextAnnouncementSync(engine);
 
+  // Register sync BEFORE hydration wait so replicated state can arrive
+  console.log('[admin-init] registering syncEntity...');
   sdkHelpers?.syncEntity?.(
     state.adminToolkitUiEntity,
     [VideoControlState.componentId, TextAnnouncements.componentId],
     ADMIN_TOOLS_ENTITY,
+  );
+  console.log(
+    `[admin-init] syncEntity registered. Waiting up to ${VIDEO_CONTROL_HYDRATION_GUARD_MS}ms for hydration...`,
   );
 
   const hydrated = await waitForVideoControlStateHydration(
     engine,
     VIDEO_CONTROL_HYDRATION_GUARD_MS,
   );
-  if (!hydrated && !VideoControlState.getOrNull(state.adminToolkitUiEntity)) {
+
+  const existingState = VideoControlState.getOrNull(state.adminToolkitUiEntity);
+  if (hydrated) {
+    console.log(
+      `[admin-init] ✅ hydration SUCCESS — VideoControlState received from network:`,
+      JSON.stringify(existingState),
+    );
+  } else if (existingState) {
+    console.log(
+      `[admin-init] ⏱️ hydration timed out but VideoControlState already exists:`,
+      JSON.stringify(existingState),
+    );
+  } else {
+    console.log(
+      '[admin-init] ⚠️ hydration timed out, no VideoControlState found — creating fresh default',
+    );
     VideoControlState.create(state.adminToolkitUiEntity);
+    console.log(
+      '[admin-init] fresh VideoControlState created:',
+      JSON.stringify(VideoControlState.getOrNull(state.adminToolkitUiEntity)),
+    );
   }
 
   engine.addSystem(() => {
@@ -194,9 +220,10 @@ async function doInitializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelpers) 
     }
   }, Number.POSITIVE_INFINITY);
 
+  console.log('[admin-init] fetching scene admins and bans...');
   await Promise.all([fetchSceneAdmins(), fetchSceneBans()]);
 
-  console.log('initializeAdminData - initialized');
+  console.log('[admin-init] ✅ fully initialized');
 }
 
 export function createAdminToolkitUI(
@@ -279,7 +306,7 @@ const uiComponent = (
               uiBackground={{ color: containerBackgroundColor }}
             >
               <Label
-                value="ADMIN TOOLS"
+                value="ADMIN TOOLS (LOCAL)"
                 fontSize={20 * scaleFactor}
                 color={Color4.create(160, 155, 168, 1)}
                 uiTransform={{ flexGrow: 1 }}

--- a/packages/asset-packs/src/admin-toolkit-ui/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/index.tsx
@@ -22,6 +22,8 @@ import { isPreview } from './fetch-utils';
 
 export const nextTickFunctions: (() => void)[] = [];
 export let scaleFactor: number;
+const VIDEO_CONTROL_HYDRATION_GUARD_MS = 3000;
+const VIDEO_CONTROL_HYDRATION_POLL_MS = 100;
 
 export let state: State = {
   adminToolkitUiEntity: 0 as Entity,
@@ -50,6 +52,27 @@ export let state: State = {
 
 let sceneAdminsCache: SceneAdmin[] = [];
 let sceneBansCache: SceneBanUser[] = [];
+
+function sleep(ms: number) {
+  return new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function waitForVideoControlStateHydration(engine: IEngine, timeoutMs: number) {
+  const { VideoControlState } = getComponents(engine);
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    if (VideoControlState.getOrNull(state.adminToolkitUiEntity)) {
+      return true;
+    }
+
+    await sleep(VIDEO_CONTROL_HYDRATION_POLL_MS);
+  }
+
+  return false;
+}
 
 // const BTN_REWARDS_CONTROL = `${CONTENT_URL}/admin_toolkit/assets/icons/admin-panel-rewards-control-button.png`
 // const BTN_REWARDS_CONTROL_ACTIVE = `${CONTENT_URL}/admin_toolkit/assets/icons/admin-panel-rewards-control-active-button.png`
@@ -150,7 +173,12 @@ export async function initializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelp
     // // Initialize Rewards sync
     // initRewardsSync(engine, sdkHelpers)
 
-    if (!VideoControlState.getOrNull(state.adminToolkitUiEntity)) {
+    // Hydration guard: give replicated state time to arrive before creating defaults.
+    const hydrated = await waitForVideoControlStateHydration(
+      engine,
+      VIDEO_CONTROL_HYDRATION_GUARD_MS,
+    );
+    if (!hydrated && !VideoControlState.getOrNull(state.adminToolkitUiEntity)) {
       VideoControlState.create(state.adminToolkitUiEntity);
     }
 

--- a/packages/asset-packs/src/admin-toolkit-ui/index.tsx
+++ b/packages/asset-packs/src/admin-toolkit-ui/index.tsx
@@ -65,13 +65,24 @@ async function waitForVideoControlStateHydration(engine: IEngine, timeoutMs: num
   const { VideoControlState } = getComponents(engine);
   const start = Date.now();
 
+  pushLog(
+    `[video-hydration] waiting for VideoControlState (entity=${state.adminToolkitUiEntity}) up to ${timeoutMs}ms`,
+  );
+
   while (Date.now() - start < timeoutMs) {
     if (VideoControlState.getOrNull(state.adminToolkitUiEntity)) {
+      pushLog(
+        `[video-hydration] VideoControlState found after ${Date.now() - start}ms for entity=${state.adminToolkitUiEntity}`,
+      );
       return true;
     }
 
     await sleep(VIDEO_CONTROL_HYDRATION_POLL_MS);
   }
+
+  pushLog(
+    `[video-hydration] timeout after ${Date.now() - start}ms waiting for VideoControlState for entity=${state.adminToolkitUiEntity}`,
+  );
 
   return false;
 }
@@ -177,8 +188,25 @@ export function pushLog(...args: any[]) {
 async function doInitializeAdminData(engine: IEngine, sdkHelpers?: ISDKHelpers) {
   pushLog('🔧 running asset packs local version');
   const { TextAnnouncements, VideoControlState } = getComponents(engine);
-  state.adminToolkitUiEntity = getAdminToolkitEntity(engine) ?? engine.addEntity();
-  pushLog(`[admin-init] entity=${state.adminToolkitUiEntity}`);
+  const existingAdminToolkitEntity = getAdminToolkitEntity(engine);
+  state.adminToolkitUiEntity = existingAdminToolkitEntity ?? engine.addEntity();
+  pushLog(
+    `[admin-init] adminToolkitUiEntity set to ${state.adminToolkitUiEntity} (existing=${existingAdminToolkitEntity}, created=${existingAdminToolkitEntity ? 'no' : 'yes'})`,
+  );
+  pushLog(
+    `[admin-init] sdkHelpers present: ${!!sdkHelpers}, has syncEntity: ${!!sdkHelpers?.syncEntity}`,
+  );
+  if (sdkHelpers) {
+    pushLog(
+      '[admin-init] sdkHelpers snapshot:',
+      JSON.stringify({
+        keys: Object.keys(sdkHelpers),
+        hasSyncEntity: !!sdkHelpers.syncEntity,
+      }),
+    );
+  } else {
+    pushLog('[admin-init] sdkHelpers is null/undefined');
+  }
   initTextAnnouncementSync(engine);
 
   // Register sync BEFORE hydration wait so replicated state can arrive
@@ -314,7 +342,7 @@ const uiComponent = (
               uiBackground={{ color: containerBackgroundColor }}
             >
               <Label
-                value="ADMIN TOOLS (LOCAL POLA)"
+                value="ADMIN TOOLS (LOCAL ALE)"
                 fontSize={20 * scaleFactor}
                 color={Color4.create(160, 155, 168, 1)}
                 uiTransform={{ flexGrow: 1 }}

--- a/packages/asset-packs/src/admin-toolkit-ui/types.ts
+++ b/packages/asset-packs/src/admin-toolkit-ui/types.ts
@@ -9,6 +9,7 @@ export enum TabType {
   TEXT_ANNOUNCEMENT_CONTROL = 'TextAnnouncementControl',
   MODERATION_CONTROL = 'ModerationControl',
   REWARDS_CONTROL = 'RewardsControl',
+  LOGS_CONTROL = 'LogsControl',
 }
 
 export type SelectedSmartItem = { visible: boolean; selectedAction: string };
@@ -39,4 +40,5 @@ export type State = {
   rewardsControl: {
     selectedRewardItem: number | undefined;
   };
+  logs: string[];
 };


### PR DESCRIPTION

## Context and Problem Statement

This attempts to fix problems where the presence of more than one admin in the scene can cause unexpected effects to a video stream, changing the state unexpectedly.

The hypothesis is that maybe when the second admin user joins the scene, as they're still loading the scene with its default state, they somehow accidentally push that default state as if it was a new change, overwriting what the first admin was attempting to set.


## Summary

This PR reduces multiplayer sync race conditions in Scene Admin video controls by preventing late-join/default-state overwrites during initialization and panel hydration.

### ✅ Changes included

- Added a **VideoControlState hydration guard** in `packages/asset-packs/src/admin-toolkit-ui/index.tsx`:
  - Waits briefly for replicated `VideoControlState` to arrive before creating a local default.
  - Only creates a new `VideoControlState` if hydration does not happen within the timeout window.
  - Prevents a second admin from immediately creating/syncing an empty state while still joining.

- Updated Live Stream panel behavior in `packages/asset-packs/src/admin-toolkit-ui/VideoControl/LiveStream/index.tsx`:
  - Removed mount-time shared-state overwrite on `getStreamKey()` error (`endsAt` is no longer forced to `undefined`).
  - Made initial stream-key fetch **read-only** for shared state:
    - Uses local UI state for `endsAt` display during hydration/loading.
    - Avoids publishing state changes just from opening the panel.
  - Explicit admin actions (generate/reset) remain the intended writers of synced stream metadata.

### 🎯 Why this helps

- Reduces accidental state clobbering when multiple admins are present.
- Avoids passive UI loads acting like authoritative state updates.
- Keeps synchronization behavior safer without introducing revision/versioning yet.

## Scope intentionally deferred

- Revision/monotonic version checks for conflict resolution were intentionally left for a follow-up PR.

## Test notes

- TypeScript/lint checks were run on edited files with no new linter errors.
- Recommended multiplayer validation:
  1. Admin A activates/changes stream state.
  2. Admin B joins late and opens Video Control.
  3. Verify Admin B loading does not revert/override Admin A state unless Admin B performs explicit actions.