### PR TITLE
feat: add spawnCustomItem SDK operation (closes #407)

### DIFF
--- a/packages/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/inspector/src/components/Renderer/Renderer.tsx
@@ -273,6 +273,9 @@ const Renderer: React.FC = () => {
   };
 
   const importCustomAsset = async (asset: CustomAsset) => {
+    if (!sdk) return;
+    const { operations } = sdk;
+
     const destFolder = 'custom';
     const assetPackageName = asset.name.trim().replaceAll(' ', '_').toLowerCase();
     const position = await getDropPosition();
@@ -307,18 +310,22 @@ const Renderer: React.FC = () => {
       content.set('composite.json', compositeJson);
     }
 
-    const model: AssetNodeItem = {
-      type: 'asset',
-      name: asset.name,
-      parent: null,
-      asset: { type: 'gltf', src: '', id: asset.id },
-      composite: asset.composite,
-    };
     const basePath = withAssetDir(`${destFolder}/${assetPackageName}`);
 
     await dataLayer.importAsset({ content, basePath, assetPackageName: '' });
     dispatch(getAssetCatalog()); // Refresh catalog after import
-    await addAsset(model, position, basePath, true);
+
+    if (!asset.composite) return;
+    operations.spawnCustomItem(asset.composite, basePath, asset.name, position, asset.id, sdk.enumEntity);
+    await operations.dispatch();
+    analytics.track(Event.ADD_ITEM, {
+      itemId: asset.id,
+      itemName: asset.name,
+      itemPath: '',
+      isSmart: isSmart(asset),
+      isCustom: true,
+    });
+    canvasRef.current?.focus();
   };
 
   /**

--- a/packages/inspector/src/lib/data-layer/host/rpc-methods.ts
+++ b/packages/inspector/src/lib/data-layer/host/rpc-methods.ts
@@ -543,5 +543,90 @@ export async function initRpcMethods(
         throw new Error(`Custom asset with id ${assetId} not found`);
       });
     },
+
+    /**
+     * Imports a custom item's assets into the scene's asset directory and
+     * returns the composite + metadata needed to spawn it as an entity tree
+     * via the `spawnCustomItem` SDK operation.
+     *
+     * `req.path` may be either the folder name alone (e.g. "my_monster") or
+     * the full custom-item path (e.g. "custom/my_monster").
+     */
+    async spawnCustomItem(req: { path: string }) {
+      const { path } = req;
+
+      // Normalise: accept "my_monster" or "custom/my_monster"
+      const folderName = path.startsWith(`${DIRECTORY.CUSTOM}/`)
+        ? path.slice(DIRECTORY.CUSTOM.length + 1)
+        : path;
+      const customItemPath = `${DIRECTORY.CUSTOM}/${folderName}`;
+
+      // Read manifest and composite from the custom item directory
+      const [dataContent, compositeContent] = await Promise.all([
+        fs.readFile(`${customItemPath}/data.json`),
+        fs.readFile(`${customItemPath}/composite.json`),
+      ]);
+
+      const data = JSON.parse(new TextDecoder().decode(dataContent)) as {
+        id: string;
+        name: string;
+      };
+      const composite = JSON.parse(new TextDecoder().decode(compositeContent));
+
+      // Collect non-metadata resource files
+      const allFiles = await getFilesInDirectory(fs, customItemPath, [], true);
+      const resourceFiles = allFiles.filter(
+        f =>
+          !f.endsWith('/data.json') &&
+          !f.endsWith('/composite.json') &&
+          !f.endsWith('/thumbnail.png'),
+      );
+
+      // Destination path inside the scene's asset directory
+      const assetPackageName = data.name.trim().replaceAll(' ', '_').toLowerCase();
+      const basePath = withAssetDir(`custom/${assetPackageName}`);
+
+      // Build content map: relative paths → file bytes
+      const content: Map<string, Uint8Array> = new Map();
+
+      if (resourceFiles.length > 0) {
+        const assetRoot = getResourcesBasePath(resourceFiles);
+        await Promise.all(
+          resourceFiles.map(async resourcePath => {
+            const fileContent = await fs.readFile(resourcePath);
+            const relativePath = getRelativeResourcePath(resourcePath, assetRoot);
+            content.set(relativePath, fileContent);
+          }),
+        );
+      }
+
+      // Always include the composite so the folder is created even when there
+      // are no additional resource files.
+      content.set('composite.json', compositeContent);
+
+      // Copy files into the scene assets directory (with undo support)
+      return stateManager.executeTransaction('external', async () => {
+        const baseFolder = basePath ? `${basePath}/` : '';
+        const undoAcc: FileOperation[] = [];
+
+        for (const [relativePath, fileContent] of content) {
+          const filePath = `${baseFolder}${relativePath}`.replaceAll('//', '/');
+          const prevValue = (await fs.existFile(filePath)) ? await fs.readFile(filePath) : null;
+          undoAcc.push({ prevValue, newValue: fileContent, path: filePath });
+          await upsertAsset(fs, filePath, fileContent);
+        }
+
+        if (undoAcc.length > 0) {
+          undoRedoProvider.addUndoFile(undoAcc);
+        }
+
+        return {
+          composite: Buffer.from(JSON.stringify(composite)),
+          basePath,
+          name: data.name,
+          assetId: data.id,
+        };
+      });
+    },
   };
 }

