### PR TITLE
feat: add SPAWN_ITEM action type to spawn Custom Items at runtime

### DIFF
--- a/packages/asset-packs/src/actions.ts
+++ b/packages/asset-packs/src/actions.ts
@@ -10,6 +10,8 @@ import type {
   PointerEventsSystem,
 } from '@dcl/ecs';
 import {
+  Composite,
+  EntityMappingMode,
   Material,
   AudioStream,
   YGUnit,
@@ -280,6 +282,10 @@ export function createActionsSystem(
           }
           case ActionType.CLONE_ENTITY: {
             handleCloneEntity(entity, getPayload<ActionType.CLONE_ENTITY>(action));
+            break;
+          }
+          case ActionType.SPAWN_ITEM: {
+            handleSpawnItem(getPayload<ActionType.SPAWN_ITEM>(action));
             break;
           }
           case ActionType.REMOVE_ENTITY: {
@@ -1128,6 +1134,79 @@ export function createActionsSystem(
 
     const transform = Transform.getOrCreateMutable(cloned);
     transform.position = position;
+  }
+
+  // SPAWN_ITEM
+  function handleSpawnItem(payload: ActionPayload<ActionType.SPAWN_ITEM>) {
+    const { src, position } = payload;
+
+    if (!sdkHelpers?.getComposite) {
+      console.warn('[SPAWN_ITEM] No getComposite helper provided in sdkHelpers — cannot spawn item.');
+      return;
+    }
+
+    const resource = sdkHelpers.getComposite(src);
+    if (!resource) {
+      console.warn(`[SPAWN_ITEM] Composite not found for src="${src}"`);
+      return;
+    }
+
+    // Collect the unique entity indices from the composite components
+    const entityIndices = new Set<number>();
+    for (const component of resource.composite.components) {
+      for (const key of Object.keys(component.data)) {
+        entityIndices.add(parseInt(key, 10));
+      }
+    }
+
+    // Allocate a fresh engine entity for each composite entity index
+    const entityMapping = new Map<number, Entity>();
+    Array.from(entityIndices).forEach(idx => {
+      entityMapping.set(idx, engine.addEntity());
+    });
+
+    try {
+      Composite.instance(engine, resource, { getCompositeOrNull: () => null }, {
+        entityMapping: {
+          type: EntityMappingMode.EMM_DIRECT_MAPPING,
+          getCompositeEntity: (compositeEntity: number | Entity) =>
+            entityMapping.get(compositeEntity as number) ?? (compositeEntity as Entity),
+        },
+      });
+    } catch (err) {
+      console.error(`[SPAWN_ITEM] Failed to instance composite src="${src}": ${(err as Error).message}`);
+      return;
+    }
+
+    // Find the root entity (the entity with no parent inside the composite, i.e. the one
+    // that maps from the smallest composite entity index that has a Transform)
+    const spawnedEntities = Array.from(entityMapping.values());
+
+    // Set position on the first spawned entity that has a Transform
+    for (const spawnedEntity of spawnedEntities) {
+      if (Transform.has(spawnedEntity)) {
+        const transform = Transform.getMutable(spawnedEntity);
+        if (!transform.parent || !entityMapping.has(transform.parent as number)) {
+          // This is the root entity (no parent within the composite)
+          transform.position = position;
+          break;
+        }
+      }
+    }
+
+    // Initialize actions, triggers and sync for all spawned entities
+    const { NetworkEntity, SyncComponents } = getExplorerComponents(engine);
+    for (const spawnedEntity of spawnedEntities) {
+      initActions(spawnedEntity);
+      initTriggers(spawnedEntity);
+
+      if (NetworkEntity.has(spawnedEntity)) {
+        const syncComponent = SyncComponents.getOrNull(spawnedEntity);
+        if (syncComponent && sdkHelpers?.syncEntity) {
+          sdkHelpers.syncEntity(spawnedEntity, syncComponent.componentIds);
+        }
+      }
+    }
   }
 
   // REMOVE_ENTITY

--- a/packages/asset-packs/src/definitions.ts
+++ b/packages/asset-packs/src/definitions.ts
@@ -270,6 +270,10 @@ export const ActionSchemas = {
     message: Schemas.String,
   }),
   [ActionType.DELETE]: Schemas.Map({}),
+  [ActionType.SPAWN_ITEM]: Schemas.Map({
+    src: Schemas.String,
+    position: Schemas.Vector3,
+  }),
 };
 
 export type ActionPayload<T extends ActionType = any> = T extends keyof typeof ActionSchemas

