### PR TITLE
fix: populate owner property in scene metadata before world deployment

### DIFF
--- a/packages/creator-hub/main/src/modules/cli.ts
+++ b/packages/creator-hub/main/src/modules/cli.ts
@@ -255,39 +255,75 @@ export async function start(
   }
 }
 
+/**
+ * Updates the `owner` field in the project's scene.json to the given wallet address.
+ * Returns the original owner value so it can be restored after deployment.
+ */
+async function setSceneOwner(path: string, wallet: string): Promise<string | undefined> {
+  const sceneJsonPath = join(path, 'scene.json');
+  const raw = await fs.readFile(sceneJsonPath, 'utf8');
+  const scene = JSON.parse(raw);
+  const originalOwner = scene.owner;
+  scene.owner = wallet;
+  await fs.writeFile(sceneJsonPath, JSON.stringify(scene, null, 2), 'utf8');
+  return originalOwner;
+}
+
+/**
+ * Restores the `owner` field in the project's scene.json to its original value.
+ */
+async function restoreSceneOwner(path: string, originalOwner: string | undefined): Promise<void> {
+  const sceneJsonPath = join(path, 'scene.json');
+  const raw = await fs.readFile(sceneJsonPath, 'utf8');
+  const scene = JSON.parse(raw);
+  if (originalOwner === undefined) {
+    delete scene.owner;
+  } else {
+    scene.owner = originalOwner;
+  }
+  await fs.writeFile(sceneJsonPath, JSON.stringify(scene, null, 2), 'utf8');
+}
+
 // ############################################################################################
 // TODO: Remove this after a couple of months...
 export async function legacyDeploy({
   path,
   target,
   targetContent,
+  wallet,
 }: DeployOptions): Promise<number> {
   if (deployServer) {
     await deployServer.stop();
   }
+
+  const originalOwner = await setSceneOwner(path, wallet);
   const port = await getAvailablePort();
-  const process = run('@dcl/sdk-commands', 'sdk-commands', {
-    args: [
-      'deploy',
-      '--no-browser',
-      '--port',
-      port.toString(),
-      ...(target ? ['--target', target] : []),
-      ...(targetContent ? ['--target-content', targetContent] : []),
-    ],
-    cwd: path,
-    env: await getEnv(path),
-    workspace: path,
-  });
+  try {
+    const process = run('@dcl/sdk-commands', 'sdk-commands', {
+      args: [
+        'deploy',
+        '--no-browser',
+        '--port',
+        port.toString(),
+        ...(target ? ['--target', target] : []),
+        ...(targetContent ? ['--target-content', targetContent] : []),
+      ],
+      cwd: path,
+      env: await getEnv(path),
+      workspace: path,
+    });
 
-  // App ready at
-  await process.waitFor(/listening/i, /error:/i, { reject: 'stderr' });
+    // App ready at
+    await process.waitFor(/listening/i, /error:/i, { reject: 'stderr' });
 
-  process.waitFor(/close the terminal/gi).then(() => process.kill());
+    process.waitFor(/close the terminal/gi).then(() => process.kill());
 
-  process.wait().catch(); // handle rejection of main promise to avoid warnings in console
+    process.wait().catch(); // handle rejection of main promise to avoid warnings in console
 
-  deployServer = { stop: () => process.kill() };
+    deployServer = { stop: () => process.kill() };
+  } finally {
+    await restoreSceneOwner(path, originalOwner);
+  }
 
   return port;
 }
@@ -332,23 +368,28 @@ export async function deploy({
     return legacyDeploy({ path, target, targetContent, chainId, wallet });
   }
 
+  const originalOwner = await setSceneOwner(path, wallet);
   const port = await getAvailablePort();
 
-  const { stop } = await runCommand(path, 'deploy', [
-    '--dir',
-    path,
-    '--no-browser',
-    '--port',
-    port.toString(),
-    ...(target ? ['--target', target] : []),
-    ...(targetContent ? ['--target-content', targetContent] : []),
-    '--programmatic',
-    '--yes',
-    '--multi-scene',
-    ...(language ? ['--language', language] : []),
-  ]);
+  try {
+    const { stop } = await runCommand(path, 'deploy', [
+      '--dir',
+      path,
+      '--no-browser',
+      '--port',
+      port.toString(),
+      ...(target ? ['--target', target] : []),
+      ...(targetContent ? ['--target-content', targetContent] : []),
+      '--programmatic',
+      '--yes',
+      '--multi-scene',
+      ...(language ? ['--language', language] : []),
+    ]);
 
-  deployServer = { stop };
+    deployServer = { stop };
+  } finally {
+    await restoreSceneOwner(path, originalOwner);
+  }
 
   return port;
 }


### PR DESCRIPTION
## Summary

- Before invoking `sdk-commands deploy`, the deployer's wallet address is now written to the `owner` field in `scene.json`
- The original value is restored after the deploy server starts (entity is already built at that point)
- Applies to both the modern (`--programmatic`) and legacy deploy paths

## Root Cause

`sdk-commands` builds the deployment entity — including its metadata — from `scene.json` **before** the wallet address is known from the linker response. The metadata was constructed with whatever `owner` value was already in `scene.json` (usually empty string or absent), so the World Content Server received `metadata.owner === ""`.

The fix writes the wallet address to `scene.json` as `owner` **before** `sdk-commands` starts, ensuring it is included when the entity is built.

## Changes

```
packages/creator-hub/main/src/modules/cli.ts | 74 +++++++++++++++++----
```

- Added `setSceneOwner` helper: reads scene.json, sets `owner`, writes it back, returns original value
- Added `restoreSceneOwner` helper: restores the original `owner` value (or deletes the field if it wasn't present)
- Updated `legacyDeploy` and `deploy` to call these helpers around the deploy invocation
- Added `wallet` destructuring to `legacyDeploy` (it was already in `DeployOptions` but unused)

## Testing

- `npm run test:main` — 16 tests passed
- `make test` — 554 tests passed
- `make typecheck` — no errors



---
🤖 Created via Slack with Claude