### PR TITLE
fix: enable copying text from the debug console

### DIFF
--- a/packages/creator-hub/main/src/mainWindow.ts
+++ b/packages/creator-hub/main/src/mainWindow.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url';
-import { type BrowserWindow } from 'electron';
+import { type BrowserWindow, Menu } from 'electron';
 
 import { createWindow, focusWindow, getWindow } from './modules/window';
 
@@ -7,6 +7,18 @@ export const MAIN_WINDOW_ID = 'main';
 
 async function createMainWindow(id: string) {
   const window = createWindow(id);
+  // Register an application menu so that macOS keyboard shortcuts (Cmd+C, Cmd+V,
+  // Cmd+A, etc.) continue to work even when the visible menu bar is hidden.
+  // On macOS these shortcuts are dispatched through the app menu; without it
+  // Cmd+C silently does nothing inside WebContents / iframes.
+  Menu.setApplicationMenu(
+    Menu.buildFromTemplate([
+      { role: 'appMenu' },
+      { role: 'editMenu' },
+      { role: 'viewMenu' },
+      { role: 'windowMenu' },
+    ]),
+  );
   window.setMenuBarVisibility(false);
   window.maximize();
 

--- a/packages/creator-hub/renderer/src/modules/rpc/scene/server.ts
+++ b/packages/creator-hub/renderer/src/modules/rpc/scene/server.ts
@@ -1,7 +1,7 @@
 import type { Transport } from '@dcl/mini-rpc';
 import { RPC } from '@dcl/mini-rpc';
 
-import { fs, editor } from '#preload';
+import { fs, editor, misc } from '#preload';
 
 import { type Project } from '/shared/types/projects';
 import { getPath } from '../';
@@ -19,18 +19,21 @@ export enum Method {
   OPEN_FILE = 'open_file',
   OPEN_DIRECTORY = 'open_directory',
   PUSH_NOTIFICATION = 'push_notification',
+  COPY_TO_CLIPBOARD = 'copy_to_clipboard',
 }
 
 export type Params = {
   [Method.OPEN_FILE]: { path: string };
   [Method.OPEN_DIRECTORY]: { path: string; createIfNotExists?: boolean };
   [Method.PUSH_NOTIFICATION]: { notification: NotificationRequest };
+  [Method.COPY_TO_CLIPBOARD]: { text: string };
 };
 
 export type Result = {
   [Method.OPEN_FILE]: void;
   [Method.OPEN_DIRECTORY]: void;
   [Method.PUSH_NOTIFICATION]: void;
+  [Method.COPY_TO_CLIPBOARD]: void;
 };
 
 export class SceneRpcServer extends RPC<Method, Params, Result> {
@@ -65,6 +68,10 @@ export class SceneRpcServer extends RPC<Method, Params, Result> {
           createGenericNotification(notification.severity, notification.message),
         ),
       );
+    });
+
+    this.handle('copy_to_clipboard', async ({ text }) => {
+      await misc.copyToClipboard(text);
     });
   }
 }

--- a/packages/inspector/src/components/Assets/DebugConsole.css
+++ b/packages/inspector/src/components/Assets/DebugConsole.css
@@ -5,6 +5,37 @@
   background: var(--tree-bg-color);
 }
 
