### PR TITLE
feat(asset-packs): add spawnCustomItem / despawnCustomItem SDK functions

### DIFF
--- a/packages/asset-packs/src/definitions.ts
+++ b/packages/asset-packs/src/definitions.ts
@@ -62,6 +62,7 @@ export * from './events';
 export * from './id';
 export * from './states';
 export * from './clone';
+export * from './spawn';
 export * from './lww';
 export * from './types';
 export * from './versioning';

--- a/packages/asset-packs/src/spawn.ts
+++ b/packages/asset-packs/src/spawn.ts
@@ -1,0 +1,598 @@
+import type {
+  Entity,
+  IEngine,
+  LastWriteWinElementSetComponentDefinition,
+  PBMaterial,
+  QuaternionType,
+  TextureUnion,
+  Vector3Type,
+} from '@dcl/ecs';
+import { getComponentEntityTree } from '@dcl/ecs';
+import {
+  Name as DefineName,
+  Transform as DefineTransform,
+} from '@dcl/ecs/dist/components';
+import { getJson, getPayload } from './action-types';
+import { getExplorerComponents } from './components';
+import { ActionType } from './enums';
+import { COMPONENTS_WITH_ID, getNextId } from './id';
+import type { AssetComposite, ISDKHelpers } from './types';
+
+// Component name constants (mirrors inspector's CoreComponents)
+const CORE_GLTF_CONTAINER = 'core::GltfContainer';
+const CORE_GLTF_NODE_MODIFIERS = 'core::GltfNodeModifiers';
+const CORE_AUDIO_SOURCE = 'core::AudioSource';
+const CORE_VIDEO_PLAYER = 'core::VideoPlayer';
+const CORE_MATERIAL = 'core::Material';
+const CORE_TRANSFORM = 'core::Transform';
+const CORE_SYNC_COMPONENTS = 'core::SyncComponents';
+
+// Asset-packs component names (from ComponentName enum, resolved at runtime)
+const ASSET_PACKS_ACTIONS_BASE = 'asset-packs::Actions';
+const ASSET_PACKS_TRIGGERS_BASE = 'asset-packs::Triggers';
+const ASSET_PACKS_STATES_BASE = 'asset-packs::States';
+const ASSET_PACKS_COUNTER_BASE = 'asset-packs::Counter';
+const ASSET_PACKS_PLACEHOLDER_BASE = 'asset-packs::Placeholder';
+const ASSET_PACKS_SCRIPT_BASE = 'asset-packs::Script';
+
+// Prefix for editor-only components that must be skipped at runtime
+const EDITOR_ONLY_PREFIX = 'inspector::';
+
+/** Self-reference sentinel value used in composite.json */
+function isSelfRef(value: any): boolean {
+  return `${value}` === '{self}';
+}
+
+/**
+ * Resolves `{self}` string references to the given entity ID (numeric),
+ * recursively applied to objects and arrays.
+ */
+function resolveSelfReferences(obj: any, entityId: Entity): any {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj === 'string' && isSelfRef(obj)) return entityId;
+  if (Array.isArray(obj)) return obj.map((item: any) => resolveSelfReferences(item, entityId));
+  if (typeof obj === 'object') {
+    const resolved: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      resolved[key] = resolveSelfReferences(value, entityId);
+    }
+    return resolved;
+  }
+  return obj;
+}
+
+/** Resolve `{assetPath}` placeholder in a texture's src field */
+function parseTexture(basePath: string, texture?: TextureUnion, entityId?: number): TextureUnion | undefined {
+  if (!texture) return texture;
+
+  if (texture.tex?.$case === 'texture') {
+    return {
+      tex: {
+        $case: 'texture',
+        texture: {
+          ...texture.tex.texture,
+          src: texture.tex.texture.src.replace('{assetPath}', basePath),
+        },
+      },
+    };
+  }
+
+  if (texture.tex?.$case === 'videoTexture' && entityId !== undefined) {
+    const videoPlayerEntity = texture.tex.videoTexture.videoPlayerEntity;
+    if (isSelfRef(videoPlayerEntity)) {
+      return {
+        tex: {
+          $case: 'videoTexture',
+          videoTexture: {
+            ...texture.tex.videoTexture,
+            videoPlayerEntity: entityId,
+          },
+        },
+      };
+    }
+  }
+
+  return texture;
+}
+
+/** Resolve `{assetPath}` placeholders within a material component */
+function parseMaterial(basePath: string, material: PBMaterial, entityId?: number): PBMaterial {
+  switch (material.material?.$case) {
+    case 'unlit':
+      return {
+        material: {
+          $case: 'unlit',
+          unlit: {
+            ...material.material.unlit,
+            texture: parseTexture(basePath, material.material.unlit.texture, entityId),
+          },
+        },
+      };
+    case 'pbr':
+      return {
+        material: {
+          $case: 'pbr',
+          pbr: {
+            ...material.material.pbr,
+            texture: parseTexture(basePath, material.material.pbr.texture, entityId),
+            alphaTexture: parseTexture(basePath, material.material.pbr.alphaTexture, entityId),
+            bumpTexture: parseTexture(basePath, material.material.pbr.bumpTexture, entityId),
+            emissiveTexture: parseTexture(basePath, material.material.pbr.emissiveTexture, entityId),
+          },
+        },
+      };
+    default:
+      return material;
+  }
+}
+
+/** Resolve component IDs from SyncComponents component names */
+function parseSyncComponents(engine: IEngine, componentNames: string[]): number[] {
+  return componentNames.reduce((acc: number[], name: string) => {
+    try {
+      const component = engine.getComponent(name);
+      return [...acc, component.componentId];
+    } catch {
+      console.error(`spawnCustomItem: SyncComponents references unknown component "${name}"`);
+      return acc;
+    }
+  }, []);
+}
+
+/** Options for spawning a custom item */
+export type SpawnCustomItemOptions = {
+  /** World position for the root entity. Defaults to origin (0,0,0). */
+  position?: Vector3Type;
+  /** World rotation for the root entity. Defaults to identity quaternion. */
+  rotation?: QuaternionType;
+  /** Scale for the root entity. Defaults to (1,1,1). */
+  scale?: Vector3Type;
+  /** Parent entity. Defaults to engine.RootEntity. */
+  parent?: Entity;
+  /** SDK helpers for network synchronization (syncEntity). */
+  sdkHelpers?: ISDKHelpers;
+};
+
+/**
+ * Spawn a Custom Item entity tree from a composite definition at runtime.
+ *
+ * Custom Items are stored in the scene project's `custom/<slug>/` directory.
+ * Each item has a `composite.json` that defines the entity tree and component
+ * data, with `{assetPath}` placeholder for asset paths.
+ *
+ * @example
+ * ```ts
+ * import monsterComposite from './custom/monster/composite.json'
+ *
+ * const entity = spawnCustomItem(engine, monsterComposite, 'custom/monster', {
+ *   position: { x: 4, y: 0, z: 4 },
+ * })
+ * ```
+ *
+ * @param engine - The ECS engine instance
+ * @param composite - The composite definition (import from composite.json)
+ * @param basePath - Path prefix that replaces `{assetPath}` in asset references
+ *                   (e.g. `'custom/monster'`)
+ * @param options - Spawn options: position, rotation, scale, parent, sdkHelpers
+ * @returns The root entity of the spawned item tree
+ */
+export function spawnCustomItem(
+  engine: IEngine,
+  composite: AssetComposite,
+  basePath: string,
+  options?: SpawnCustomItemOptions,
+): Entity {
+  const {
+    position = { x: 0, y: 0, z: 0 },
+    rotation = { x: 0, y: 0, z: 0, w: 1 },
+    scale = { x: 1, y: 1, z: 1 },
+    parent,
+    sdkHelpers,
+  } = options ?? {};
+
+  const Transform = DefineTransform(engine);
+  const Name = DefineName(engine);
+  const { SyncComponents: SyncComponentsComponent } = getExplorerComponents(engine);
+
+  const parentEntity = parent ?? engine.RootEntity;
+
+  // ── Step 1: Collect entity IDs and build hierarchy maps ──────────────────
+
+  const entityIds = new Set<Entity>();
+  const parentOf = new Map<Entity, Entity>(); // composite entityId → composite parentId
+  const transformValues = new Map<Entity, any>();
+  const names = new Map<Entity, string>();
+
+  const transformComponent = composite.components.find(c => c.name === CORE_TRANSFORM);
+  if (transformComponent) {
+    for (const [entityIdStr, transformData] of Object.entries(transformComponent.data)) {
+      const entityId = Number(entityIdStr) as Entity;
+      entityIds.add(entityId);
+      transformValues.set(entityId, transformData.json);
+      if (typeof transformData.json.parent === 'number') {
+        parentOf.set(entityId, transformData.json.parent as Entity);
+        entityIds.add(transformData.json.parent as Entity);
+      }
+    }
+  }
+
+  // Collect names
+  const nameComponentData = composite.components.find(c => c.name === 'core::Name');
+  if (nameComponentData) {
+    for (const [entityIdStr, nameData] of Object.entries(nameComponentData.data)) {
+      names.set(Number(entityIdStr) as Entity, nameData.json.value);
+    }
+  }
+
+  // Collect all entity IDs referenced in any component
+  for (const component of composite.components) {
+    for (const idStr of Object.keys(component.data)) {
+      entityIds.add(Number(idStr) as Entity);
+    }
+  }
+
+  // ── Step 2: Find root entities (no parent in composite) ──────────────────
+
+  const roots = new Set<Entity>();
+  for (const entityId of entityIds) {
+    if (!parentOf.has(entityId)) {
+      roots.add(entityId);
+    }
+  }
+
+  if (roots.size === 0) {
+    throw new Error('spawnCustomItem: No root entities found in composite');
+  }
+
+  // ── Step 3: Create engine entities ───────────────────────────────────────
+
+  /** Map from composite entity ID → live engine entity */
+  const entities = new Map<Entity, Entity>();
+
+  let mainEntity: Entity;
+
+  if (entityIds.size === 1) {
+    // Single-entity composite: the entity itself is the root
+    const compositeId = entityIds.values().next().value as Entity;
+    const entity = engine.addEntity();
+    const entityName = names.get(compositeId) ?? 'custom_item';
+    Name.createOrReplace(entity, { value: entityName });
+    Transform.createOrReplace(entity, { parent: parentEntity, position, rotation, scale });
+    entities.set(compositeId, entity);
+    mainEntity = entity;
+  } else {
+    let defaultParent = parentEntity;
+
+    if (roots.size > 1) {
+      // Multiple roots: create a synthetic wrapper entity
+      mainEntity = engine.addEntity();
+      Name.createOrReplace(mainEntity, { value: 'custom_item_root' });
+      Transform.createOrReplace(mainEntity, { parent: parentEntity, position, rotation, scale });
+      defaultParent = mainEntity;
+    } else {
+      // Placeholder; will be set when single root entity is created
+      mainEntity = engine.addEntity(); // temp, overwritten below
+    }
+
+    // Track orphaned entities that reference a parent not yet created
+    const orphanedEntities = new Map<Entity, Entity>(); // compositeId → compositeParentId
+
+    // Create entities in composite order
+    for (const entityId of entityIds) {
+      if (roots.size === 1 && roots.has(entityId)) {
+        // For single-root multi-entity composites, use mainEntity slot
+        const entity = engine.addEntity();
+        const entityName = names.get(entityId) ?? 'custom_item';
+        Name.createOrReplace(entity, { value: entityName });
+        Transform.createOrReplace(entity, { parent: parentEntity, position, rotation, scale });
+        entities.set(entityId, entity);
+        mainEntity = entity;
+        continue;
+      }
+
+      const isRoot = roots.has(entityId);
+      const intendedParentCompositeId = parentOf.get(entityId);
+      const resolvedParentEntity = isRoot
+        ? defaultParent
+        : typeof intendedParentCompositeId === 'number'
+          ? entities.get(intendedParentCompositeId)
+          : undefined;
+
+      // Detect forward references (parent not yet created)
+      if (!isRoot && typeof intendedParentCompositeId === 'number' && resolvedParentEntity === undefined) {
+        orphanedEntities.set(entityId, intendedParentCompositeId);
+      }
+
+      const entity = engine.addEntity();
+      const entityName = names.get(entityId) ?? `custom_item_${entityId}`;
+      Name.createOrReplace(entity, { value: entityName });
+
+      const tvRaw = transformValues.get(entityId);
+      if (tvRaw && !isRoot) {
+        // Non-root entities: use composite transform values relative to parent
+        Transform.createOrReplace(entity, {
+          parent: resolvedParentEntity ?? defaultParent,
+          position: tvRaw.position ?? { x: 0, y: 0, z: 0 },
+          rotation: tvRaw.rotation ?? { x: 0, y: 0, z: 0, w: 1 },
+          scale: tvRaw.scale ?? { x: 1, y: 1, z: 1 },
+        });
+      } else if (isRoot) {
+        // Root entities in multi-root scenario get positioned under wrapper
+        Transform.createOrReplace(entity, {
+          parent: defaultParent,
+          position: tvRaw?.position ?? { x: 0, y: 0, z: 0 },
+          rotation: tvRaw?.rotation ?? { x: 0, y: 0, z: 0, w: 1 },
+          scale: tvRaw?.scale ?? { x: 1, y: 1, z: 1 },
+        });
+      } else {
+        Transform.createOrReplace(entity, { parent: resolvedParentEntity ?? defaultParent });
+      }
+
+      entities.set(entityId, entity);
+    }
+
+    // Second pass: reparent orphaned entities now that all entities exist
+    for (const [orphanCompositeId, parentCompositeId] of orphanedEntities) {
+      const entity = entities.get(orphanCompositeId)!;
+      const resolvedParent = entities.get(parentCompositeId);
+      if (entity && resolvedParent) {
+        const tvRaw = transformValues.get(orphanCompositeId);
+        Transform.createOrReplace(entity, {
+          parent: resolvedParent,
+          position: tvRaw?.position ?? { x: 0, y: 0, z: 0 },
+          rotation: tvRaw?.rotation ?? { x: 0, y: 0, z: 0, w: 1 },
+          scale: tvRaw?.scale ?? { x: 1, y: 1, z: 1 },
+        });
+      } else {
+        console.error(
+          `spawnCustomItem: Could not reparent entity ${orphanCompositeId}: parent ${parentCompositeId} not found`,
+        );
+      }
+    }
+  }
+
+  // ── Step 4: Pre-pass — assign fresh IDs for COMPONENTS_WITH_ID ───────────
+  // Key format: "<componentName>:<compositeEntityId>"
+  const ids = new Map<string, number>();
+  for (const component of composite.components) {
+    if (!COMPONENTS_WITH_ID.includes(component.name)) continue;
+    for (const [entityIdStr, data] of Object.entries(component.data)) {
+      const key = `${component.name}:${entityIdStr}`;
+      if (typeof data.json.id === 'string' && data.json.id.startsWith('{self')) {
+        ids.set(key, getNextId(engine));
+      }
+    }
+  }
+
+  // Resolve cross-entity and self-entity ID references from composite templates
+  const mapId = (id: string | number, entityIdStr: string): number | string | undefined => {
+    if (typeof id !== 'string') return id;
+
+    // {self:ComponentName} → ID generated for this entity's component
+    const selfMatch = id.match(/^\{self:(.+)\}$/);
+    if (selfMatch) {
+      const key = `${selfMatch[1]}:${entityIdStr}`;
+      return ids.get(key);
+    }
+
+    // {N:ComponentName} → ID generated for entity N's component
+    const crossMatch = id.match(/^\{(\d+):(.+)\}$/);
+    if (crossMatch) {
+      const [, refEntityId, componentName] = crossMatch;
+      const key = `${componentName}:${refEntityId}`;
+      return ids.get(key);
+    }
+
+    return id;
+  };
+
+  // ── Step 5: Apply components to each entity ───────────────────────────────
+
+  for (const component of composite.components) {
+    const componentName = component.name;
+
+    // Skip Transform and Name — already applied during entity creation
+    if (componentName === CORE_TRANSFORM || componentName === 'core::Name') continue;
+
+    // Skip editor-only components (inspector::*)
+    if (componentName.startsWith(EDITOR_ONLY_PREFIX)) continue;
+
+    for (const [entityIdStr, rawData] of Object.entries(component.data)) {
+      const compositeEntityId = Number(entityIdStr) as Entity;
+      const targetEntity = entities.get(compositeEntityId);
+      if (!targetEntity) continue;
+
+      const key = `${componentName}:${entityIdStr}`;
+      let componentValue = { ...rawData.json };
+
+      // Restore the pre-assigned ID if this is a COMPONENTS_WITH_ID entry
+      if (COMPONENTS_WITH_ID.includes(componentName) && ids.has(key)) {
+        componentValue = { ...componentValue, id: ids.get(key) };
+      }
+
+      try {
+        switch (componentName) {
+          // ── GltfContainer: replace {assetPath} in src ──
+          case CORE_GLTF_CONTAINER: {
+            componentValue.visibleMeshesCollisionMask ??= 0;
+            componentValue.invisibleMeshesCollisionMask ??= 3;
+            componentValue.src = componentValue.src.replace('{assetPath}', basePath);
+            break;
+          }
+
+          // ── AudioSource: replace {assetPath} in audioClipUrl ──
+          case CORE_AUDIO_SOURCE: {
+            if (componentValue.audioClipUrl) {
+              componentValue.audioClipUrl = componentValue.audioClipUrl.replace('{assetPath}', basePath);
+            }
+            break;
+          }
+
+          // ── VideoPlayer: replace {assetPath} in src ──
+          case CORE_VIDEO_PLAYER: {
+            if (componentValue.src) {
+              componentValue.src = componentValue.src.replace('{assetPath}', basePath);
+            }
+            break;
+          }
+
+          // ── Material: replace {assetPath} in nested texture srcs ──
+          case CORE_MATERIAL: {
+            componentValue = parseMaterial(basePath, componentValue as PBMaterial, targetEntity);
+            break;
+          }
+
+          // ── GltfNodeModifiers: replace {assetPath} in modifier materials ──
+          case CORE_GLTF_NODE_MODIFIERS: {
+            if (Array.isArray(componentValue.modifiers)) {
+              componentValue.modifiers = componentValue.modifiers.map((modifier: any) => ({
+                ...modifier,
+                material: modifier.material
+                  ? parseMaterial(basePath, modifier.material, targetEntity)
+                  : undefined,
+              }));
+            }
+            break;
+          }
+
+          // ── Placeholder: replace {assetPath} in src ──
+          default:
+            if (componentName.startsWith(ASSET_PACKS_PLACEHOLDER_BASE)) {
+              if (componentValue.src) {
+                componentValue.src = componentValue.src.replace('{assetPath}', basePath);
+              }
+            }
+            // ── Script: replace {assetPath} in each script item path ──
+            else if (componentName.startsWith(ASSET_PACKS_SCRIPT_BASE)) {
+              if (Array.isArray(componentValue.value)) {
+                componentValue.value = componentValue.value.map((scriptItem: any) => ({
+                  ...scriptItem,
+                  path: scriptItem.path?.replace('{assetPath}', basePath) ?? scriptItem.path,
+                }));
+              }
+            }
+            // ── Actions: replace {assetPath} in audio/emote/image payloads ──
+            else if (componentName.startsWith(ASSET_PACKS_ACTIONS_BASE)) {
+              if (Array.isArray(componentValue.value)) {
+                const newActions: any[] = [];
+                for (const action of componentValue.value) {
+                  switch (action.type) {
+                    case ActionType.PLAY_SOUND: {
+                      const payload = getPayload<ActionType.PLAY_SOUND>(action);
+                      newActions.push({
+                        ...action,
+                        jsonPayload: getJson<ActionType.PLAY_SOUND>({
+                          ...payload,
+                          src: payload.src?.replace('{assetPath}', basePath) ?? payload.src,
+                        }),
+                      });
+                      break;
+                    }
+                    case ActionType.PLAY_CUSTOM_EMOTE: {
+                      const payload = getPayload<ActionType.PLAY_CUSTOM_EMOTE>(action);
+                      newActions.push({
+                        ...action,
+                        jsonPayload: getJson<ActionType.PLAY_CUSTOM_EMOTE>({
+                          ...payload,
+                          src: payload.src?.replace('{assetPath}', basePath) ?? payload.src,
+                        }),
+                      });
+                      break;
+                    }
+                    case ActionType.SHOW_IMAGE: {
+                      const payload = getPayload<ActionType.SHOW_IMAGE>(action);
+                      newActions.push({
+                        ...action,
+                        jsonPayload: getJson<ActionType.SHOW_IMAGE>({
+                          ...payload,
+                          src: payload.src?.replace('{assetPath}', basePath) ?? payload.src,
+                        }),
+                      });
+                      break;
+                    }
+                    case ActionType.CHANGE_CAMERA: {
+                      try {
+                        const payload = getPayload<ActionType.CHANGE_CAMERA>(action);
+                        const resolvedPayload = resolveSelfReferences(payload, targetEntity);
+                        newActions.push({
+                          ...action,
+                          jsonPayload: getJson<ActionType.CHANGE_CAMERA>(resolvedPayload),
+                        });
+                      } catch (err) {
+                        console.error('spawnCustomItem: Failed to parse CHANGE_CAMERA payload:', err);
+                        newActions.push(action);
+                      }
+                      break;
+                    }
+                    default:
+                      newActions.push(action);
+                  }
+                }
+                componentValue = { ...componentValue, value: newActions };
+              }
+            }
+            // ── Triggers: remap condition and action IDs ──
+            else if (componentName.startsWith(ASSET_PACKS_TRIGGERS_BASE)) {
+              if (Array.isArray(componentValue.value)) {
+                componentValue.value = componentValue.value.map((trigger: any) => ({
+                  ...trigger,
+                  conditions: (trigger.conditions ?? []).map((condition: any) => ({
+                    ...condition,
+                    id: mapId(condition.id, entityIdStr),
+                  })),
+                  actions: trigger.actions.map((action: any) => ({
+                    ...action,
+                    id: mapId(action.id, entityIdStr),
+                  })),
+                }));
+              }
+            }
+            break;
+        }
+
+        // ── SyncComponents: wire network sync via sdkHelpers ──────────────
+        if (componentName === CORE_SYNC_COMPONENTS) {
+          const componentIds = parseSyncComponents(
+            engine,
+            componentValue.value ?? componentValue.componentIds ?? [],
+          );
+          // Store the resolved componentIds on the entity
+          SyncComponentsComponent.createOrReplace(targetEntity, { componentIds });
+          if (sdkHelpers?.syncEntity) {
+            sdkHelpers.syncEntity(targetEntity, componentIds);
+          }
+          continue; // Already handled above
+        }
+
+        // Apply component to entity (generic path for all other components)
+        const Component = engine.getComponent(componentName) as LastWriteWinElementSetComponentDefinition<unknown>;
+        Component.createOrReplace(targetEntity, componentValue);
+      } catch (err) {
+        // Unknown components (e.g. editor-only that slipped through) are skipped silently
+        console.error(
+          `spawnCustomItem: Failed to create component "${componentName}" on entity ${targetEntity}:`,
+          err,
+        );
+      }
+    }
+  }
+
+  return mainEntity!;
+}
+
+/**
+ * Remove all entities that were spawned as part of a Custom Item tree.
+ *
+ * Unlike `engine.removeEntity`, this walks the full Transform-parented
+ * entity tree and removes every entity in it.
+ *
+ * @param engine - The ECS engine instance
+ * @param entity - The root entity returned by `spawnCustomItem`
+ */
+export function despawnCustomItem(engine: IEngine, entity: Entity): void {
+  const Transform = DefineTransform(engine);
+  const tree = getComponentEntityTree(engine, entity, Transform);
+  for (const e of tree) {
+    engine.removeEntity(e);
+  }
+}