--- a/packages/asset-packs/src/enums.ts
+++ b/packages/asset-packs/src/enums.ts
@@ -116,6 +116,7 @@ export enum ActionType {
   CALL_SCRIPT_METHOD = 'call_script_method',
   LOG_TO_CONSOLE = 'log_to_console',
   DELETE = 'delete',
+  SPAWN_ITEM = 'spawn_item',
 }
 
 // Re-export trigger enums from versioning (source of truth)

--- a/packages/asset-packs/src/types.ts
+++ b/packages/asset-packs/src/types.ts
@@ -1,4 +1,4 @@
-import type { Entity, PBAvatarBase, PBAvatarEquippedData, TransformType } from '@dcl/ecs';
+import type { Composite, Entity, PBAvatarBase, PBAvatarEquippedData, TransformType } from '@dcl/ecs';
 import { BaseComponentNames } from './constants';
 
 export type AssetPackData = {
@@ -130,6 +130,8 @@ export type Component = {
 export type ISDKHelpers = {
   // SyncEntity helper to create network entities at runtime.
   syncEntity?: SyncEntitySDK;
+  // Composite provider — resolves a composite resource by src path for SPAWN_ITEM.
+  getComposite?: (src: string) => Composite.Resource | null;
 };
 
 export type SyncEntitySDK = (

--- a/packages/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
@@ -66,6 +66,7 @@ import { ChangeTextAction } from './ChangeTextAction';
 import { ChangeCollisionsAction } from './ChangeCollisionsAction';
 import { ChangeSkyboxAction } from './ChangeSkyboxAction';
 import { SlideTextureAction } from './SlideTextureAction';
+import { SpawnItemAction } from './SpawnItemAction';
 import type { Props } from './types';
 
 import './ActionInspector.css';
@@ -132,6 +133,7 @@ const ActionMapOption: Record<string, string> = {
   [ActionType.RESET_SKYBOX]: 'Reset Skybox',
   [ActionType.LOG_TO_CONSOLE]: 'Log to Console',
   [ActionType.DELETE]: 'Delete',
+  [ActionType.SPAWN_ITEM]: 'Spawn Custom Item',
 };
 
 export default withSdk<Props>(({ sdk, entity: entityId, initialOpen = true }) => {
@@ -313,6 +315,20 @@ export default withSdk<Props>(({ sdk, entity: entityId, initialOpen = true }) =>
           const payload = getPartialPayload<ActionType.CLONE_ENTITY>(action);
           return (
             !!payload &&
+            typeof payload.position?.x === 'number' &&
+            !isNaN(payload.position?.x) &&
+            typeof payload.position?.y === 'number' &&
+            !isNaN(payload.position?.y) &&
+            typeof payload.position?.z === 'number' &&
+            !isNaN(payload.position?.z)
+          );
+        }
+        case ActionType.SPAWN_ITEM: {
+          const payload = getPartialPayload<ActionType.SPAWN_ITEM>(action);
+          return (
+            !!payload &&
+            typeof payload.src === 'string' &&
+            payload.src.length > 0 &&
             typeof payload.position?.x === 'number' &&
             !isNaN(payload.position?.x) &&
             typeof payload.position?.y === 'number' &&
@@ -620,6 +636,16 @@ export default withSdk<Props>(({ sdk, entity: entityId, initialOpen = true }) =>
       handleModifyAction(idx, {
         ...actions[idx],
         jsonPayload: getJson<ActionType.CLONE_ENTITY>(value),
+      });
+    },
+    [actions, handleModifyAction],
+  );
+
+  const handleChangeSpawnItem = useCallback(
+    (value: ActionPayload<ActionType.SPAWN_ITEM>, idx: number) => {
+      handleModifyAction(idx, {
+        ...actions[idx],
+        jsonPayload: getJson<ActionType.SPAWN_ITEM>(value),
       });
     },
     [actions, handleModifyAction],
@@ -1095,6 +1121,14 @@ export default withSdk<Props>(({ sdk, entity: entityId, initialOpen = true }) =>
           <CloneEntityAction
             value={getPartialPayload<ActionType.CLONE_ENTITY>(action)}
             onUpdate={e => handleChangeCloneEntity(e, idx)}
+          />
+        );
+      }
+      case ActionType.SPAWN_ITEM: {
+        return (
+          <SpawnItemAction
+            value={getPartialPayload<ActionType.SPAWN_ITEM>(action)}
+            onUpdate={e => handleChangeSpawnItem(e, idx)}
           />
         );
       }

--- a/packages/inspector/src/components/EntityInspector/ActionInspector/SpawnItemAction/SpawnItemAction.css
+++ b/packages/inspector/src/components/EntityInspector/ActionInspector/SpawnItemAction/SpawnItemAction.css
@@ -1,0 +1,17 @@
+.SpawnItemActionContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.SpawnItemActionContainer .row {
+  display: flex;
+  width: 100%;
+}
+
+.SpawnItemActionContainer__hint {
+  font-size: 12px;
+  color: var(--text-secondary, #888);
+  margin: 0;
+}

--- a/packages/inspector/src/components/EntityInspector/ActionInspector/SpawnItemAction/SpawnItemAction.tsx
+++ b/packages/inspector/src/components/EntityInspector/ActionInspector/SpawnItemAction/SpawnItemAction.tsx
@@ -1,0 +1,216 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { type ActionPayload, type ActionType } from '@dcl/asset-packs';
+import type { Vector3 } from '@dcl/ecs-math';
+import { recursiveCheck } from '../../../../lib/utils/deep-equal';
+import { useAppSelector } from '../../../../redux/hooks';
+import { selectCustomAssets } from '../../../../redux/app';
+import { getDataLayerInterface } from '../../../../redux/data-layer';
+import { Dropdown, TextField, InfoTooltip } from '../../../ui';
+import type { Props } from './types';
+
+import './SpawnItemAction.css';
+
+const CUSTOM_ITEM_BUNDLE_DIR = 'assets/custom';
+
+function isNumeric(value?: number) {
+  return value !== undefined && !isNaN(value);
+}
+
+function isValid(
+  payload: Partial<ActionPayload<ActionType.SPAWN_ITEM>>,
+): payload is ActionPayload<ActionType.SPAWN_ITEM> {
+  return (
+    !!payload &&
+    typeof payload.src === 'string' &&
+    payload.src.length > 0 &&
+    payload.position !== undefined &&
+    isNumeric(payload.position.x) &&
+    isNumeric(payload.position.y) &&
+    isNumeric(payload.position.z)
+  );
+}
+
+/**
+ * Resolve the `{assetPath}` tokens in a composite JSON string, replacing them
+ * with the relative path to the custom item's resource directory in the scene.
+ */
+function resolveAssetPathTokens(compositeJson: string, slug: string): string {
+  return compositeJson.replace(/\{assetPath\}/g, `custom/${slug}`);
+}
+
+/**
+ * Derive a filesystem-safe slug from a custom item directory resource path.
+ * Resources are stored under `custom/{slug}/…` so the second path segment is the slug.
+ */
+function getSlugFromResources(resources: string[]): string | null {
+  if (resources.length === 0) return null;
+  const parts = resources[0].split('/');
+  return parts.length >= 2 ? parts[1] : null;
+}
+
+const SpawnItemAction: React.FC<Props> = ({ value, onUpdate }: Props) => {
+  const customAssets = useAppSelector(selectCustomAssets);
+  const [payload, setPayload] = useState<Partial<ActionPayload<ActionType.SPAWN_ITEM>>>({
+    ...value,
+  });
+  const [bundling, setBundling] = useState(false);
+
+  const handleUpdate = useCallback(
+    (_payload: Partial<ActionPayload<ActionType.SPAWN_ITEM>>) => {
+      setPayload(_payload);
+      if (!recursiveCheck(_payload, value, 2) || !isValid(_payload)) return;
+      onUpdate(_payload);
+    },
+    [setPayload, value, onUpdate],
+  );
+
+  const customItemOptions = useMemo(
+    () => [
+      { label: 'Select a Custom Item…', value: '' },
+      ...customAssets.map(asset => ({ label: asset.name, value: asset.id })),
+    ],
+    [customAssets],
+  );
+
+  const selectedAssetId = useMemo(() => {
+    if (!payload.src) return '';
+    // Reverse-lookup the asset whose bundled composite matches the stored src
+    for (const asset of customAssets) {
+      const slug = getSlugFromResources(asset.resources);
+      if (slug && payload.src === `${CUSTOM_ITEM_BUNDLE_DIR}/${slug}.composite`) {
+        return asset.id;
+      }
+    }
+    return '';
+  }, [payload.src, customAssets]);
+
+  const handleSelectCustomItem = useCallback(
+    async ({ target: { value: assetId } }: React.ChangeEvent<HTMLSelectElement>) => {
+      if (!assetId) return;
+
+      const asset = customAssets.find(a => a.id === assetId);
+      if (!asset) return;
+
+      const slug = getSlugFromResources(asset.resources);
+      if (!slug) {
+        console.warn('[SpawnItemAction] Cannot determine slug for custom item', asset.id);
+        return;
+      }
+
+      const targetSrc = `${CUSTOM_ITEM_BUNDLE_DIR}/${slug}.composite`;
+
+      // Bundle the composite into scene assets via saveFile
+      const dataLayer = getDataLayerInterface();
+      if (dataLayer) {
+        setBundling(true);
+        try {
+          const compositeJson = JSON.stringify(asset.composite, null, 2);
+          const resolved = resolveAssetPathTokens(compositeJson, slug);
+          const content = new TextEncoder().encode(resolved);
+          await dataLayer.saveFile({ path: targetSrc, content });
+        } catch (err) {
+          console.error('[SpawnItemAction] Failed to bundle composite:', err);
+        } finally {
+          setBundling(false);
+        }
+      }
+
+      handleUpdate({ ...payload, src: targetSrc });
+    },
+    [customAssets, payload, handleUpdate],
+  );
+
+  const handleChangePositionX = useCallback(
+    ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
+      if (!value) return;
+      handleUpdate({
+        ...payload,
+        position: { ...(payload.position as Vector3), x: parseFloat(value) },
+      });
+    },
+    [payload, handleUpdate],
+  );
+
+  const handleChangePositionY = useCallback(
+    ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
+      if (!value) return;
+      handleUpdate({
+        ...payload,
+        position: { ...(payload.position as Vector3), y: parseFloat(value) },
+      });
+    },
+    [payload, handleUpdate],
+  );
+
+  const handleChangePositionZ = useCallback(
+    ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
+      if (!value) return;
+      handleUpdate({
+        ...payload,
+        position: { ...(payload.position as Vector3), z: parseFloat(value) },
+      });
+    },
+    [payload, handleUpdate],
+  );
+
+  const renderPositionInfo = useMemo(
+    () => (
+      <InfoTooltip
+        text="Position where the Custom Item will be spawned, relative to the scene origin. X: left/right, Y: up/down, Z: forward/backward."
+        position="top center"
+      />
+    ),
+    [],
+  );
+
+  return (
+    <div className="SpawnItemActionContainer">
+      <div className="row">
+        <Dropdown
+          label="Custom Item"
+          value={selectedAssetId}
+          options={customItemOptions}
+          onChange={handleSelectCustomItem}
+          disabled={bundling}
+        />
+      </div>
+      {customAssets.length === 0 && (
+        <div className="row">
+          <p className="SpawnItemActionContainer__hint">
+            No Custom Items found in this scene. Save entities as Custom Items first.
+          </p>
+        </div>
+      )}
+      <div className="row">
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', width: '100%' }}>
+          <div style={{ flex: 1, display: 'flex', gap: '8px' }}>
+            <TextField
+              leftLabel="X"
+              type="number"
+              value={payload.position?.x}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChangePositionX(e)}
+              autoSelect
+            />
+            <TextField
+              leftLabel="Y"
+              type="number"
+              value={payload.position?.y}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChangePositionY(e)}
+              autoSelect
+            />
+            <TextField
+              leftLabel="Z"
+              type="number"
+              value={payload.position?.z}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChangePositionZ(e)}
+              autoSelect
+            />
+          </div>
+          {renderPositionInfo}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(SpawnItemAction);

--- a/packages/inspector/src/components/EntityInspector/ActionInspector/SpawnItemAction/index.ts
+++ b/packages/inspector/src/components/EntityInspector/ActionInspector/SpawnItemAction/index.ts
@@ -1,0 +1,3 @@
+import SpawnItemAction from './SpawnItemAction';
+
+export { SpawnItemAction };

--- a/packages/inspector/src/components/EntityInspector/ActionInspector/SpawnItemAction/types.ts
+++ b/packages/inspector/src/components/EntityInspector/ActionInspector/SpawnItemAction/types.ts
@@ -1,0 +1,6 @@
+import type { ActionPayload, ActionType } from '@dcl/asset-packs';
+
+export interface Props {
+  value: Partial<ActionPayload<ActionType.SPAWN_ITEM>>;
+  onUpdate: (value: ActionPayload<ActionType.SPAWN_ITEM>) => void;
+}

--- a/packages/inspector/src/lib/data-layer/host/composite-provider.ts
+++ b/packages/inspector/src/lib/data-layer/host/composite-provider.ts
@@ -260,6 +260,52 @@ export class CompositeProvider implements StateProvider {
     await this.initialize();
   }
 
+  /**
+   * Bundle a custom item's composite into the scene assets so it can be used by SPAWN_ITEM.
+   *
+   * The composite JSON is read from `custom/{slug}/composite.json`, `{assetPath}` tokens
+   * are resolved to `custom/{slug}/`, and the result is written as a `.composite` file
+   * at `assets/custom/{slug}.composite`. The composite is then registered in memory so
+   * SPAWN_ITEM actions can find it via getCompositeOrNull without a filesystem rescan.
+   *
+   * This operation is idempotent: if the target file already exists with identical content
+   * the write and registration are skipped.
+   *
+   * @param slug    The custom item directory slug (e.g. "padlock" for `custom/padlock/`)
+   * @returns       The path of the bundled composite file
+   */
+  async bundleCustomItem(slug: string): Promise<string> {
+    if (!this.compositeManager) throw new Error('Composite manager not initialized');
+
+    const sourcePath = `${DIRECTORY.CUSTOM}/${slug}/composite.json`;
+    const targetPath = `assets/custom/${slug}.composite`;
+
+    // Read and parse the source composite
+    const sourceBytes = await this.fs.readFile(sourcePath);
+    const sourceText = new TextDecoder().decode(sourceBytes);
+    // Resolve {assetPath} tokens to the relative resource directory
+    const assetPath = `${DIRECTORY.CUSTOM}/${slug}`;
+    const resolved = sourceText.replace(/\{assetPath\}/g, assetPath);
+
+    // Check idempotency: skip if target already exists with same content
+    if (await this.fs.existFile(targetPath)) {
+      const existingBytes = await this.fs.readFile(targetPath);
+      const existingText = new TextDecoder().decode(existingBytes);
+      if (existingText === resolved) {
+        return targetPath;
+      }
+    }
+
+    // Write the resolved composite to scene assets
+    await this.fs.writeFile(targetPath, Buffer.from(resolved, 'utf-8'));
+
+    // Parse and register in memory
+    const compositeDefinition = Composite.fromJson(JSON.parse(resolved));
+    this.compositeManager.register({ src: targetPath, composite: compositeDefinition });
+
+    return targetPath;
+  }
+
   async dispose(): Promise<void> {
     if (this.savePromise) {
       await this.savePromise;

--- a/packages/inspector/src/lib/data-layer/host/utils/fs-composite-provider.ts
+++ b/packages/inspector/src/lib/data-layer/host/utils/fs-composite-provider.ts
@@ -4,6 +4,12 @@ import type { FileSystemInterface } from '../../types';
 
 export type CompositeManager = Composite.Provider & {
   save: (composite: Composite.Resource, type: 'json' | 'binary') => Promise<void>;
+  /**
+   * Register a composite resource in memory without re-scanning the filesystem.
+   * Used to add dynamically-bundled composites (e.g. Custom Items) at authoring time.
+   * If a resource with the same src already exists, it will be replaced.
+   */
+  register: (resource: Composite.Resource) => void;
 };
 
 export async function createFsCompositeProvider(
@@ -84,6 +90,19 @@ export async function createFsCompositeProvider(
       const existingComposite = composites.find(item => item.src === composite.src);
       if (existingComposite) {
         existingComposite.composite = compositeDefinition;
+      }
+    },
+    register(resource: Composite.Resource) {
+      function normalizePath(val: string) {
+        return val.replace(/\\/g, '/').toLocaleLowerCase();
+      }
+      const existingIdx = composites.findIndex(
+        item => normalizePath(item.src) === normalizePath(resource.src),
+      );
+      if (existingIdx >= 0) {
+        composites[existingIdx] = resource;
+      } else {
+        composites.push(resource);
       }
     },
   };


### PR DESCRIPTION
## Summary

- Adds a new `SPAWN_ITEM` `ActionType` to `@dcl/asset-packs` that instantiates a Custom Item entity tree from a composite file at runtime, positioning it at a configurable XYZ coordinate
- Extends the Inspector with a `SpawnItemAction` UI component (dropdown for selecting a Custom Item + XYZ position inputs) and a composite bundling step that writes `assets/custom/{slug}.composite` when the action is authored
- Adds a `register()` method to `FsCompositeProvider` so newly-bundled composites are available immediately without a file-system rescan

## Plan

### Root Cause Analysis

Custom Items can be used to build up the initial scene via drag-and-drop, but there is no SDK/action mechanism to spawn them dynamically at runtime (e.g. a monster spawner that instantiates a Custom Item entity tree on demand).

**What's missing today:**

1. **No `SPAWN_ITEM` action type** — `ActionType` enum, `definitions.ts` schema, and the `actions.ts` dispatch switch all lack any spawn-from-composite entry. The closest existing action is `CLONE_ENTITY` (clones an already-present entity tree); SPAWN_ITEM must instantiate from a composite definition at runtime, which is a different code path.

2. **Custom item composites are not bundled into scene assets** — Custom items live at `custom/{slug}/composite.json` within the scene directory. `FsCompositeProvider` scans for `.composite`/`.composite.bin` files only. The SDK runtime therefore cannot load a custom item's composite by path until it is written to `assets/custom/{slug}.composite`.

3. **No Inspector UI for SPAWN_ITEM** — `ActionInspector.tsx` has no case for a `SPAWN_ITEM` action, and there is no `SpawnItemAction/` component directory.

### Proposed Changes (all implemented)

- ✅ Add `SPAWN_ITEM = 'spawn_item'` to `ActionType` enum in `packages/asset-packs/src/enums.ts`
- ✅ Add action schema (`src: String, position: Vector3`) in `packages/asset-packs/src/definitions.ts`
- ✅ Add `handleSpawnItem` handler in `packages/asset-packs/src/actions.ts` — allocates fresh entity IDs, calls `Composite.instance()` with `EMM_DIRECT_MAPPING`, sets position on root entity, calls `initActions`/`initTriggers`/`syncEntity` for each spawned entity
- ✅ Extend `ISDKHelpers` in `packages/asset-packs/src/types.ts` with optional `getComposite?(src: string): Composite.Resource | null` callback
- ✅ Add `register()` to `CompositeManager` type and implementation in `fs-composite-provider.ts`
- ✅ Add `bundleCustomItem(slug)` method in `composite-provider.ts` — reads `custom/{slug}/composite.json`, resolves `{assetPath}` tokens, writes to `assets/custom/{slug}.composite`, registers in-memory (idempotent)
- ✅ New `SpawnItemAction` component with Custom Item dropdown + XYZ position inputs, uses `saveFile` RPC for composite bundling (browser-safe, `TextEncoder`)
- ✅ Wire `SpawnItemAction` into `ActionInspector.tsx` (label map, validity check, handler, render case)

## Changes

```
packages/asset-packs/src/actions.ts                |  79 ++++++++
packages/asset-packs/src/definitions.ts            |   4 +
packages/asset-packs/src/enums.ts                  |   1 +
packages/asset-packs/src/types.ts                  |   4 +-
.../ActionInspector/ActionInspector.tsx            |  34 ++++
.../SpawnItemAction/SpawnItemAction.css            |  17 ++
.../SpawnItemAction/SpawnItemAction.tsx            | 216 +++++++++++++++++++++
.../ActionInspector/SpawnItemAction/index.ts       |   3 +
.../ActionInspector/SpawnItemAction/types.ts       |   6 +
.../data-layer/host/composite-provider.ts          |  46 +++++
.../data-layer/host/utils/fs-composite-provider.ts |  19 ++
11 files changed, 428 insertions(+), 1 deletion(-)
```

## Testing

- `npm run build` passes in `packages/asset-packs` and `packages/inspector`
- `npm run typecheck` passes in both packages
- TypeScript compile errors fixed: `Buffer.from()` → `TextEncoder` (browser-safe), ES5 `Set` iteration → `Array.from().forEach()`

## Note on PR #1291

PR #1291 (`fix/407-spawn-custom-item`) implements the direct SDK function approach (`spawnCustomItem()` async helper). This PR is **complementary** — it adds the no-code action panel integration so scene authors can author SPAWN_ITEM actions visually without writing SDK code. Both approaches are described in the original issue.

## Closes

https://github.com/decentraland/creator-hub/issues/407

---
🤖 Created via Slack with Claude