+.DebugConsole-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 2px 8px;
+  border-bottom: 1px solid var(--divider-color, rgba(255, 255, 255, 0.1));
+  flex-shrink: 0;
+}
+
+.DebugConsole-copy-btn {
+  background: transparent;
+  border: 1px solid var(--base-08, rgba(255, 255, 255, 0.3));
+  border-radius: 3px;
+  color: var(--base-08, rgba(255, 255, 255, 0.6));
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 11px;
+  padding: 2px 8px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.DebugConsole-copy-btn:hover:not(:disabled) {
+  border-color: var(--base-01, #fff);
+  color: var(--base-01, #fff);
+}
+
+.DebugConsole-copy-btn:disabled {
+  cursor: default;
+  opacity: 0.35;
+}
+
 .DebugConsole-logs {
   flex: 1;
   overflow-y: auto;

--- a/packages/inspector/src/components/Assets/DebugConsole.tsx
+++ b/packages/inspector/src/components/Assets/DebugConsole.tsx
@@ -1,6 +1,13 @@
-import React, { useEffect, useRef, useSyncExternalStore } from 'react';
+import React, { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 
-import { subscribe, getSnapshot, clear, type DebugLogEntry } from '../../lib/logic/debug-log-store';
+import {
+  subscribe,
+  getSnapshot,
+  getPlainText,
+  clear,
+  type DebugLogEntry,
+} from '../../lib/logic/debug-log-store';
+import { getSceneClient } from '../../lib/rpc/scene';
 import { useAppSelector } from '../../redux/hooks';
 import { getDebugConsoleEnabled } from '../../redux/ui';
 
@@ -11,6 +18,7 @@ function DebugConsole() {
   const enabled = useAppSelector(getDebugConsoleEnabled);
   const logsRef = useRef<HTMLDivElement>(null);
   const prevLogCountRef = useRef(0);
+  const [copying, setCopying] = useState(false);
 
   useEffect(() => {
     if (logs.length > prevLogCountRef.current && logsRef.current) {
@@ -25,8 +33,34 @@ function DebugConsole() {
     }
   }, [enabled]);
 
+  const handleCopyAll = useCallback(async () => {
+    if (logs.length === 0 || copying) return;
+    const sceneClient = getSceneClient();
+    if (!sceneClient) return;
+    try {
+      setCopying(true);
+      const text = getPlainText();
+      await sceneClient.copyToClipboard(text);
+      await sceneClient.pushNotification({ severity: 'success', message: 'Copied to clipboard' });
+    } catch (error) {
+      console.error('Failed to copy console logs:', error);
+    } finally {
+      setCopying(false);
+    }
+  }, [logs.length, copying]);
+
   return (
     <div className="DebugConsole">
+      <div className="DebugConsole-toolbar">
+        <button
+          className="DebugConsole-copy-btn"
+          onClick={handleCopyAll}
+          disabled={logs.length === 0 || copying}
+          title="Copy all logs to clipboard"
+        >
+          {copying ? 'Copying…' : 'Copy All'}
+        </button>
+      </div>
       <div
         className="DebugConsole-logs"
         ref={logsRef}

--- a/packages/inspector/src/lib/logic/debug-log-store.ts
+++ b/packages/inspector/src/lib/logic/debug-log-store.ts
@@ -35,3 +35,17 @@ export function subscribe(listener: () => void): () => void {
   listeners.add(listener);
   return () => listeners.delete(listener);
 }
+
+/**
+ * Returns the current log entries as plain text (HTML stripped, entities decoded).
+ * Uses DOMParser so that HTML entities like &lt; and &amp; are properly unescaped.
+ */
+export function getPlainText(): string {
+  const parser = new DOMParser();
+  return entries
+    .map(entry => {
+      const doc = parser.parseFromString(entry.html, 'text/html');
+      return doc.body.textContent ?? '';
+    })
+    .join('\n');
+}

--- a/packages/inspector/src/lib/rpc/scene/client.ts
+++ b/packages/inspector/src/lib/rpc/scene/client.ts
@@ -6,18 +6,21 @@ enum Method {
   OPEN_FILE = 'open_file',
   OPEN_DIRECTORY = 'open_directory',
   PUSH_NOTIFICATION = 'push_notification',
+  COPY_TO_CLIPBOARD = 'copy_to_clipboard',
 }
 
 type Params = {
   [Method.OPEN_FILE]: { path: string };
   [Method.OPEN_DIRECTORY]: { path: string; createIfNotExists?: boolean };
   [Method.PUSH_NOTIFICATION]: { notification: NotificationRequest };
+  [Method.COPY_TO_CLIPBOARD]: { text: string };
 };
 
 type Result = {
   [Method.OPEN_FILE]: void;
   [Method.OPEN_DIRECTORY]: void;
   [Method.PUSH_NOTIFICATION]: void;
+  [Method.COPY_TO_CLIPBOARD]: void;
 };
 
 export class SceneClient extends RPC<Method, Params, Result> {
@@ -35,5 +38,9 @@ export class SceneClient extends RPC<Method, Params, Result> {
 
   pushNotification = (notification: NotificationRequest) => {
     return this.request('push_notification', { notification });
+  };
+
+  copyToClipboard = (text: string) => {
+    return this.request('copy_to_clipboard', { text });
   };
 }


### PR DESCRIPTION
## Summary

- Fix macOS `Cmd+C` on selected console text by registering an Electron application menu with `editMenu` role — `setMenuBarVisibility(false)` was hiding it, but without a registered menu the OS shortcut had nothing to invoke
- Add a **Copy All** button to the `DebugConsole` toolbar that copies all buffered log entries as plain text to the system clipboard
- Wire the copy action through the existing `SceneRpcOutbound` channel (inspector → creator-hub) via a new `copy_to_clipboard` RPC method — avoids needing `allow="clipboard-write"` on the iframe and reuses the existing Electron clipboard chain
- Show a "Copied to clipboard" snackbar on success via the existing `pushNotification` RPC path

## Plan

### Root Cause Analysis

Two independent root causes:

**1. macOS keyboard shortcut broken (Cmd+C on selected text)**
`packages/creator-hub/main/src/mainWindow.ts` calls `window.setMenuBarVisibility(false)` but never calls `Menu.setApplicationMenu()`. On macOS, `Cmd+C` for selected text requires a menu item with `role: 'copy'` in the Edit menu. Without it, the shortcut is silently dropped. Windows/Linux handle `Ctrl+C` at the OS level so they work regardless.

**2. No programmatic copy path (all platforms)**
The `DebugConsole` component had no Copy button. The inspector iframe had no access to the Electron clipboard API (it has no preload, no `contextBridge`). The `<iframe>` element also had no `allow="clipboard-write"` attribute, so `navigator.clipboard` was blocked inside the frame.

### Key Files Changed

- `packages/creator-hub/main/src/mainWindow.ts` — added `Menu.setApplicationMenu()` with edit roles
- `packages/inspector/src/components/Assets/DebugConsole.tsx` — added toolbar + Copy All button
- `packages/inspector/src/components/Assets/DebugConsole.css` — added toolbar styles
- `packages/inspector/src/lib/logic/debug-log-store.ts` — added `getPlainText()` helper (HTML stripped via DOMParser)
- `packages/inspector/src/lib/rpc/scene/client.ts` — added `COPY_TO_CLIPBOARD` RPC method
- `packages/creator-hub/renderer/src/modules/rpc/scene/server.ts` — handle `copy_to_clipboard` via `misc.copyToClipboard`

## Changes

```
 packages/creator-hub/main/src/mainWindow.ts                     |  12 +++++++++++
 packages/creator-hub/renderer/src/modules/rpc/scene/server.ts  |  10 ++++++++++
 packages/inspector/src/components/Assets/DebugConsole.css      |  28 ++++++++++++++++++++++++++++
 packages/inspector/src/components/Assets/DebugConsole.tsx       |  39 +++++++++++++++++++++++++++++++++++++++
 packages/inspector/src/lib/logic/debug-log-store.ts            |  16 ++++++++++++++++
 packages/inspector/src/lib/rpc/scene/client.ts                  |   8 ++++++++
 6 files changed, 113 insertions(+)
```

## Testing

- `make typecheck` — passed (no TS errors across all packages)
- `make test` — 66 test files, 572 tests passed (pre-existing happy-dom teardown warning unrelated to this change, confirmed identical on `main`)
- Pre-commit hook ran lint-fix, format-fix, and typecheck — all passed

## Closes

https://github.com/decentraland/creator-hub/issues/1232

---
🤖 Created via Slack with Claude