### PR TITLE
feat:init textshape component with empty text

### DIFF
--- a/packages/inspector/src/components/EntityInspector/EntityHeader/EntityHeader.tsx
+++ b/packages/inspector/src/components/EntityInspector/EntityHeader/EntityHeader.tsx
@@ -265,7 +265,7 @@ export default React.memo(
             conflictsWith: [sdk.components.NftShape.componentId],
           },
           // Default font should be Sans Serif (Font.F_SANS_SERIF = 0)
-          { font: 0 },
+          { font: 0, text: '' },
         ),
         createOption(sdk.components.PointerEvents, 'Pointer Events', {
           description:


### PR DESCRIPTION
## Fix init of Text Shape component

The TextShape component requires a text property to be init.
<img width="667" height="87" alt="Screenshot 2026-03-04 at 15 55 58" src="https://github.com/user-attachments/assets/88f73ca7-0972-41a5-9fa3-b7b5bee5fbb2" />

We were not sending that property when adding the component, so every time I tried to add a TextShape, it failed:

https://github.com/user-attachments/assets/a5d52c62-f5b4-4b8d-8649-abc2e9181515

I've only added the text property on the init:

https://github.com/user-attachments/assets/5f961676-2261-4c18-b1d8-5348bcad6ef9




