### PR TITLE
feat: add PostToolUse hook to bootstrap worktree environments

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "make init && make test",
+            "timeout": 600,
+            "statusMessage": "Setting up worktree environment (install, protoc, build, test)..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# feat: add PostToolUse hook to bootstrap worktree environments

## Context and Problem Statement

When Claude Code creates git worktrees (via `EnterWorktree` or agent isolation), the worktree gets a fresh copy of the repo but lacks `node_modules`, built artifacts, and generated protobuf files. This means any work in the worktree fails until you manually run the setup commands.

## Solution

Add a `PostToolUse` hook in `.claude/settings.json` (project-level, shared with the team) that automatically bootstraps the environment after entering a worktree.

Key changes:
- New `.claude/settings.json` with a `PostToolUse` hook scoped to `EnterWorktree`
- Runs `make init && make test` which handles: clean → install → protoc → build → test
- 10-minute timeout to accommodate cold installs
- Status message so the user knows what's happening during setup

## Testing

- [ ] Open a new Claude Code session in the project
- [ ] Use worktree isolation (e.g., an agent with `isolation: "worktree"` or command line `claude -w "fix-button-alignment"`)
- [ ] Confirm the hook fires and runs `make init && make test`
- [ ] Verify the worktree has `node_modules`, protobuf gen files, and build artifacts

## Impact

Eliminates the manual setup step when working in worktrees. No impact on normal (non-worktree) workflows since the hook only fires on `EnterWorktree`.