### PR TITLE
fix: show image action should work without alignment field

### DIFF
--- a/packages/asset-packs/src/actions.ts
+++ b/packages/asset-packs/src/actions.ts
@@ -58,6 +58,7 @@ import {
   mapAlignToScreenAlign,
   showCaptchaPrompt,
 } from './ui';
+import { AlignMode } from './enums';
 import { getExplorerComponents } from './components';
 import { initTriggers, damageTargets, healTargets } from './triggers';
 import { followMap } from './transform';
@@ -1159,7 +1160,8 @@ export function createActionsSystem(
     getUITransform(UiTransform, engine.RootEntity);
 
     // Get a UI Stack entity
-    const screenAlign = mapAlignToScreenAlign(align);
+    // Default to center alignment if align is not provided
+    const screenAlign = mapAlignToScreenAlign(align ?? AlignMode.TAM_MIDDLE_CENTER);
     const uiStack = getUiStack(screenAlign);
 
     // TODO: Fix items wrapping


### PR DESCRIPTION
## Summary

Fixes bug where the "show image" action fails to display images when the alignment field is not set, even though the field is optional.

## Root Cause

The `mapAlignToScreenAlign()` function in `ui.ts` throws an error when it receives `undefined` as input. When the alignment field is not provided in the action payload, the function was being called with `undefined`, causing it to fail validation and throw: "Unsupported AlignMode: undefined".

## Changes

- Added `AlignMode` import from `./enums` in `actions.ts`
- Modified `handleShowImage` function to provide a default alignment (`TAM_MIDDLE_CENTER`) when `align` is `undefined` using the nullish coalescing operator (`??`)

## Testing

- ✅ Build passes: `make build-asset-packs`
- ✅ TypeScript type checking passes: `npm run typecheck` (asset-packs package)
- ✅ Linting passes: `make lint`
- ✅ Images now display correctly with alignment field unset (defaults to center alignment)

## Impact

This fix ensures the "show image" action works as expected even when users don't provide an alignment value, improving the user experience and making the optional field truly optional.

---
🤖 Created via Slack with Claude