### PR TITLE
[TEST/DO NOT MERGE] fix: set default alignment for show image action

### DIFF
--- a/packages/inspector/src/components/EntityInspector/ActionInspector/ShowImageAction/ShowImageAction.tsx
+++ b/packages/inspector/src/components/EntityInspector/ActionInspector/ShowImageAction/ShowImageAction.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { type ActionPayload, type ActionType } from '@dcl/asset-packs';
+import { AlignMode, type ActionPayload, type ActionType } from '@dcl/asset-packs';
 import { recursiveCheck } from '../../../../lib/utils/deep-equal';
 import { addBasePath } from '../../../../lib/logic/add-base-path';
 import { useAppSelector } from '../../../../redux/hooks';
@@ -32,6 +32,7 @@ function isValid(
 const ShowImageAction: React.FC<Props> = ({ value, onUpdate }: Props) => {
   const imageOptions = useAssetOptions(ACCEPTED_FILE_TYPES['image']);
   const [payload, setPayload] = useState<Partial<ActionPayload<ActionType.SHOW_IMAGE>>>({
+    align: AlignMode.TAM_MIDDLE_CENTER, // Default alignment
     ...value,
   });
 


### PR DESCRIPTION
## Summary

Fixed an issue where the "show image" action would not display images unless the user explicitly set the alignment field. The field is optional and should work with a default value.

## Problem

The alignment field in the show image action was not being initialized with a default value. When users created a show image action without selecting an alignment:
- The `payload.align` field remained `undefined`
- The action would fail at runtime when `mapAlignToScreenAlign(align)` was called with `undefined`
- This prevented images from being displayed

## Solution

- Imported `AlignMode` enum from `@dcl/asset-packs`
- Initialize the payload state with `align: AlignMode.TAM_MIDDLE_CENTER` as the default value
- This matches the default defined in the schema (`@dcl/asset-packs/src/definitions.ts`)
- User-provided values still override the default (via spread operator)

## Changes

```diff
+++ packages/inspector/src/components/EntityInspector/ActionInspector/ShowImageAction/ShowImageAction.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { type ActionPayload, type ActionType } from '@dcl/asset-packs';
+import { AlignMode, type ActionPayload, type ActionType } from '@dcl/asset-packs';
...
   const [payload, setPayload] = useState<Partial<ActionPayload<ActionType.SHOW_IMAGE>>>({
+    align: AlignMode.TAM_MIDDLE_CENTER, // Default alignment
     ...value,
   });
```

## Testing

- ✅ TypeScript compilation passes
- ✅ Build succeeds
- ✅ All 554 unit tests pass
- ✅ Lint and format checks pass

---
🤖 Created via Slack with Claude