### PR TITLE
fix: add entity tracking map for hide image action

### DIFF
--- a/packages/asset-packs/src/actions.ts
+++ b/packages/asset-packs/src/actions.ts
@@ -80,6 +80,7 @@ const initedEntities = new Set<Entity>();
 const uiStacks = new Map<string, Entity>();
 const lastUiEntityClicked = new Map<Entity, Entity>();
 const textEntities = new Map<Entity, Entity>(); // Model Entity, Text Entity
+const imageEntities = new Map<Entity, Entity>(); // Model Entity, Image Entity
 
 let internalInitActions: ((entity: Entity) => void) | null = null;
 
@@ -1171,6 +1172,8 @@ export function createActionsSystem(
 
     // Create a UI entity and a Transform component for the image
     const imageEntity = engine.addEntity();
+    // Store the image entity in the map for proper tracking
+    imageEntities.set(entity, imageEntity);
     const imageTransformComponent = getUITransform(
       UiTransform,
       imageEntity,
@@ -1218,12 +1221,26 @@ export function createActionsSystem(
 
     if (imageEntity) {
       engine.removeEntity(imageEntity as Entity);
+      // Clean up maps
+      imageEntities.delete(entity);
+      lastUiEntityClicked.delete(entity);
     } else {
-      const clickedImage = lastUiEntityClicked.get(entity);
-      if (clickedImage) {
-        engine.removeEntity(clickedImage);
+      // First check the tracked image entity
+      const trackedImage = imageEntities.get(entity);
+      if (trackedImage) {
+        engine.removeEntity(trackedImage);
+        imageEntities.delete(entity);
         lastUiEntityClicked.delete(entity);
+      } else {
+        // Fallback to clicked image for backwards compatibility
+        const clickedImage = lastUiEntityClicked.get(entity);
+        if (clickedImage) {
+          engine.removeEntity(clickedImage);
+          lastUiEntityClicked.delete(entity);
+        }
       }
+      // Clear timeout if it exists
+      stopTimeout(entity, ActionType.HIDE_IMAGE);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the hide image action to properly remove images that were never clicked.

## Root Cause

The hide image action previously only tracked images in `lastUiEntityClicked` when they were clicked via the `ON_CLICK_IMAGE` trigger. This meant that if an image was never clicked, it couldn't be removed by the hide image action.

## Changes

- Added `imageEntities` Map to track all image entities created by show image action (similar to existing `textEntities` map)
- Modified `handleShowImage` to store image entity in the tracking map
- Modified `handleHideImage` to check the tracking map first, falling back to clicked images for backwards compatibility
- Added proper cleanup of maps when removing images

## Testing

- ✅ Build passed (`make build-asset-packs`)
- ✅ Tests passed (asset-packs unit tests)
- ✅ TypeScript compilation passed (`npm run typecheck`)

## Closes

Fixes https://github.com/decentraland/asset-packs/issues/170

---
🤖 Created via Slack with Claude