--- a/packages/inspector/src/lib/data-layer/proto/data-layer.proto
+++ b/packages/inspector/src/lib/data-layer/proto/data-layer.proto
@@ -104,6 +104,21 @@ message RenameCustomAssetRequest {
   string new_name = 2;
 }
 
+// Request to import a custom item's assets into the scene and return the data
+// needed to spawn it as an entity tree via the SDK `spawnCustomItem` operation.
+// `path` may be just the folder name (e.g. "my_monster") or the full custom
+// item path (e.g. "custom/my_monster").
+message SpawnCustomItemRequest {
+  string path = 1;
+}
+
+message SpawnCustomItemResponse {
+  bytes composite = 1;
+  string base_path = 2;
+  string name = 3;
+  string asset_id = 4;
+}
+
 message UndoRedoStateResponse {
   bool can_undo = 1;
   bool can_redo = 2;
@@ -156,4 +171,7 @@ service DataService {
   rpc GetCustomAssets(Empty) returns (GetCustomAssetsResponse) {}
   rpc DeleteCustomAsset(DeleteCustomAssetRequest) returns (Empty) {}
   rpc RenameCustomAsset(RenameCustomAssetRequest) returns (Empty) {}
+  // Imports a custom item's assets into the scene and returns the composite +
+  // metadata required to spawn it as an entity tree via the SDK operation.
+  rpc SpawnCustomItem(SpawnCustomItemRequest) returns (SpawnCustomItemResponse) {}
 }

--- a/packages/inspector/src/lib/sdk/operations/index.spec.ts
+++ b/packages/inspector/src/lib/sdk/operations/index.spec.ts
@@ -35,6 +35,7 @@ describe('createOperations', () => {
     expect(operations.removeSelectedEntities).toBeDefined();
     expect(operations.duplicateEntity).toBeDefined();
     expect(operations.createCustomAsset).toBeDefined();
+    expect(operations.spawnCustomItem).toBeDefined();
     expect(operations.getSelectedEntities).toBeDefined();
     expect(operations.setGround).toBeDefined();
     expect(operations.lock).toBeDefined();

--- a/packages/inspector/src/lib/sdk/operations/index.ts
+++ b/packages/inspector/src/lib/sdk/operations/index.ts
@@ -19,6 +19,7 @@ import setGround from './set-ground';
 import lock from './lock';
 import hide from './hide';
 import createCustomAsset from './create-custom-asset';
+import spawnCustomItem from './spawn-custom-item';
 
 export interface Dispatch {
   dirty?: boolean;
@@ -38,6 +39,7 @@ export function createOperations(engine: IEngine) {
     removeSelectedEntities: removeSelectedEntities(engine),
     duplicateEntity: duplicateEntity(engine),
     createCustomAsset: createCustomAsset(engine),
+    spawnCustomItem: spawnCustomItem(engine),
     dispatch: async ({ dirty = true }: Dispatch = {}) => {
       store.dispatch(updateCanSave({ dirty }));
       await engine.update(1);

--- a/packages/inspector/src/lib/sdk/operations/spawn-custom-item/index.ts
+++ b/packages/inspector/src/lib/sdk/operations/spawn-custom-item/index.ts
@@ -1,0 +1,57 @@
+import type { Entity, IEngine, Vector3Type } from '@dcl/ecs';
+
+import type { AssetData } from '../../../logic/catalog';
+import type { EnumEntity } from '../../enum-entity';
+import addAsset from '../add-asset';
+
+/**
+ * Spawns a custom item entity tree in the scene.
+ *
+ * This operation creates an entity (or entity tree) in the ECS engine
+ * that adopts all components and structure defined in the given composite.
+ * It is the programmatic equivalent of dragging a Custom Item from the
+ * catalog into the 3D viewport.
+ *
+ * Call this after the custom item's asset files have been imported into the
+ * scene directory (e.g. via `dataLayer.spawnCustomItem`) so that all
+ * resource paths resolve correctly.
+ *
+ * @example
+ * // 1. Import files + retrieve spawn data from the data layer
+ * const { composite, basePath, name, assetId } =
+ *   await dataLayer.spawnCustomItem({ path: 'my_monster' });
+ *
+ * // 2. Spawn the entity tree at the desired position
+ * const entity = operations.spawnCustomItem(
+ *   composite, basePath, name,
+ *   { x: 8, y: 0, z: 8 },
+ *   assetId,
+ *   sdk.enumEntity,
+ * );
+ * await operations.dispatch();
+ */
+export function spawnCustomItem(engine: IEngine) {
+  return function spawnCustomItem(
+    composite: AssetData['composite'],
+    basePath: string,
+    name: string,
+    position: Vector3Type,
+    assetId: string,
+    enumEntityId: EnumEntity,
+    parent?: Entity,
+  ): Entity {
+    return addAsset(engine)(
+      parent ?? engine.RootEntity,
+      /* src */ '',
+      name,
+      position,
+      basePath,
+      enumEntityId,
+      composite,
+      assetId,
+      /* custom */ true,
+    );
+  };
+}
+
+export default spawnCustomItem;


### PR DESCRIPTION
## Summary

Closes #407

Adds the ability to spawn a Custom Item as a full entity tree in the scene **programmatically**, not just via the drag-and-drop UI.

- *New SDK operation* `operations.spawnCustomItem(composite, basePath, name, position, assetId, enumEntityId, parent?)` — wraps the existing `addAsset` path with the `custom` flag set, marking entities with the `CustomAsset` component and merging tags. An optional `parent` entity can be supplied; defaults to the scene root.
- *New RPC method* `dataLayer.spawnCustomItem({ path })` — given a custom item folder name (`"my_monster"`) or full path (`"custom/my_monster"`), copies the item's assets into the scene's `assets/custom/` directory (with undo support) and returns `{ composite, basePath, name, assetId }` ready to pass straight into `operations.spawnCustomItem`.
- *Proto* — `SpawnCustomItemRequest` / `SpawnCustomItemResponse` messages + `SpawnCustomItem` RPC added to `DataService`. Run `make protoc` after merging to regenerate the TypeScript bindings.
- *Renderer.tsx* (`importCustomAsset`) — refactored to use the new `operations.spawnCustomItem` call, removing the intermediate `AssetNodeItem` boilerplate and keeping custom-item spawn logic in one place.

## Usage example

```ts
// 1. Import asset files into the scene & get spawn data
const { composite, basePath, name, assetId } =
  await dataLayer.spawnCustomItem({ path: 'my_monster' });

// 2. Spawn the entity tree at a world position
const entity = operations.spawnCustomItem(
  composite, basePath, name,
  { x: 8, y: 0, z: 8 },
  assetId,
  sdk.enumEntity,
);
await operations.dispatch();
```

## Test plan

- [ ] Drag a Custom Item from the catalog into the 3D viewport — entity spawns correctly (existing behaviour unchanged via `importCustomAsset` refactor)
- [ ] Verify undo/redo correctly removes and restores the spawned entity + copied asset files
- [ ] Verify `operations.spawnCustomItem` is present in `createOperations` (unit test assertion added in `index.spec.ts`)
- [ ] After running `make protoc`, TypeScript compilation passes with the new proto bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Requested by nachomazzara via Slack