### PR TITLE
fix: remove restricted from world content rating options

### DIFF
--- a/packages/creator-hub/renderer/src/components/Modals/WorldSettingsModal/tabs/DetailsTab/component.tsx
+++ b/packages/creator-hub/renderer/src/components/Modals/WorldSettingsModal/tabs/DetailsTab/component.tsx
@@ -18,10 +18,6 @@ const AGE_RATING_OPTIONS = [
     value: SceneAgeRating.Adult,
     label: t('modal.world_settings.details.age_rating_options.adult'),
   },
-  {
-    value: SceneAgeRating.Restricted,
-    label: t('modal.world_settings.details.age_rating_options.restricted'),
-  },
 ];
 
 const CATEGORIES_OPTIONS = [


### PR DESCRIPTION
# fix: remove restricted from world content rating options
## Context and Problem Statement

Related thread: https://decentralandteam.slack.com/archives/C07FAJEQFPE/p1772811802608219

<img width="868" height="656" alt="image" src="https://github.com/user-attachments/assets/eb47a7a8-7062-425a-b687-f8ea0069d985" />
