### PR TITLE
fix: enable gizmo before setup to fix broken first selection

### DIFF
--- a/packages/inspector/src/lib/babylon/decentraland/GizmoManager.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/GizmoManager.ts
@@ -341,15 +341,16 @@ export function createGizmoManager(context: SceneContext) {
       // Setup the new transformer based on type
       switch (type) {
         case GizmoType.POSITION: {
+          gizmoManager.positionGizmoEnabled = true;
           activateTransformer(positionTransformer, snapManager.getPositionSnap());
           // Set up callbacks for ECS updates
           if ('setUpdateCallbacks' in positionTransformer) {
             positionTransformer.setUpdateCallbacks(updateEntityPosition, dispatchAndClearFlag);
           }
-          gizmoManager.positionGizmoEnabled = true;
           break;
         }
         case GizmoType.ROTATION: {
+          gizmoManager.rotationGizmoEnabled = true;
           activateTransformer(rotationTransformer, snapManager.getRotationSnap());
           // Set up callbacks for ECS updates
           if ('setUpdateCallbacks' in rotationTransformer) {
@@ -360,16 +361,15 @@ export function createGizmoManager(context: SceneContext) {
               context,
             );
           }
-          gizmoManager.rotationGizmoEnabled = true;
           break;
         }
         case GizmoType.SCALE: {
+          gizmoManager.scaleGizmoEnabled = true;
           activateTransformer(scaleTransformer, snapManager.getScaleSnap());
           // Set up callbacks for ECS updates
           if ('setUpdateCallbacks' in scaleTransformer) {
             scaleTransformer.setUpdateCallbacks(updateEntityScale, dispatchAndClearFlag);
           }
-          gizmoManager.scaleGizmoEnabled = true;
           break;
         }
         case GizmoType.FREE: {


### PR DESCRIPTION
This PR fixes the position, rotation and scale gizmos first selection after the scene is loaded.

https://github.com/user-attachments/assets/e8971a31-33dd-476b-928b-3a942c387071


closes: #1203