--- a/packages/asset-packs/test/spawn.test.ts
+++ b/packages/asset-packs/test/spawn.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Engine } from '@dcl/ecs/dist/engine';
+import { Transform as DefineTransform, Name as DefineName } from '@dcl/ecs/dist/components';
+import { getComponentEntityTree } from '@dcl/ecs';
+import { spawnCustomItem, despawnCustomItem } from '../src/spawn';
+import type { AssetComposite } from '../src/types';
+import { ComponentName } from '../src/enums';
+import { defineAllComponents } from '../src/versioning/registry';
+
+// Helper: bootstrap the ECS engine with all asset-packs components registered
+function createTestEngine() {
+  const engine = Engine();
+  defineAllComponents(engine);
+  return engine;
+}
+
+describe('spawnCustomItem', () => {
+  it('should create a single entity for a single-entity composite', () => {
+    const engine = createTestEngine();
+    const Transform = DefineTransform(engine);
+
+    const composite: AssetComposite = {
+      version: 1,
+      components: [
+        {
+          name: 'core::GltfContainer',
+          data: {
+            '0': { json: { src: '{assetPath}/model.glb' } },
+          },
+        },
+      ],
+    };
+
+    const entity = spawnCustomItem(engine, composite, 'custom/monster', {
+      position: { x: 4, y: 0, z: 4 },
+    });
+
+    expect(entity).toBeTruthy();
+
+    const transform = Transform.getOrNull(entity);
+    expect(transform).not.toBeNull();
+    expect(transform!.position).toEqual({ x: 4, y: 0, z: 4 });
+  });
+
+  it('should replace {assetPath} in GltfContainer src', () => {
+    const engine = createTestEngine();
+
+    const composite: AssetComposite = {
+      version: 1,
+      components: [
+        {
+          name: 'core::GltfContainer',
+          data: {
+            '0': { json: { src: '{assetPath}/mesh.glb' } },
+          },
+        },
+      ],
+    };
+
+    const entity = spawnCustomItem(engine, composite, 'custom/my-item');
+
+    // GltfContainer should have resolved src
+    const GltfContainer = engine.getComponent('core::GltfContainer') as any;
+    const gltf = GltfContainer.getOrNull(entity);
+    expect(gltf).not.toBeNull();
+    expect(gltf!.src).toBe('custom/my-item/mesh.glb');
+  });
+
+  it('should replace {assetPath} in AudioSource audioClipUrl', () => {
+    const engine = createTestEngine();
+
+    const composite: AssetComposite = {
+      version: 1,
+      components: [
+        {
+          name: 'core::AudioSource',
+          data: {
+            '0': {
+              json: {
+                audioClipUrl: '{assetPath}/sound.mp3',
+                playing: false,
+                loop: false,
+                volume: 1,
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const entity = spawnCustomItem(engine, composite, 'custom/sound-item');
+
+    const AudioSource = engine.getComponent('core::AudioSource') as any;
+    const audio = AudioSource.getOrNull(entity);
+    expect(audio).not.toBeNull();
+    expect(audio!.audioClipUrl).toBe('custom/sound-item/sound.mp3');
+  });
+
+  it('should create a parent entity for multi-entity composite (parent + child)', () => {
+    const engine = createTestEngine();
+    const Transform = DefineTransform(engine);
+
+    // Entity 0 is parent, entity 1 is child (parent=0)
+    const composite: AssetComposite = {
+      version: 1,
+      components: [
+        {
+          name: 'core::Transform',
+          data: {
+            '0': { json: { position: { x: 0, y: 0, z: 0 } } },
+            '1': {
+              json: { position: { x: 1, y: 0, z: 0 }, parent: 0 },
+            },
+          },
+        },
+        {
+          name: 'core::GltfContainer',
+          data: {
+            '0': { json: { src: '{assetPath}/parent.glb' } },
+            '1': { json: { src: '{assetPath}/child.glb' } },
+          },
+        },
+      ],
+    };
+
+    const rootEntity = spawnCustomItem(engine, composite, 'custom/multi', {
+      position: { x: 2, y: 0, z: 2 },
+    });
+
+    expect(rootEntity).toBeTruthy();
+    const rootTransform = Transform.getOrNull(rootEntity);
+    expect(rootTransform).not.toBeNull();
+    expect(rootTransform!.position).toEqual({ x: 2, y: 0, z: 2 });
+
+    // Find the child entity (parented to root)
+    let childFound = false;
+    for (const [entity] of engine.getEntitiesWith(Transform)) {
+      const t = Transform.get(entity);
+      if (t.parent === rootEntity && entity !== rootEntity) {
+        childFound = true;
+        break;
+      }
+    }
+    expect(childFound).toBe(true);
+  });
+
+  it('should skip editor-only inspector:: components silently', () => {
+    const engine = createTestEngine();
+
+    const composite: AssetComposite = {
+      version: 1,
+      components: [
+        {
+          name: 'inspector::CustomAsset',
+          data: { '0': { json: { assetId: 'some-id' } } },
+        },
+        {
+          name: 'inspector::Config',
+          data: { '0': { json: { sections: [] } } },
+        },
+        {
+          name: 'core::GltfContainer',
+          data: { '0': { json: { src: '{assetPath}/model.glb' } } },
+        },
+      ],
+    };
+
+    // Should not throw even though inspector:: components are present
+    expect(() => spawnCustomItem(engine, composite, 'custom/item')).not.toThrow();
+
+    const entity = spawnCustomItem(engine, composite, 'custom/item');
+    // GltfContainer should exist
+    const GltfContainer = engine.getComponent('core::GltfContainer') as any;
+    const gltf = GltfContainer.getOrNull(entity);
+    expect(gltf).not.toBeNull();
+  });
+
+  it('should call sdkHelpers.syncEntity for SyncComponents entities', () => {
+    const engine = createTestEngine();
+    const syncEntity = vi.fn();
+    const sdkHelpers = { syncEntity };
+
+    const composite: AssetComposite = {
+      version: 1,
+      components: [
+        {
+          name: 'core::SyncComponents',
+          data: { '0': { json: { value: [] } } },
+        },
+      ],
+    };
+
+    spawnCustomItem(engine, composite, 'custom/sync-item', { sdkHelpers });
+
+    expect(syncEntity).toHaveBeenCalledTimes(1);
+    expect(syncEntity).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Array),
+    );
+  });
+
+  it('should assign fresh IDs to Actions components (COMPONENTS_WITH_ID)', () => {
+    const engine = createTestEngine();
+
+    const actionsComponentName = ComponentName.ACTIONS;
+
+    const composite: AssetComposite = {
+      version: 1,
+      components: [
+        {
+          name: actionsComponentName,
+          data: {
+            '0': {
+              json: {
+                id: '{self}',
+                value: [
+                  {
+                    name: 'play_something',
+                    type: 'play_animation',
+                    jsonPayload: '{}',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const entity1 = spawnCustomItem(engine, composite, 'custom/actor');
+    const entity2 = spawnCustomItem(engine, composite, 'custom/actor');
+
+    // Both entities should have Actions component but with different IDs
+    const Actions = engine.getComponent(actionsComponentName) as any;
+    const actions1 = Actions.getOrNull(entity1);
+    const actions2 = Actions.getOrNull(entity2);
+
+    expect(actions1).not.toBeNull();
+    expect(actions2).not.toBeNull();
+    // IDs should be different fresh values (not the template string '{self}')
+    expect(typeof actions1.id).toBe('number');
+    expect(typeof actions2.id).toBe('number');
+    expect(actions1.id).not.toBe(actions2.id);
+  });
+
+  it('should use default position (0,0,0) when no position specified', () => {
+    const engine = createTestEngine();
+    const Transform = DefineTransform(engine);
+
+    const composite: AssetComposite = {
+      version: 1,
+      components: [
+        {
+          name: 'core::GltfContainer',
+          data: { '0': { json: { src: '{assetPath}/model.glb' } } },
+        },
+      ],
+    };
+
+    const entity = spawnCustomItem(engine, composite, 'custom/item');
+    const transform = Transform.getOrNull(entity);
+    expect(transform).not.toBeNull();
+    expect(transform!.position).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it('should throw when composite has no entities', () => {
+    const engine = createTestEngine();
+
+    const composite: AssetComposite = {
+      version: 1,
+      components: [],
+    };
+
+    expect(() => spawnCustomItem(engine, composite, 'custom/empty')).toThrow(
+      'No root entities found in composite',
+    );
+  });
+});
+
+describe('despawnCustomItem', () => {
+  it('should remove the root entity', () => {
+    const engine = createTestEngine();
+    const Transform = DefineTransform(engine);
+
+    const composite: AssetComposite = {
+      version: 1,
+      components: [
+        {
+          name: 'core::GltfContainer',
+          data: { '0': { json: { src: '{assetPath}/model.glb' } } },
+        },
+      ],
+    };
+
+    const entity = spawnCustomItem(engine, composite, 'custom/item');
+    expect(Transform.getOrNull(entity)).not.toBeNull();
+
+    despawnCustomItem(engine, entity);
+    // After removal, getting the component should return null
+    expect(Transform.getOrNull(entity)).toBeNull();
+  });
+
+  it('should remove all entities in a multi-entity tree', () => {
+    const engine = createTestEngine();
+    const Transform = DefineTransform(engine);
+
+    const composite: AssetComposite = {
+      version: 1,
+      components: [
+        {
+          name: 'core::Transform',
+          data: {
+            '0': { json: { position: { x: 0, y: 0, z: 0 } } },
+            '1': { json: { position: { x: 1, y: 0, z: 0 }, parent: 0 } },
+          },
+        },
+      ],
+    };
+
+    const rootEntity = spawnCustomItem(engine, composite, 'custom/tree');
+
+    // Count entities before despawn
+    const entitiesBeforeDespawn = Array.from(
+      getComponentEntityTree(engine, rootEntity, Transform),
+    );
+    expect(entitiesBeforeDespawn.length).toBeGreaterThan(1);
+
+    despawnCustomItem(engine, rootEntity);
+
+    // All entities in the tree should be removed
+    for (const e of entitiesBeforeDespawn) {
+      expect(Transform.getOrNull(e)).toBeNull();
+    }
+  });
+});

--- a/packages/asset-packs/vitest.config.ts
+++ b/packages/asset-packs/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['test/**/*.test.ts'],
+    passWithNoTests: true,
+  },
+  ssr: {
+    // Prevent vite from bundling @dcl/ecs protobuf generated files
+    // in a way that breaks the test environment
+    noExternal: [],
+    external: ['protobufjs', 'protobufjs/minimal'],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `spawnCustomItem(engine, composite, basePath, options?)` to `@dcl/asset-packs` — instantiates an entity tree from a Custom Item's `composite.json` at runtime, enabling dynamic spawning (monsters, pooled props, etc.) from TypeScript scene code
- Adds `despawnCustomItem(engine, entity)` which correctly removes the entire entity tree (not just the root) via `getComponentEntityTree`
- Handles `{assetPath}` placeholder resolution, fresh ID assignment for `COMPONENTS_WITH_ID`, cross-entity `{self:X}` / `{N:X}` reference remapping, editor-only component skipping, and `SyncComponents` via `sdkHelpers.syncEntity`

## Plan

### Root Cause Analysis

Custom Item placement is currently an **editor-only** operation:

1. The Inspector stores each custom item under `custom/<slug>/composite.json` + assets.
2. `packages/inspector/src/lib/sdk/operations/add-asset/index.ts` hydrates the composite into the ECS at design time (with `Nodes`, `CustomAsset`, `updateSelectedEntity` wiring).
3. The runtime package `packages/asset-packs/src/` has no composite hydration logic. The closest analogue is `clone.ts` which clones **live entities**, not composite definitions.

What's missing is a runtime function that:
- Reads a composite object (JSON, imported by the scene developer)
- Creates the corresponding entity tree in the ECS
- Resolves `{assetPath}` placeholders using the provided base path
- Remaps entity IDs and cross-entity `{self:X}` / `{N:X}` action references
- Handles `SyncComponents` via `sdkHelpers.syncEntity` (matching `clone.ts` pattern)
- Skips editor-only components (`inspector::Nodes`, `inspector::Config`, `inspector::CustomAsset`, `inspector::TransformConfig`)
- Returns the root `Entity` so the caller can track and later despawn it

### Key Implementation Notes

- **`ON_SPAWN` fires automatically**: The `triggersSystem` calls `initEntityTriggers` on every tick for every entity with a `Triggers` component. `ON_SPAWN` is emitted at the end of `initEntityTriggers`. No explicit `initTriggers(entity)` call is needed in the spawn function.
- **`actionsSystem` auto-discovery**: Similarly, `actionsSystem` calls `initActions` for every entity with `Actions` on every tick. Actions are wired automatically.
- **SyncComponents**: Uses `sdkHelpers?.syncEntity(entity, componentIds)` from `clone.ts` pattern — NOT `enumEntityId.getNextEnumEntityId()` (inspector-only).
- **`despawnCustomItem`**: `engine.removeEntity()` does NOT cascade to Transform-parented children. Must walk via `getComponentEntityTree(engine, entity, Transform)`.
- **ID remapping**: `COMPONENTS_WITH_ID` (`Actions`, `States`, `Counter`) receive fresh IDs via `getNextId`. Cross-entity references use the `ids` map built during pre-pass.
- **Two-pass entity creation**: Forward-referenced parent entities (orphaned) are collected and reparented after all entities are created.

### Usage Examples

```typescript
// Single-entity spawn
import monsterComposite from './custom/monster/composite.json'
const entity = spawnCustomItem(engine, monsterComposite, 'custom/monster', {
  position: { x: 4, y: 0, z: 4 }
})
// → ON_SPAWN fires next tick automatically

// Multi-entity composite (parent + child tree)
const entity = spawnCustomItem(engine, bossComposite, 'custom/boss', {
  position: { x: 0, y: 0, z: 0 }
})

// Despawn entire tree
despawnCustomItem(engine, entity)
```

## Changes

- `packages/asset-packs/src/spawn.ts` (new) — `spawnCustomItem` and `despawnCustomItem` implementation
- `packages/asset-packs/src/definitions.ts` — added `export * from './spawn'`
- `packages/asset-packs/test/spawn.test.ts` (new) — 11 unit tests

## Testing

All tests pass:

```
✓ packages/asset-packs/test/spawn.test.ts (11 tests)
  ✓ spawnCustomItem > should create a single entity for a single-entity composite
  ✓ spawnCustomItem > should replace {assetPath} in GltfContainer src
  ✓ spawnCustomItem > should replace {assetPath} in AudioSource audioClipUrl
  ✓ spawnCustomItem > should create a parent entity for multi-entity composite (parent + child)
  ✓ spawnCustomItem > should skip editor-only inspector:: components silently
  ✓ spawnCustomItem > should call sdkHelpers.syncEntity for SyncComponents entities
  ✓ spawnCustomItem > should assign fresh IDs to Actions components (COMPONENTS_WITH_ID)
  ✓ spawnCustomItem > should use default position (0,0,0) when no position specified
  ✓ spawnCustomItem > should throw when composite has no entities
  ✓ despawnCustomItem > should remove the root entity
  ✓ despawnCustomItem > should remove all entities in a multi-entity tree

Test Files  2 passed (2)
Tests       21 passed | 1 skipped (22)
```

No TypeScript errors introduced in the modified/new files (`make typecheck` passes for asset-packs source files).

## Closes

https://github.com/decentraland/creator-hub/issues/407

---
🤖 Created via Slack with Claude