### PR TITLE
fix: show only worlds with published scenes on manage published filter

### DIFF
--- a/packages/creator-hub/renderer/src/lib/worlds.ts
+++ b/packages/creator-hub/renderer/src/lib/worlds.ts
@@ -302,6 +302,7 @@ export class Worlds {
       sort?: string;
       order?: 'asc' | 'desc';
       authorized_deployer?: string;
+      has_deployed_scenes?: boolean;
     } = { limit: 100, offset: 0 },
   ): Promise<WorldDataResponse | null> {
     const queryString = formatQueryParams(params);

--- a/packages/creator-hub/renderer/src/modules/store/management/slice.ts
+++ b/packages/creator-hub/renderer/src/modules/store/management/slice.ts
@@ -139,6 +139,7 @@ export const fetchWorlds = createAsyncThunk(
     const WorldsAPI = new Worlds();
 
     const worldsResponse = await WorldsAPI.fetchWorlds({
+      has_deployed_scenes: true,
       limit: PROJECTS_PAGE_LIMIT,
       search: searchQuery,
       sort: sortBy,


### PR DESCRIPTION
# fix: show only worlds with published scenes on manage published filter

## Context and Problem Statement

GET /worlds endpoints returned worlds with null properties as "published" when new worlds had permissions but no world settings yet.

<img width="838" height="830" alt="image" src="https://github.com/user-attachments/assets/a604748b-ff3e-46d2-bb94-d702bfbe808d" />

Related thread: https://decentralandteam.slack.com/archives/C07FAJEQFPE/p1772206312319009

## Solution

New query param added to the API endpoint to get only scenes with/without published scenes.

`has_deployed_scenes?: boolean`

https://docs.decentraland.org/apis/apis/worlds-content-server/content-server#get-worlds