### PR TITLE
fix: upload multiple texture files when creating custom item

### DIFF
--- a/packages/inspector/src/lib/sdk/operations/create-custom-asset/index.ts
+++ b/packages/inspector/src/lib/sdk/operations/create-custom-asset/index.ts
@@ -36,42 +36,24 @@ const excludeComponents: string[] = [
   CoreComponents.NETWORK_ENTITY,
 ];
 
-const componentsWithResources: Record<string, string[]> = {};
+const componentsWithResources: Record<string, string[][]> = {};
 
-// Modified handleResource function to be strongly typed with array paths
 function handleResource(type: string, keys: string[]): void {
-  componentsWithResources[type] = (keys as string[]).map(String);
+  if (!componentsWithResources[type]) {
+    componentsWithResources[type] = [];
+  }
+  componentsWithResources[type].push(keys);
 }
 
-// Update the handlers to use proper typing with array paths
 handleResource(CoreComponents.GLTF_CONTAINER, ['src']);
 handleResource(CoreComponents.AUDIO_SOURCE, ['audioClipUrl']);
 handleResource(CoreComponents.VIDEO_PLAYER, ['src']);
-handleResource(CoreComponents.MATERIAL, ['material', 'pbr', 'texture', 'tex', 'texture', 'src']);
-handleResource(CoreComponents.MATERIAL, [
-  'material',
-  'pbr',
-  'alphaTexture',
-  'tex',
-  'texture',
-  'src',
-]);
-handleResource(CoreComponents.MATERIAL, [
-  'material',
-  'pbr',
-  'emissiveTexture',
-  'tex',
-  'texture',
-  'src',
-]);
-handleResource(CoreComponents.MATERIAL, [
-  'material',
-  'pbr',
-  'bumpTexture',
-  'tex',
-  'texture',
-  'src',
-]);
+
+const PBR_TEXTURE_SLOTS = ['texture', 'alphaTexture', 'emissiveTexture', 'bumpTexture'];
+for (const slot of PBR_TEXTURE_SLOTS) {
+  handleResource(CoreComponents.MATERIAL, ['material', 'pbr', slot, 'tex', 'texture', 'src']);
+}
+handleResource(CoreComponents.MATERIAL, ['material', 'unlit', 'texture', 'tex', 'texture', 'src']);
 
 // Add these action types at the top with other constants
 const RESOURCE_ACTION_TYPES = [
@@ -264,23 +246,24 @@ export function createCustomAsset(engine: IEngine) {
 
         // Handle special components
         if (componentsWithResources[componentName]) {
-          const propertyKeys = componentsWithResources[componentName];
-          let value = processedComponentValue;
+          for (const propertyKeys of componentsWithResources[componentName]) {
+            let value = processedComponentValue;
 
-          // Navigate through the property chain safely
-          for (let i = 0; i < propertyKeys.length - 1; i++) {
-            if (value === undefined || value === null) break;
-            value = value[propertyKeys[i]];
-          }
+            // Navigate through the property chain safely
+            for (let i = 0; i < propertyKeys.length - 1; i++) {
+              if (value === undefined || value === null) break;
+              value = value[propertyKeys[i]];
+            }
 
-          // Only process if we have a valid value and final key
-          if (value && propertyKeys.length > 0) {
-            const finalKey = propertyKeys[propertyKeys.length - 1];
-            const originalValue: string = value[finalKey];
-            // Only local asset resources are supported
-            if (originalValue && !isValidHttpsUrl(originalValue)) {
-              value[finalKey] = originalValue.replace(/^.*[/]([^/]+)$/, '{assetPath}/$1');
-              resources.push(originalValue);
+            // Only process if we have a valid value and final key
+            if (value && propertyKeys.length > 0) {
+              const finalKey = propertyKeys[propertyKeys.length - 1];
+              const originalValue: string = value[finalKey];
+              // Only local asset resources are supported
+              if (originalValue && !isValidHttpsUrl(originalValue)) {
+                value[finalKey] = originalValue.replace(/^.*[/]([^/]+)$/, '{assetPath}/$1');
+                resources.push(originalValue);
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

Fixed a bug where custom smart items were not saving texture files in the asset folder, causing broken references when spawning the item in another scene.

### Root Cause

`componentsWithResources` was typed as `Record<string, string[]>`, allowing only **one** resource path per component type.

Since `handleResource` was called 4 times for `Material` (`texture`, `alphaTexture`, `emissiveTexture`, `bumpTexture`), each call overwrote the previous one.

Only `bumpTexture` (the last call) survived — all other textures were silently lost.

### Fix

- Changed `componentsWithResources` from `Record<string, string[]>` to `Record<string, string[][]>` to support multiple paths per component
- Changed `handleResource` to **push** paths into an array instead of overwriting
- Updated the resource extraction loop to iterate over all registered paths per component
- Added support for **unlit** material textures (previously only PBR paths were registered)


https://github.com/user-attachments/assets/ead028fa-14f4-477b-8ae5-c3d89140e208

