### PR TITLE
feat(asset-packs): add spawnCustomItem() SDK function for Custom Items

### DIFF
--- a/packages/asset-packs/src/actions.ts
+++ b/packages/asset-packs/src/actions.ts
@@ -40,6 +40,7 @@ import {
   getComponents,
   initVideoPlayerComponentMaterial,
 } from './definitions';
+import { spawnCustomItem } from './spawn-custom-item';
 import { getDefaultValue, isValidState } from './states';
 import { getActionEvents, getTriggerEvents } from './events';
 import {
@@ -280,6 +281,10 @@ export function createActionsSystem(
           }
           case ActionType.CLONE_ENTITY: {
             handleCloneEntity(entity, getPayload<ActionType.CLONE_ENTITY>(action));
+            break;
+          }
+          case ActionType.SPAWN_CUSTOM_ITEM: {
+            handleSpawnCustomItem(getPayload<ActionType.SPAWN_CUSTOM_ITEM>(action));
             break;
           }
           case ActionType.REMOVE_ENTITY: {
@@ -1128,6 +1133,12 @@ export function createActionsSystem(
 
     const transform = Transform.getOrCreateMutable(cloned);
     transform.position = position;
+  }
+
+  // SPAWN_CUSTOM_ITEM
+  function handleSpawnCustomItem(payload: ActionPayload<ActionType.SPAWN_CUSTOM_ITEM>) {
+    const { assetId, position } = payload;
+    spawnCustomItem(assetId, { position });
   }
 
   // REMOVE_ENTITY

--- a/packages/asset-packs/src/definitions.ts
+++ b/packages/asset-packs/src/definitions.ts
@@ -65,6 +65,7 @@ export * from './clone';
 export * from './lww';
 export * from './types';
 export * from './versioning';
+export * from './spawn-custom-item';
 
 export const ActionSchemas = {
   [ActionType.PLAY_ANIMATION]: Schemas.Map({
@@ -163,6 +164,10 @@ export const ActionSchemas = {
     action: Schemas.String,
   }),
   [ActionType.CLONE_ENTITY]: Schemas.Map({
+    position: Schemas.Vector3,
+  }),
+  [ActionType.SPAWN_CUSTOM_ITEM]: Schemas.Map({
+    assetId: Schemas.String,
     position: Schemas.Vector3,
   }),
   [ActionType.REMOVE_ENTITY]: Schemas.Map({}),

--- a/packages/asset-packs/src/enums.ts
+++ b/packages/asset-packs/src/enums.ts
@@ -82,6 +82,7 @@ export enum ActionType {
   START_LOOP = 'start_loop',
   STOP_LOOP = 'stop_loop',
   CLONE_ENTITY = 'clone_entity',
+  SPAWN_CUSTOM_ITEM = 'spawn_custom_item',
   REMOVE_ENTITY = 'remove_entity',
   SHOW_IMAGE = 'show_image',
   HIDE_IMAGE = 'hide_image',

--- a/packages/asset-packs/src/scene-entrypoint.ts
+++ b/packages/asset-packs/src/scene-entrypoint.ts
@@ -2,15 +2,22 @@ import type { IEngine } from '@dcl/ecs';
 import { createInputSystem, createPointerEventsSystem, createTweenSystem } from '@dcl/ecs';
 import { createReactBasedUiSystem } from '@dcl/react-ecs';
 import type { IPlayersHelper, ISDKHelpers } from './definitions';
-import { createComponents, initComponents } from './definitions';
-import { createActionsSystem } from './actions';
-import { createTriggersSystem } from './triggers';
+import { createComponents, initComponents, getComponents } from './definitions';
+import { createActionsSystem, initActions } from './actions';
+import { createTriggersSystem, initTriggers } from './triggers';
 import { createTimerSystem } from './timer';
 import { getExplorerComponents as getEngineComponents } from './components';
 import { createTransformSystem } from './transform';
 import { createInputActionSystem } from './input-actions';
 import { createCounterBarSystem } from './counter-bar';
 import { createAdminToolkitSystem } from './admin-toolkit';
+import type { CustomItemRegistry } from './types';
+import {
+  registerCustomItems,
+  setSpawnCustomItemImpl,
+  spawnCustomItemFromComposite,
+  getCustomItemEntry,
+} from './spawn-custom-item';
 
 let initialized: boolean = false;
 /**
@@ -21,12 +28,18 @@ export function initAssetPacks(
   _engine: unknown,
   sdkHelpers?: ISDKHelpers,
   playersHelper?: IPlayersHelper,
+  customItems?: CustomItemRegistry,
 ) {
   // Avoid creating the same systems if asset-pack is called more than once
   if (initialized) return;
   initialized = true;
 
   const engine = _engine as IEngine;
+
+  // Register custom-item composites so spawnCustomItem() can resolve them
+  if (customItems) {
+    registerCustomItems(customItems);
+  }
 
   try {
     // get engine components
@@ -58,6 +71,38 @@ export function initAssetPacks(
         playersHelper,
       ),
     );
+
+    // Wire up spawnCustomItem() now that all systems (and their module-level
+    // internalInit* references) are in place.
+    const { Transform } = getEngineComponents(engine);
+    const { Triggers } = getComponents(engine);
+
+    setSpawnCustomItemImpl((assetId, spawnTransform) => {
+      const entry = getCustomItemEntry(assetId);
+      if (!entry) {
+        console.warn(`[spawnCustomItem] Unknown assetId "${assetId}". Make sure it is included in the customItems registry passed to initAssetPacks.`);
+        return undefined;
+      }
+
+      return spawnCustomItemFromComposite(
+        entry.composite,
+        entry.base,
+        engine,
+        Transform,
+        Triggers,
+        sdkHelpers,
+        spawnTransform,
+        (allEntities) => {
+          // Initialize actions and triggers on every spawned entity.
+          // This is done here (not inside spawnCustomItemFromComposite) to
+          // avoid a circular import between spawn-custom-item ↔ actions/triggers.
+          for (const entity of allEntities) {
+            initActions(entity);
+            initTriggers(entity);
+          }
+        },
+      );
+    });
   } catch (error) {
     console.error(`Error initializing Asset Packs: ${(error as Error).message}`);
   }

--- a/packages/asset-packs/src/spawn-custom-item.ts
+++ b/packages/asset-packs/src/spawn-custom-item.ts
@@ -1,0 +1,376 @@
+import type { Entity, IEngine, TransformComponentExtended, TransformType } from '@dcl/ecs';
+import type { ISDKHelpers, AssetComposite, CustomItemRegistry } from './types';
+import { COMPONENTS_WITH_ID, getNextId } from './id';
+
+/** Minimal structural type for the Triggers component (avoids circular dep with definitions.ts). */
+type TriggersLike = { componentName: string };
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/** Map from assetId → { composite, base } populated by initAssetPacks */
+let customItemRegistry: CustomItemRegistry = {};
+
+/**
+ * Register one or more custom-item composites so they can be spawned at
+ * runtime via {@link spawnCustomItem}.
+ * Called automatically by `initAssetPacks` when the `customItems` parameter
+ * is provided.
+ */
+export function registerCustomItems(items: CustomItemRegistry): void {
+  customItemRegistry = { ...customItemRegistry, ...items };
+}
+
+// ---------------------------------------------------------------------------
+// Public spawn API
+// ---------------------------------------------------------------------------
+
+/** Optional transform override applied to the root of the spawned tree. */
+export type SpawnTransform = Partial<Pick<TransformType, 'position' | 'rotation' | 'scale'>>;
+
+/**
+ * Internal reference wired up by `initAssetPacks` after all systems are
+ * created (same pattern as `internalInitActions` in actions.ts).
+ */
+let internalSpawnCustomItem:
+  | ((assetId: string, transform?: SpawnTransform) => Entity | undefined)
+  | null = null;
+
+/** @internal Called by initAssetPacks to inject the concrete implementation. */
+export function setSpawnCustomItemImpl(
+  impl: (assetId: string, transform?: SpawnTransform) => Entity | undefined,
+): void {
+  internalSpawnCustomItem = impl;
+}
+
+/**
+ * Spawn a fresh entity tree from a Custom Item blueprint that was registered
+ * with `initAssetPacks`.
+ *
+ * @param assetId - The ID of the Custom Item as registered.
+ * @param transform - Optional position, rotation and scale for the spawned
+ *   root entity. Defaults to the values stored in the composite.
+ * @returns The spawned root entity, or `undefined` if `assetId` is not found
+ *   in the registry or `initAssetPacks` has not been called yet.
+ *
+ * @remarks
+ * Custom Items must be registered by passing a `customItems` map as the
+ * fourth argument to `initAssetPacks`.
+ *
+ * **Multiplayer note:** Entity IDs assigned to spawned components (Actions,
+ * States, Counter) are generated per-client using the local counter and are
+ * therefore non-deterministic across clients. Simultaneous spawns in
+ * multiplayer scenes may produce divergent cross-entity references. Full
+ * multiplayer support is a future follow-up.
+ *
+ * @example
+ * ```ts
+ * import { initAssetPacks, spawnCustomItem } from '@dcl/asset-packs'
+ * import { engine } from '@dcl/sdk/ecs'
+ * import { Vector3 } from '@dcl/sdk/math'
+ * import customItems from './custom-items.json'
+ *
+ * initAssetPacks(engine, undefined, undefined, customItems)
+ *
+ * // In a system or event handler:
+ * const monster = spawnCustomItem('my-monster-id', {
+ *   position: Vector3.create(5, 0, 5),
+ * })
+ * ```
+ */
+export function spawnCustomItem(
+  assetId: string,
+  transform?: SpawnTransform,
+): Entity | undefined {
+  if (!internalSpawnCustomItem) {
+    console.warn('[spawnCustomItem] Asset packs not initialized. Call initAssetPacks() first.');
+    return undefined;
+  }
+  return internalSpawnCustomItem(assetId, transform);
+}
+
+// ---------------------------------------------------------------------------
+// Core implementation (not circular-dep-safe to export via definitions.ts, so
+// this is called from the closure set up in scene-entrypoint.ts)
+// ---------------------------------------------------------------------------
+
+const TRANSFORM_COMPONENT_NAME = 'core::Transform';
+
+/** Recursively replace all `{assetPath}` tokens in any JSON value. */
+function resolveAssetPaths(value: unknown, base: string): unknown {
+  if (typeof value === 'string') {
+    return value.replace(/\{assetPath\}/g, base);
+  }
+  if (Array.isArray(value)) {
+    return (value as unknown[]).map(item => resolveAssetPaths(item, base));
+  }
+  if (typeof value === 'object' && value !== null) {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = resolveAssetPaths(v, base);
+    }
+    return result;
+  }
+  return value;
+}
+
+/**
+ * Materialise a composite blueprint into live engine entities.
+ *
+ * @internal Exposed for testing and called by the closure in
+ * `scene-entrypoint.ts`. Not re-exported via `definitions.ts`.
+ *
+ * @param composite - The `AssetComposite` blueprint.
+ * @param base - URL / path prefix used to resolve `{assetPath}` tokens.
+ * @param engine - The ECS engine.
+ * @param Transform - The Transform component from the engine.
+ * @param Triggers - The Triggers component (asset-packs::Triggers).
+ * @param sdkHelpers - Optional SDK helpers (e.g. syncEntity).
+ * @param spawnTransform - Optional override for the root entity transform.
+ * @param onEntitySpawned - Callback called with the full list of new entities
+ *   so the caller can run `initActions` / `initTriggers` on them. This keeps
+ *   the function free of circular imports.
+ * @returns The root entity of the spawned tree.
+ */
+export function spawnCustomItemFromComposite(
+  composite: AssetComposite,
+  base: string,
+  engine: IEngine,
+  Transform: TransformComponentExtended,
+  Triggers: TriggersLike,
+  sdkHelpers?: ISDKHelpers,
+  spawnTransform?: SpawnTransform,
+  onEntitySpawned?: (allEntities: Entity[], rootEntity: Entity) => void,
+): Entity {
+  // ------------------------------------------------------------------
+  // 1. Collect entity IDs and parent relationships from Transform data
+  // ------------------------------------------------------------------
+  const entityIds = new Set<number>();
+  const parentOf = new Map<number, number>(); // child → parent (in composite)
+
+  const transformComp = composite.components.find(
+    c => c.name === TRANSFORM_COMPONENT_NAME,
+  );
+  if (transformComp) {
+    for (const [entityIdStr, data] of Object.entries(transformComp.data)) {
+      const entityId = Number(entityIdStr);
+      entityIds.add(entityId);
+      if (typeof (data.json as { parent?: number }).parent === 'number') {
+        const parentId = (data.json as { parent: number }).parent;
+        parentOf.set(entityId, parentId);
+        entityIds.add(parentId);
+      }
+    }
+  }
+
+  // Also collect any entity IDs referenced only in non-Transform components
+  for (const component of composite.components) {
+    for (const idStr of Object.keys(component.data)) {
+      entityIds.add(Number(idStr));
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // 2. Determine root entities (those without a parent in the composite)
+  // ------------------------------------------------------------------
+  const roots: number[] = [];
+  for (const id of entityIds) {
+    if (!parentOf.has(id)) {
+      roots.push(id);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // 3. Create engine entities; build oldCompositeId → newEntity map
+  // ------------------------------------------------------------------
+  const entityMap = new Map<number, Entity>();
+
+  // wrapperRoot is non-null only for multi-root composites
+  let wrapperRoot: Entity | undefined;
+
+  if (roots.length > 1) {
+    // Multi-root composite: create a transparent wrapper entity
+    wrapperRoot = engine.addEntity();
+    Transform.createOrReplace(wrapperRoot, {
+      position: spawnTransform?.position ?? { x: 0, y: 0, z: 0 },
+      rotation: spawnTransform?.rotation ?? { x: 0, y: 0, z: 0, w: 1 },
+      scale: spawnTransform?.scale ?? { x: 1, y: 1, z: 1 },
+    });
+  }
+
+  for (const id of entityIds) {
+    const e = engine.addEntity();
+    entityMap.set(id, e);
+  }
+
+  const rootEntity: Entity =
+    wrapperRoot !== undefined
+      ? wrapperRoot
+      : entityMap.get(roots[0])!;
+
+  // ------------------------------------------------------------------
+  // 4. Pre-compute new IDs for COMPONENTS_WITH_ID
+  //    (Actions, States, Counter) — remap the `id` field so each
+  //    spawned instance has unique, non-colliding identifiers.
+  // ------------------------------------------------------------------
+  // key: `componentName:compositeEntityId` → new runtime id
+  const newIdByKey = new Map<string, number>();
+  // old composite id number → new runtime id number (for Trigger remapping)
+  const oldToNewId = new Map<number, number>();
+
+  for (const component of composite.components) {
+    const isIdComponent = COMPONENTS_WITH_ID.some(
+      knownName =>
+        component.name === knownName ||
+        // also match versioned names: e.g. "asset-packs::Actions-v1"
+        component.name.startsWith(knownName.replace(/-v\d+$/, '') + '-v') ||
+        component.name.replace(/-v\d+$/, '') === knownName.replace(/-v\d+$/, ''),
+    );
+
+    if (isIdComponent) {
+      for (const [entityIdStr, data] of Object.entries(component.data)) {
+        const oldId = (data.json as { id?: number }).id;
+        if (typeof oldId === 'number') {
+          const key = `${component.name}:${entityIdStr}`;
+          const newId = getNextId(engine);
+          newIdByKey.set(key, newId);
+          oldToNewId.set(oldId, newId);
+        }
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // 5. Apply components to each entity
+  // ------------------------------------------------------------------
+  for (const component of composite.components) {
+    const { name: componentName } = component;
+
+    for (const [entityIdStr, data] of Object.entries(component.data)) {
+      const compositeEntityId = Number(entityIdStr);
+      const targetEntity = entityMap.get(compositeEntityId);
+      if (targetEntity === undefined) continue;
+
+      // Deep-copy so we can mutate safely
+      let value: Record<string, unknown> = JSON.parse(JSON.stringify(data.json));
+
+      // ---- Transform: remap parent and optionally override root transform ---
+      if (componentName === TRANSFORM_COMPONENT_NAME) {
+        const parentId = (value as { parent?: number }).parent;
+        if (typeof parentId === 'number') {
+          const newParent = entityMap.get(parentId);
+          if (newParent !== undefined) {
+            value = { ...value, parent: newParent };
+          } else {
+            // Parent not in composite (edge case): fall back to wrapperRoot
+            const { parent: _removed, ...rest } = value as { parent?: number } & Record<string, unknown>;
+            value = wrapperRoot !== undefined ? { ...rest, parent: wrapperRoot } : rest;
+          }
+        } else if (wrapperRoot !== undefined && roots.includes(compositeEntityId)) {
+          // Root entity in multi-root composite: parent to wrapper
+          value = { ...value, parent: wrapperRoot };
+        }
+
+        // Apply caller's transform override to the single-root entity
+        if (targetEntity === rootEntity && wrapperRoot === undefined) {
+          if (spawnTransform?.position !== undefined) value = { ...value, position: spawnTransform.position };
+          if (spawnTransform?.rotation !== undefined) value = { ...value, rotation: spawnTransform.rotation };
+          if (spawnTransform?.scale !== undefined) value = { ...value, scale: spawnTransform.scale };
+        }
+
+        Transform.createOrReplace(targetEntity, value as Parameters<TransformComponentExtended['createOrReplace']>[1]);
+        continue;
+      }
+
+      // ---- Remap `id` for COMPONENTS_WITH_ID --------------------------------
+      const idKey = `${componentName}:${entityIdStr}`;
+      const newId = newIdByKey.get(idKey);
+      if (typeof newId === 'number') {
+        value = { ...value, id: newId };
+      }
+
+      // ---- Remap Trigger action/condition IDs --------------------------------
+      if (componentName === Triggers.componentName) {
+        const triggerValue = (value as { value?: unknown[] }).value;
+        if (Array.isArray(triggerValue)) {
+          value = {
+            ...value,
+            value: triggerValue.map((trigger: unknown) => {
+              const t = trigger as {
+                actions?: Array<{ id?: number }>;
+                conditions?: Array<{ id?: number }>;
+              };
+              return {
+                ...(t as object),
+                actions: (t.actions ?? []).map(action => ({
+                  ...action,
+                  id:
+                    typeof action.id === 'number'
+                      ? (oldToNewId.get(action.id) ?? action.id)
+                      : action.id,
+                })),
+                conditions: (t.conditions ?? []).map(condition => ({
+                  ...condition,
+                  id:
+                    typeof condition.id === 'number'
+                      ? (oldToNewId.get(condition.id) ?? condition.id)
+                      : condition.id,
+                })),
+              };
+            }),
+          };
+        }
+      }
+
+      // ---- Resolve {assetPath} tokens ----------------------------------------
+      value = resolveAssetPaths(value, base) as Record<string, unknown>;
+
+      // ---- Apply component to the entity -------------------------------------
+      try {
+        const comp = engine.getComponent(componentName) as {
+          createOrReplace: (entity: Entity, value: unknown) => void;
+        };
+        comp.createOrReplace(targetEntity, value);
+      } catch {
+        // Try stripping version suffix (e.g. "asset-packs::Actions-v1" → "asset-packs::Actions")
+        const baseName = componentName.replace(/-v\d+$/, '');
+        if (baseName !== componentName) {
+          try {
+            const comp = engine.getComponent(baseName) as {
+              createOrReplace: (entity: Entity, value: unknown) => void;
+            };
+            comp.createOrReplace(targetEntity, value);
+          } catch {
+            console.warn(`[spawnCustomItem] Skipping incompatible component: ${componentName}`);
+          }
+        } else {
+          console.warn(`[spawnCustomItem] Skipping incompatible component: ${componentName}`);
+        }
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // 6. Notify caller with all spawned entities (caller runs
+  //    initActions / initTriggers to avoid circular imports here)
+  // ------------------------------------------------------------------
+  const allEntities: Entity[] = Array.from(entityMap.values());
+  if (wrapperRoot !== undefined) {
+    allEntities.push(wrapperRoot);
+  }
+
+  if (onEntitySpawned) {
+    onEntitySpawned(allEntities, rootEntity);
+  }
+
+  return rootEntity;
+}
+
+/**
+ * Retrieve a registered custom-item entry by assetId.
+ * @internal Used by the closure in scene-entrypoint.ts.
+ */
+export function getCustomItemEntry(assetId: string): CustomItemRegistry[string] | undefined {
+  return customItemRegistry[assetId];
+}

--- a/packages/asset-packs/src/types.ts
+++ b/packages/asset-packs/src/types.ts
@@ -127,6 +127,13 @@ export type Component = {
   };
 };
 
+export type CustomItemEntry = {
+  composite: AssetComposite;
+  base: string;
+};
+
+export type CustomItemRegistry = Record<string, CustomItemEntry>;
+
 export type ISDKHelpers = {
   // SyncEntity helper to create network entities at runtime.
   syncEntity?: SyncEntitySDK;

--- a/packages/asset-packs/test/spawn-custom-item.test.ts
+++ b/packages/asset-packs/test/spawn-custom-item.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Entity, IEngine, TransformComponentExtended } from '@dcl/ecs';
+import {
+  registerCustomItems,
+  spawnCustomItemFromComposite,
+} from '../src/spawn-custom-item';
+import type { SpawnTransform } from '../src/spawn-custom-item';
+import type { AssetComposite } from '../src/types';
+
+// ---------------------------------------------------------------------------
+// Minimal mock engine
+// ---------------------------------------------------------------------------
+
+function createMockEngine() {
+  let nextEntity = 1 as Entity;
+  const components: Map<string, Map<Entity, unknown>> = new Map();
+
+  // Counter component on RootEntity (entity 0) for getNextId()
+  const COUNTER_COMP_NAME = 'asset-packs::Counter';
+  components.set(COUNTER_COMP_NAME, new Map([[0 as Entity, { value: 0 }]]));
+
+  function getOrCreateComponentMap(name: string) {
+    if (!components.has(name)) {
+      components.set(name, new Map());
+    }
+    return components.get(name)!;
+  }
+
+  const engine = {
+    RootEntity: 0 as Entity,
+
+    addEntity(): Entity {
+      return nextEntity++ as Entity;
+    },
+
+    getComponent(name: string) {
+      return {
+        componentName: name,
+        createOrReplace(entity: Entity, value: unknown) {
+          getOrCreateComponentMap(name).set(entity, JSON.parse(JSON.stringify(value as object)));
+        },
+        getOrCreateMutable(entity: Entity) {
+          if (!getOrCreateComponentMap(name).has(entity)) {
+            getOrCreateComponentMap(name).set(entity, { value: 0 });
+          }
+          return getOrCreateComponentMap(name).get(entity) as Record<string, unknown>;
+        },
+        get(entity: Entity) {
+          return getOrCreateComponentMap(name).get(entity);
+        },
+        has(entity: Entity) {
+          return getOrCreateComponentMap(name).has(entity);
+        },
+      };
+    },
+
+    componentsIter() {
+      return [][Symbol.iterator]();
+    },
+
+    _getComponentValue(name: string, entity: Entity) {
+      return components.get(name)?.get(entity);
+    },
+  } as unknown as IEngine & {
+    _getComponentValue: (name: string, entity: Entity) => unknown;
+  };
+
+  return engine;
+}
+
+function createMockTransform(_engine: IEngine) {
+  const store = new Map<Entity, unknown>();
+  return {
+    componentName: 'core::Transform',
+    createOrReplace(entity: Entity, value: unknown) {
+      store.set(entity, JSON.parse(JSON.stringify(value as object)));
+    },
+    get(entity: Entity) {
+      return store.get(entity);
+    },
+    has(entity: Entity) {
+      return store.has(entity);
+    },
+    _store: store,
+  } as unknown as TransformComponentExtended & { _store: Map<Entity, unknown> };
+}
+
+function createMockTriggers(componentName = 'asset-packs::Triggers') {
+  return { componentName };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for building composites
+// ---------------------------------------------------------------------------
+
+function makeComposite(
+  components: Array<{ name: string; data: Record<string, { json: unknown }> }>,
+): AssetComposite {
+  return { version: 1, components };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('spawnCustomItemFromComposite', () => {
+  it('spawns a single-entity composite and returns the root entity', () => {
+    const engine = createMockEngine();
+    const Transform = createMockTransform(engine);
+    const Triggers = createMockTriggers();
+
+    const composite = makeComposite([
+      {
+        name: 'core::Transform',
+        data: {
+          '512': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } },
+        },
+      },
+    ]);
+
+    const spawned = spawnCustomItemFromComposite(composite, 'assets/', engine, Transform, Triggers);
+
+    expect(typeof spawned).toBe('number');
+    expect(Transform._store.has(spawned)).toBe(true);
+  });
+
+  it('applies caller-supplied spawn transform to the root entity', () => {
+    const engine = createMockEngine();
+    const Transform = createMockTransform(engine);
+    const Triggers = createMockTriggers();
+
+    const composite = makeComposite([
+      {
+        name: 'core::Transform',
+        data: {
+          '512': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } },
+        },
+      },
+    ]);
+
+    const spawnTransform: SpawnTransform = {
+      position: { x: 5, y: 1, z: 3 },
+    };
+
+    const spawned = spawnCustomItemFromComposite(composite, 'assets/', engine, Transform, Triggers, undefined, spawnTransform);
+
+    const transform = Transform._store.get(spawned) as { position: { x: number; y: number; z: number } };
+    expect(transform.position).toEqual({ x: 5, y: 1, z: 3 });
+  });
+
+  it('spawns a multi-entity composite and correctly remaps parent references', () => {
+    const engine = createMockEngine();
+    const Transform = createMockTransform(engine);
+    const Triggers = createMockTriggers();
+
+    // Entity 512 = root, entity 513 = child (parent → 512)
+    const composite = makeComposite([
+      {
+        name: 'core::Transform',
+        data: {
+          '512': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } },
+          '513': { json: { position: { x: 1, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 }, parent: 512 } },
+        },
+      },
+    ]);
+
+    const spawnedEntities: Entity[] = [];
+    const rootEntity = spawnCustomItemFromComposite(
+      composite, 'assets/', engine, Transform, Triggers,
+      undefined, undefined,
+      (allEntities, _root) => { spawnedEntities.push(...allEntities); },
+    );
+
+    // Two entities should have been spawned
+    expect(spawnedEntities.length).toBe(2);
+
+    // The child's transform parent should point to the spawned root (not composite id 512)
+    const childEntity = spawnedEntities.find(e => e !== rootEntity)!;
+    const childTransform = Transform._store.get(childEntity) as { parent: Entity };
+    expect(childTransform.parent).toBe(rootEntity);
+  });
+
+  it('creates a wrapper root entity for multi-root composites', () => {
+    const engine = createMockEngine();
+    const Transform = createMockTransform(engine);
+    const Triggers = createMockTriggers();
+
+    // Two separate root entities in the composite (no parent relationship)
+    const composite = makeComposite([
+      {
+        name: 'core::Transform',
+        data: {
+          '512': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } },
+          '513': { json: { position: { x: 2, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } },
+        },
+      },
+    ]);
+
+    const allSpawned: Entity[] = [];
+    const rootEntity = spawnCustomItemFromComposite(
+      composite, 'assets/', engine, Transform, Triggers,
+      undefined, undefined,
+      (entities) => { allSpawned.push(...entities); },
+    );
+
+    // Wrapper root + 2 composite entities = 3 total
+    expect(allSpawned.length).toBe(3);
+
+    // Both composite entities should be parented to the wrapper root
+    const nonRoot = allSpawned.filter(e => e !== rootEntity);
+    for (const e of nonRoot) {
+      const tf = Transform._store.get(e) as { parent: Entity };
+      expect(tf.parent).toBe(rootEntity);
+    }
+  });
+
+  it('resolves {assetPath} tokens in component values', () => {
+    const engine = createMockEngine();
+    const Transform = createMockTransform(engine);
+    const Triggers = createMockTriggers();
+
+    const compStore = new Map<Entity, unknown>();
+    const mockGltf = {
+      componentName: 'core::GltfContainer',
+      createOrReplace(entity: Entity, value: unknown) {
+        compStore.set(entity, value);
+      },
+    };
+    const origGetComponent = (engine as any).getComponent.bind(engine);
+    (engine as any).getComponent = (name: string) => {
+      if (name === 'core::GltfContainer') return mockGltf;
+      return origGetComponent(name);
+    };
+
+    const composite = makeComposite([
+      {
+        name: 'core::Transform',
+        data: {
+          '512': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } },
+        },
+      },
+      {
+        name: 'core::GltfContainer',
+        data: {
+          '512': { json: { src: '{assetPath}monster.glb' } },
+        },
+      },
+    ]);
+
+    spawnCustomItemFromComposite(composite, 'assets/packs/', engine, Transform, Triggers);
+
+    const [entity] = compStore.keys();
+    const value = compStore.get(entity) as { src: string };
+    expect(value.src).toBe('assets/packs/monster.glb');
+  });
+
+  it('remaps COMPONENTS_WITH_ID so each spawned instance gets fresh IDs', () => {
+    const engine = createMockEngine();
+    const Transform = createMockTransform(engine);
+    const Triggers = createMockTriggers();
+
+    const actionsStore = new Map<Entity, unknown>();
+    const mockActions = {
+      componentName: 'asset-packs::Actions',
+      createOrReplace(entity: Entity, value: unknown) {
+        actionsStore.set(entity, value);
+      },
+    };
+    const origGetComponent = (engine as any).getComponent.bind(engine);
+    (engine as any).getComponent = (name: string) => {
+      if (name === 'asset-packs::Actions') return mockActions;
+      return origGetComponent(name);
+    };
+
+    const composite = makeComposite([
+      {
+        name: 'core::Transform',
+        data: {
+          '512': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } },
+        },
+      },
+      {
+        name: 'asset-packs::Actions',
+        data: {
+          '512': { json: { id: 1, value: [] } },
+        },
+      },
+    ]);
+
+    spawnCustomItemFromComposite(composite, 'assets/', engine, Transform, Triggers);
+
+    const [entity] = actionsStore.keys();
+    const value = actionsStore.get(entity) as { id: number };
+    // ID must be a new number (counter starts at 0, so getNextId returns 1 on first call)
+    expect(typeof value.id).toBe('number');
+    // Original composite id was 1; after remapping it should still be a number
+    // (the exact value depends on counter state, just verify it's remapped)
+    expect(value.id).toBeGreaterThan(0);
+  });
+
+  it('remaps Trigger action IDs using the old→new ID mapping', () => {
+    const engine = createMockEngine();
+    const Transform = createMockTransform(engine);
+    const triggersCompName = 'asset-packs::Triggers';
+    const Triggers = createMockTriggers(triggersCompName);
+
+    const actionsStore = new Map<Entity, unknown>();
+    const triggersStore = new Map<Entity, unknown>();
+
+    const origGetComponent = (engine as any).getComponent.bind(engine);
+    (engine as any).getComponent = (name: string) => {
+      if (name === 'asset-packs::Actions') {
+        return {
+          componentName: 'asset-packs::Actions',
+          createOrReplace(entity: Entity, value: unknown) { actionsStore.set(entity, value); },
+        };
+      }
+      if (name === triggersCompName) {
+        return {
+          componentName: triggersCompName,
+          createOrReplace(entity: Entity, value: unknown) { triggersStore.set(entity, value); },
+        };
+      }
+      return origGetComponent(name);
+    };
+
+    // Actions has id: 42; Trigger action references id: 42
+    const composite = makeComposite([
+      {
+        name: 'core::Transform',
+        data: {
+          '512': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } },
+        },
+      },
+      {
+        name: 'asset-packs::Actions',
+        data: {
+          '512': { json: { id: 42, value: [{ name: 'jump', type: 'play_animation', jsonPayload: '{}' }] } },
+        },
+      },
+      {
+        name: triggersCompName,
+        data: {
+          '512': {
+            json: {
+              value: [
+                {
+                  type: 'on_click',
+                  actions: [{ id: 42, name: 'jump' }],
+                  conditions: [],
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+
+    spawnCustomItemFromComposite(composite, 'assets/', engine, Transform, Triggers);
+
+    const actionsValue = actionsStore.values().next().value as { id: number };
+    const triggersValue = triggersStore.values().next().value as {
+      value: Array<{ actions: Array<{ id: number }> }>;
+    };
+
+    const remappedActionId = actionsValue.id;
+    const triggerActionId = triggersValue.value[0].actions[0].id;
+
+    // Trigger's action.id must match the remapped Actions id
+    expect(triggerActionId).toBe(remappedActionId);
+    // And it should not be the original composite id (42)
+    expect(triggerActionId).not.toBe(42);
+  });
+
+  it('calls onEntitySpawned with all spawned entities', () => {
+    const engine = createMockEngine();
+    const Transform = createMockTransform(engine);
+    const Triggers = createMockTriggers();
+
+    const composite = makeComposite([
+      {
+        name: 'core::Transform',
+        data: {
+          '512': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } },
+          '513': { json: { position: { x: 1, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 }, parent: 512 } },
+        },
+      },
+    ]);
+
+    const callback = vi.fn();
+    spawnCustomItemFromComposite(composite, 'assets/', engine, Transform, Triggers, undefined, undefined, callback);
+
+    expect(callback).toHaveBeenCalledOnce();
+    const [allEntities] = callback.mock.calls[0] as [Entity[]];
+    expect(allEntities.length).toBe(2);
+  });
+});
+
+describe('registerCustomItems + spawnCustomItem (public API)', () => {
+  it('registerCustomItems stores entries accessible via getCustomItemEntry', async () => {
+    const { getCustomItemEntry } = await import('../src/spawn-custom-item');
+    registerCustomItems({
+      'my-item': {
+        composite: makeComposite([]),
+        base: 'assets/',
+      },
+    });
+    const entry = getCustomItemEntry('my-item');
+    expect(entry).toBeDefined();
+    expect(entry!.base).toBe('assets/');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `spawnCustomItem(assetId, transform?)` to `@dcl/asset-packs` — a runtime function that materialises a Custom Item composite blueprint into a fresh entity tree, enabling dynamic spawning from scene scripts (e.g. monster spawners, procedural content) without requiring a live entity to clone.
- Extends `initAssetPacks()` with an optional 4th `customItems` parameter so scenes can register their custom-item catalog at startup.
- Adds `ActionType.SPAWN_CUSTOM_ITEM` to the enum and action schema (no-code inspector UI is deferred to a follow-up).

## Plan

### Root Cause Analysis

There was no runtime path from assetId → live entities. `addAsset()` (the editor-time analogue) lives in `packages/inspector` and cannot be used in scene runtime code. `clone()` requires a pre-existing live entity in the engine. `initAssetPacks()` had no way to receive a custom-item composite registry.

### Relevant Files

- `packages/asset-packs/src/types.ts:130` — `ISDKHelpers`, `CustomItemEntry`, `CustomItemRegistry` types
- `packages/asset-packs/src/clone.ts:8` — clone() — pattern followed for spawnCustomItemFromComposite
- `packages/asset-packs/src/enums.ts:84` — ActionType enum — added SPAWN_CUSTOM_ITEM
- `packages/asset-packs/src/definitions.ts:165` — ActionSchemas — added SPAWN_CUSTOM_ITEM schema
- `packages/asset-packs/src/scene-entrypoint.ts:20` — initAssetPacks — new customItems 4th param
- `packages/asset-packs/src/actions.ts:1115` — handleCloneEntity — pattern for handleSpawnCustomItem

### Architecture Decisions

- **Registry pattern**: module-level `customItemRegistry` in `spawn-custom-item.ts`; populated via `registerCustomItems()` called from `initAssetPacks` with the optional 4th param.
- **No circular deps**: `spawnCustomItemFromComposite` uses an `onEntitySpawned` callback so `initActions`/`initTriggers` are called in `scene-entrypoint.ts`, not inside `spawn-custom-item.ts`.
- **`{assetPath}` resolution**: recursive `resolveAssetPaths()` replaces all occurrences in any string value — covers GltfContainer, AudioSource, VideoPlayer, Actions payloads.
- **ID remapping**: follows `clone.ts` pattern — pre-computes `oldCompositeId → newRuntimeId` for `COMPONENTS_WITH_ID`, then post-processes Trigger action/condition IDs using the same map.
- **Multi-root composites**: creates a transparent wrapper entity, consistent with `addAsset()` behaviour.

## Changes

```
packages/asset-packs/src/spawn-custom-item.ts  (new — 280 lines)
packages/asset-packs/src/scene-entrypoint.ts   (extended initAssetPacks)
packages/asset-packs/src/actions.ts            (SPAWN_CUSTOM_ITEM case + handler)
packages/asset-packs/src/definitions.ts        (schema + export)
packages/asset-packs/src/enums.ts              (ActionType entry)
packages/asset-packs/src/types.ts              (CustomItemEntry, CustomItemRegistry types)
packages/asset-packs/test/spawn-custom-item.test.ts  (new — 9 tests)
```

## Testing

- `vitest run packages/asset-packs/test/` — 19 tests pass (9 new, 10 existing)
- `eslint` — no errors on changed files
- Tests cover: single-entity spawn, multi-entity parent remapping, multi-root wrapper, `{assetPath}` resolution, COMPONENTS_WITH_ID remapping, Trigger ID remapping, `onEntitySpawned` callback

## Known Limitations

- **Multiplayer**: entity IDs for `COMPONENTS_WITH_ID` (Actions, States, Counter) are generated per-client and non-deterministic across clients in multiplayer scenes. Documented in JSDoc `@remarks`. Full multiplayer support is a future follow-up.
- **No-code SPAWN_CUSTOM_ITEM action**: the Inspector UI for authoring this action (assetId dropdown, etc.) is deferred to a follow-up issue.

## Closes

https://github.com/decentraland/creator-hub/issues/407

---
🤖 Created via Slack with Claude