### PR TITLE
fix: add missing dependency

### DIFF
--- a/packages/inspector/src/components/ui/ColorPicker/ColorPicker.tsx
+++ b/packages/inspector/src/components/ui/ColorPicker/ColorPicker.tsx
@@ -24,7 +24,7 @@ const ColorPicker: React.FC<Props> = ({
       setColor(e.target.value.toUpperCase());
       onChange && onChange(e);
     },
-    [setColor],
+    [setColor, onChange],
   );
 
   const handleClick = useCallback(() => {


### PR DESCRIPTION
## Fix: Color picker change resetting other field values

**Root cause:** `ColorPicker`'s `handleChange` was wrapped in `useCallback` with `[setColor]` as its only dependency, missing `onChange`. This caused the callback to capture a stale `onChange` closure from the initial render. When the user changed another field (e.g. intensity) and then picked a color, the color picker's `onChange` still referenced the old input state, overwriting the intensity back to its previous value.                                            
                                                            

https://github.com/user-attachments/assets/3d5e11e5-f9fe-48b9-824b-772e6b84e31e

