### PR TITLE
feat(asset-packs): add spawnCustomItem runtime function for dynamic Custom Item instantiation

### DIFF
--- a/packages/asset-packs/src/definitions.ts
+++ b/packages/asset-packs/src/definitions.ts
@@ -62,6 +62,7 @@ export * from './events';
 export * from './id';
 export * from './states';
 export * from './clone';
+export * from './spawn';
 export * from './lww';
 export * from './types';
 export * from './versioning';

--- a/packages/asset-packs/src/spawn.ts
+++ b/packages/asset-packs/src/spawn.ts
@@ -183,7 +183,7 @@ export function spawnCustomItem(
   // -------------------------------------------------------------------------
   // Step 1: Parse Transform tree to build parent relationships
   // -------------------------------------------------------------------------
-  const transformComponent = composite.components.find((c) => c.name === CORE_TRANSFORM);
+  const transformComponent = composite.components.find(c => c.name === CORE_TRANSFORM);
   const entityIds = new Set<Entity>();
 
   if (transformComponent) {
@@ -215,7 +215,7 @@ export function spawnCustomItem(
   // Step 3: Parse entity names
   // -------------------------------------------------------------------------
   const names = new Map<Entity, string>();
-  const nameComponent = composite.components.find((c) => c.name === CORE_NAME);
+  const nameComponent = composite.components.find(c => c.name === CORE_NAME);
   if (nameComponent) {
     for (const [entityIdStr, nameData] of Object.entries(nameComponent.data)) {
       names.set(Number(entityIdStr) as Entity, (nameData as any).json.value as string);
@@ -395,14 +395,20 @@ export function spawnCustomItem(
             ...componentValue,
           };
           if (basePath && componentValue.src?.includes('{assetPath}')) {
-            componentValue = { ...componentValue, src: replaceAssetPath(componentValue.src, basePath) };
+            componentValue = {
+              ...componentValue,
+              src: replaceAssetPath(componentValue.src, basePath),
+            };
           }
           break;
         }
 
         case ComponentName.PLACEHOLDER: {
           if (basePath && componentValue.src?.includes('{assetPath}')) {
-            componentValue = { ...componentValue, src: replaceAssetPath(componentValue.src, basePath) };
+            componentValue = {
+              ...componentValue,
+              src: replaceAssetPath(componentValue.src, basePath),
+            };
           }
           break;
         }
@@ -432,7 +438,10 @@ export function spawnCustomItem(
 
         case CORE_VIDEO_PLAYER: {
           if (basePath && componentValue.src?.includes('{assetPath}')) {
-            componentValue = { ...componentValue, src: replaceAssetPath(componentValue.src, basePath) };
+            componentValue = {
+              ...componentValue,
+              src: replaceAssetPath(componentValue.src, basePath),
+            };
           }
           break;
         }
@@ -519,7 +528,8 @@ export function spawnCustomItem(
         }
 
         case CORE_SYNC_COMPONENTS: {
-          const componentNames: string[] = componentValue.value ?? componentValue.componentIds ?? [];
+          const componentNames: string[] =
+            componentValue.value ?? componentValue.componentIds ?? [];
           const componentIds = componentNames.reduce((acc: number[], name: string) => {
             try {
               return [...acc, engine.getComponent(name).componentId];
@@ -545,10 +555,9 @@ export function spawnCustomItem(
           if (basePath) {
             const newScripts = (componentValue.value ?? []).map((scriptItem: any) => ({
               ...scriptItem,
-              path:
-                scriptItem.path?.includes('{assetPath}')
-                  ? replaceAssetPath(scriptItem.path, basePath)
-                  : scriptItem.path,
+              path: scriptItem.path?.includes('{assetPath}')
+                ? replaceAssetPath(scriptItem.path, basePath)
+                : scriptItem.path,
             }));
             componentValue = { ...componentValue, value: newScripts };
           }

--- a/packages/asset-packs/src/spawn.ts
+++ b/packages/asset-packs/src/spawn.ts
@@ -1,0 +1,585 @@
+import type {
+  Entity,
+  IEngine,
+  LastWriteWinElementSetComponentDefinition,
+  QuaternionType,
+  TransformComponentExtended,
+  Vector3Type,
+} from '@dcl/ecs';
+import type { AssetComposite, ISDKHelpers, TriggersComponent } from './definitions';
+import { ActionType, ComponentName } from './enums';
+import { getJson, getPayload } from './action-types';
+import { COMPONENTS_WITH_ID, getNextId } from './id';
+import { isLastWriteWinComponent } from './lww';
+
+// Core component name constants — mirrors CoreComponents in inspector/src/lib/sdk/components/types.ts
+const CORE_TRANSFORM = 'core::Transform';
+const CORE_GLTF_CONTAINER = 'core::GltfContainer';
+const CORE_AUDIO_SOURCE = 'core::AudioSource';
+const CORE_VIDEO_PLAYER = 'core::VideoPlayer';
+const CORE_MATERIAL = 'core::Material';
+const CORE_SYNC_COMPONENTS = 'core-schema::Sync-Components';
+const CORE_NAME = 'core-schema::Name';
+const CORE_GLTF_NODE_MODIFIERS = 'core::GltfNodeModifiers';
+
+/**
+ * Options for `spawnCustomItem`.
+ */
+export type SpawnCustomItemOptions = {
+  /** Parent entity for the spawned tree. Defaults to `engine.RootEntity`. */
+  parent?: Entity;
+  /** World position of the root entity. Defaults to `{x:0, y:0, z:0}`. */
+  position?: Vector3Type;
+  /** Rotation of the root entity. Defaults to identity `{x:0, y:0, z:0, w:1}`. */
+  rotation?: QuaternionType;
+  /** Scale of the root entity. Defaults to `{x:1, y:1, z:1}`. */
+  scale?: Vector3Type;
+  /**
+   * Base path used to replace `{assetPath}` placeholders in asset references
+   * (GLTF sources, audio clips, video sources, textures, action payloads, scripts).
+   *
+   * Typically this is the directory where the custom item's assets are deployed,
+   * e.g. `'assets/custom/my-monster-slug'`.
+   *
+   * If not provided, `{assetPath}` placeholders are left unreplaced and asset
+   * references will be broken. Always pass this when the composite contains
+   * asset references.
+   */
+  basePath?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers (mirrors inspector/src/lib/sdk/operations/add-asset/utils.ts)
+// ---------------------------------------------------------------------------
+
+function replaceAssetPath(value: string, basePath: string): string {
+  return value.replace('{assetPath}', basePath);
+}
+
+function parseTexture(basePath: string, texture: any, entityId: number): any {
+  if (!texture) return texture;
+
+  if (texture?.tex?.$case === 'texture') {
+    return {
+      tex: {
+        $case: 'texture',
+        texture: {
+          ...texture.tex.texture,
+          src: replaceAssetPath(texture.tex.texture.src, basePath),
+        },
+      },
+    };
+  }
+
+  if (texture?.tex?.$case === 'videoTexture') {
+    const videoPlayerEntity = texture.tex.videoTexture.videoPlayerEntity;
+    if (`${videoPlayerEntity}` === '{self}') {
+      return {
+        tex: {
+          $case: 'videoTexture',
+          videoTexture: {
+            ...texture.tex.videoTexture,
+            videoPlayerEntity: entityId,
+          },
+        },
+      };
+    }
+  }
+
+  return texture;
+}
+
+function parseMaterial(basePath: string, material: any, entityId: number): any {
+  switch (material?.material?.$case) {
+    case 'unlit':
+      return {
+        ...material,
+        material: {
+          $case: 'unlit',
+          unlit: {
+            ...material.material.unlit,
+            texture: parseTexture(basePath, material.material.unlit.texture, entityId),
+          },
+        },
+      };
+    case 'pbr':
+      return {
+        ...material,
+        material: {
+          $case: 'pbr',
+          pbr: {
+            ...material.material.pbr,
+            texture: parseTexture(basePath, material.material.pbr.texture, entityId),
+            alphaTexture: parseTexture(basePath, material.material.pbr.alphaTexture, entityId),
+            bumpTexture: parseTexture(basePath, material.material.pbr.bumpTexture, entityId),
+            emissiveTexture: parseTexture(
+              basePath,
+              material.material.pbr.emissiveTexture,
+              entityId,
+            ),
+          },
+        },
+      };
+    default:
+      return material;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Instantiates a Custom Item composite as a live entity tree in the engine.
+ *
+ * This is the runtime counterpart of the editor's `addAsset()` operation.
+ * Use it from scene code to dynamically spawn entities defined as Custom Items
+ * (for example, to implement a wave spawner for a "monster" Custom Item).
+ *
+ * The composite JSON is typically deployed alongside scene files and can be
+ * fetched at runtime:
+ *
+ * ```typescript
+ * const composite: AssetComposite = await fetch(
+ *   'assets/custom/my-monster/composite.json'
+ * ).then(r => r.json());
+ *
+ * const root = spawnCustomItem(engine, composite, Transform, Triggers, sdkHelpers, {
+ *   parent: engine.RootEntity,
+ *   position: { x: 4, y: 0, z: 4 },
+ *   basePath: 'assets/custom/my-monster',
+ * });
+ * ```
+ *
+ * @param engine      - The ECS engine instance.
+ * @param composite   - The `AssetComposite` definition (e.g. from `composite.json`).
+ * @param Transform   - The `Transform` component obtained from the engine.
+ * @param Triggers    - The `Triggers` component obtained from the engine.
+ * @param sdkHelpers  - Optional SDK helpers. Required for SyncComponents/NetworkEntity support.
+ * @param options     - Spawn options: parent, position, rotation, scale, basePath.
+ * @returns The root entity of the spawned entity tree.
+ * @throws If the composite contains no entities.
+ */
+export function spawnCustomItem(
+  engine: IEngine,
+  composite: AssetComposite,
+  Transform: TransformComponentExtended,
+  _Triggers: TriggersComponent,
+  sdkHelpers?: ISDKHelpers,
+  options?: SpawnCustomItemOptions,
+): Entity {
+  const parent = options?.parent ?? engine.RootEntity;
+  const position = options?.position ?? { x: 0, y: 0, z: 0 };
+  const rotation = options?.rotation ?? { x: 0, y: 0, z: 0, w: 1 };
+  const scale = options?.scale ?? { x: 1, y: 1, z: 1 };
+  const basePath = options?.basePath ?? '';
+
+  // Map from composite entity ID → live ECS entity
+  const entities = new Map<Entity, Entity>();
+
+  // Map from composite entity ID → its parent composite entity ID
+  const parentOf = new Map<Entity, Entity>();
+
+  // -------------------------------------------------------------------------
+  // Step 1: Parse Transform tree to build parent relationships
+  // -------------------------------------------------------------------------
+  const transformComponent = composite.components.find((c) => c.name === CORE_TRANSFORM);
+  const entityIds = new Set<Entity>();
+
+  if (transformComponent) {
+    for (const [entityIdStr, transformData] of Object.entries(transformComponent.data)) {
+      const entity = Number(entityIdStr) as Entity;
+      entityIds.add(entity);
+      const parentId = (transformData as any).json.parent;
+      if (typeof parentId === 'number') {
+        parentOf.set(entity, parentId as Entity);
+        entityIds.add(parentId as Entity);
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 2: Collect all entity IDs from every component
+  // -------------------------------------------------------------------------
+  for (const component of composite.components) {
+    for (const id of Object.keys(component.data)) {
+      entityIds.add(Number(id) as Entity);
+    }
+  }
+
+  if (entityIds.size === 0) {
+    throw new Error('[spawnCustomItem] Composite contains no entities');
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 3: Parse entity names
+  // -------------------------------------------------------------------------
+  const names = new Map<Entity, string>();
+  const nameComponent = composite.components.find((c) => c.name === CORE_NAME);
+  if (nameComponent) {
+    for (const [entityIdStr, nameData] of Object.entries(nameComponent.data)) {
+      names.set(Number(entityIdStr) as Entity, (nameData as any).json.value as string);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 4: Identify root entities (those with no parent in the composite)
+  // -------------------------------------------------------------------------
+  const roots = new Set<Entity>();
+  for (const entityId of entityIds) {
+    if (!parentOf.has(entityId)) {
+      roots.add(entityId);
+    }
+  }
+
+  if (roots.size === 0) {
+    throw new Error('[spawnCustomItem] No root entities found in composite');
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 5: Parse stored Transform values
+  // -------------------------------------------------------------------------
+  const transformValues = new Map<Entity, any>();
+  if (transformComponent) {
+    for (const [entityIdStr, transformData] of Object.entries(transformComponent.data)) {
+      transformValues.set(Number(entityIdStr) as Entity, (transformData as any).json);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 6: Create entities
+  // -------------------------------------------------------------------------
+  let mainEntity: Entity | null = null;
+  let defaultParent = parent;
+
+  // If multiple roots, create a synthetic wrapper entity
+  if (roots.size > 1) {
+    const wrapper = engine.addEntity();
+    Transform.createOrReplace(wrapper, { parent, position, rotation, scale });
+    mainEntity = wrapper;
+    defaultParent = wrapper;
+  }
+
+  if (entityIds.size === 1) {
+    // Single-entity composite
+    const singleId = entityIds.values().next().value as Entity;
+    const entity = engine.addEntity();
+    Transform.createOrReplace(entity, { parent, position, rotation, scale });
+    entities.set(singleId, entity);
+    mainEntity = entity;
+  } else {
+    // Multi-entity composite — create all, track orphans for reparenting
+    const orphanedEntities = new Map<Entity, Entity>();
+
+    for (const entityId of entityIds) {
+      const isRoot = roots.has(entityId);
+      const intendedParentId = parentOf.get(entityId);
+      const parentEntity = isRoot
+        ? defaultParent
+        : typeof intendedParentId === 'number'
+          ? entities.get(intendedParentId)
+          : undefined;
+
+      if (!isRoot && typeof intendedParentId === 'number' && parentEntity === undefined) {
+        orphanedEntities.set(entityId, intendedParentId);
+      }
+
+      const entity = engine.addEntity();
+      const resolvedParent = parentEntity ?? defaultParent;
+
+      if (isRoot) {
+        // Apply caller-specified transform to root entities
+        Transform.createOrReplace(entity, { parent: resolvedParent, position, rotation, scale });
+      } else {
+        const tv = transformValues.get(entityId);
+        Transform.createOrReplace(entity, {
+          parent: resolvedParent,
+          position: tv?.position ?? { x: 0, y: 0, z: 0 },
+          rotation: tv?.rotation ?? { x: 0, y: 0, z: 0, w: 1 },
+          scale: tv?.scale ?? { x: 1, y: 1, z: 1 },
+        });
+      }
+
+      entities.set(entityId, entity);
+    }
+
+    // Reparent orphaned entities now that all have been created
+    for (const [entityId, intendedParentId] of orphanedEntities) {
+      const entity = entities.get(entityId)!;
+      const parentEntity = entities.get(intendedParentId);
+      if (parentEntity) {
+        const tv = transformValues.get(entityId);
+        Transform.createOrReplace(entity, {
+          parent: parentEntity,
+          position: tv?.position ?? { x: 0, y: 0, z: 0 },
+          rotation: tv?.rotation ?? { x: 0, y: 0, z: 0, w: 1 },
+          scale: tv?.scale ?? { x: 1, y: 1, z: 1 },
+        });
+      } else {
+        console.error(
+          `[spawnCustomItem] Failed to reparent entity ${entityId}: ` +
+            `parent ${intendedParentId} not found`,
+        );
+      }
+    }
+
+    // Single-root composite: promote the root entity to main
+    if (roots.size === 1) {
+      const root = Array.from(roots)[0];
+      mainEntity = entities.get(root)!;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 7: Pre-generate IDs for COMPONENTS_WITH_ID (Actions, States, Counter)
+  //         Must happen BEFORE the component-application loop so that
+  //         {self:ComponentName} references in Triggers can be resolved.
+  // -------------------------------------------------------------------------
+  const ids = new Map<string, number>();
+  const values = new Map<string, any>();
+
+  for (const component of composite.components) {
+    const componentName = component.name;
+    for (const [entityIdStr, data] of Object.entries(component.data)) {
+      const key = `${componentName}:${entityIdStr}`;
+      const componentValue = { ...(data as any).json };
+      if (COMPONENTS_WITH_ID.includes(componentName) && `${componentValue.id}` === '{self}') {
+        const newId = getNextId(engine);
+        ids.set(key, newId);
+        componentValue.id = newId;
+      }
+      values.set(key, componentValue);
+    }
+  }
+
+  // Resolve {self:ComponentName} and {N:ComponentName} ID references
+  const mapId = (id: string | number, entityIdStr: string): number | string => {
+    if (typeof id === 'string') {
+      const selfMatch = id.match(/\{self:(.+)\}/);
+      if (selfMatch) {
+        const key = `${selfMatch[1]}:${entityIdStr}`;
+        return ids.get(key) ?? id;
+      }
+      const crossMatch = id.match(/\{(\d+):(.+)\}/);
+      if (crossMatch) {
+        const key = `${crossMatch[2]}:${crossMatch[1]}`;
+        return ids.get(key) ?? id;
+      }
+    }
+    return id;
+  };
+
+  // -------------------------------------------------------------------------
+  // Step 8: Apply components to each entity
+  // -------------------------------------------------------------------------
+  for (const component of composite.components) {
+    const componentName = component.name;
+
+    for (const [entityIdStr] of Object.entries(component.data)) {
+      const entityId = Number(entityIdStr) as Entity;
+      const targetEntity = entities.get(entityId);
+
+      if (!targetEntity) continue;
+
+      // Transform and Name are already applied during entity creation — skip
+      if (componentName === CORE_TRANSFORM || componentName === CORE_NAME) continue;
+
+      const key = `${componentName}:${entityIdStr}`;
+      let componentValue = values.get(key);
+
+      switch (componentName) {
+        case CORE_GLTF_CONTAINER: {
+          componentValue = {
+            visibleMeshesCollisionMask: 0,
+            invisibleMeshesCollisionMask: 3,
+            ...componentValue,
+          };
+          if (basePath && componentValue.src?.includes('{assetPath}')) {
+            componentValue = { ...componentValue, src: replaceAssetPath(componentValue.src, basePath) };
+          }
+          break;
+        }
+
+        case ComponentName.PLACEHOLDER: {
+          if (basePath && componentValue.src?.includes('{assetPath}')) {
+            componentValue = { ...componentValue, src: replaceAssetPath(componentValue.src, basePath) };
+          }
+          break;
+        }
+
+        case CORE_GLTF_NODE_MODIFIERS: {
+          if (basePath) {
+            componentValue = {
+              ...componentValue,
+              modifiers: (componentValue.modifiers ?? []).map((modifier: any) => ({
+                ...modifier,
+                material: parseMaterial(basePath, modifier.material, targetEntity),
+              })),
+            };
+          }
+          break;
+        }
+
+        case CORE_AUDIO_SOURCE: {
+          if (basePath && componentValue.audioClipUrl?.includes('{assetPath}')) {
+            componentValue = {
+              ...componentValue,
+              audioClipUrl: replaceAssetPath(componentValue.audioClipUrl, basePath),
+            };
+          }
+          break;
+        }
+
+        case CORE_VIDEO_PLAYER: {
+          if (basePath && componentValue.src?.includes('{assetPath}')) {
+            componentValue = { ...componentValue, src: replaceAssetPath(componentValue.src, basePath) };
+          }
+          break;
+        }
+
+        case CORE_MATERIAL: {
+          if (basePath) {
+            componentValue = parseMaterial(basePath, componentValue, targetEntity);
+          }
+          break;
+        }
+
+        case ComponentName.ACTIONS: {
+          const newActions: any[] = [];
+          for (const action of componentValue.value ?? []) {
+            switch (action.type) {
+              case ActionType.PLAY_SOUND: {
+                const payload = getPayload<ActionType.PLAY_SOUND>(action);
+                newActions.push(
+                  basePath && payload.src?.includes('{assetPath}')
+                    ? {
+                        ...action,
+                        jsonPayload: getJson<ActionType.PLAY_SOUND>({
+                          ...payload,
+                          src: replaceAssetPath(payload.src, basePath),
+                        }),
+                      }
+                    : action,
+                );
+                break;
+              }
+              case ActionType.PLAY_CUSTOM_EMOTE: {
+                const payload = getPayload<ActionType.PLAY_CUSTOM_EMOTE>(action);
+                newActions.push(
+                  basePath && payload.src?.includes('{assetPath}')
+                    ? {
+                        ...action,
+                        jsonPayload: getJson<ActionType.PLAY_CUSTOM_EMOTE>({
+                          ...payload,
+                          src: replaceAssetPath(payload.src, basePath),
+                        }),
+                      }
+                    : action,
+                );
+                break;
+              }
+              case ActionType.SHOW_IMAGE: {
+                const payload = getPayload<ActionType.SHOW_IMAGE>(action);
+                newActions.push(
+                  basePath && payload.src?.includes('{assetPath}')
+                    ? {
+                        ...action,
+                        jsonPayload: getJson<ActionType.SHOW_IMAGE>({
+                          ...payload,
+                          src: replaceAssetPath(payload.src, basePath),
+                        }),
+                      }
+                    : action,
+                );
+                break;
+              }
+              default:
+                newActions.push(action);
+                break;
+            }
+          }
+          componentValue = { ...componentValue, value: newActions };
+          break;
+        }
+
+        case ComponentName.TRIGGERS: {
+          const newTriggers = (componentValue.value ?? []).map((trigger: any) => ({
+            ...trigger,
+            conditions: (trigger.conditions ?? []).map((condition: any) => ({
+              ...condition,
+              id: mapId(condition.id, entityIdStr),
+            })),
+            actions: (trigger.actions ?? []).map((action: any) => ({
+              ...action,
+              id: mapId(action.id, entityIdStr),
+            })),
+          }));
+          componentValue = { ...componentValue, value: newTriggers };
+          break;
+        }
+
+        case CORE_SYNC_COMPONENTS: {
+          const componentNames: string[] = componentValue.value ?? componentValue.componentIds ?? [];
+          const componentIds = componentNames.reduce((acc: number[], name: string) => {
+            try {
+              return [...acc, engine.getComponent(name).componentId];
+            } catch (_e) {
+              console.error(`[spawnCustomItem] Component "${name}" does not exist in engine`);
+              return acc;
+            }
+          }, []);
+
+          if (sdkHelpers?.syncEntity) {
+            sdkHelpers.syncEntity(targetEntity, componentIds);
+          } else {
+            console.error(
+              '[spawnCustomItem] SyncComponents found but sdkHelpers.syncEntity is not provided. ' +
+                'This entity will not be synchronized in multiplayer.',
+            );
+          }
+          // syncEntity handles network registration — skip generic createOrReplace
+          continue;
+        }
+
+        case ComponentName.SCRIPT: {
+          if (basePath) {
+            const newScripts = (componentValue.value ?? []).map((scriptItem: any) => ({
+              ...scriptItem,
+              path:
+                scriptItem.path?.includes('{assetPath}')
+                  ? replaceAssetPath(scriptItem.path, basePath)
+                  : scriptItem.path,
+            }));
+            componentValue = { ...componentValue, value: newScripts };
+          }
+          break;
+        }
+
+        default:
+          break;
+      }
+
+      // Apply the component using createOrReplace; catch unknown components gracefully
+      try {
+        const Component = engine.getComponent(
+          componentName,
+        ) as LastWriteWinElementSetComponentDefinition<unknown>;
+        if (isLastWriteWinComponent(Component)) {
+          Component.createOrReplace(targetEntity, componentValue);
+        }
+      } catch (_error) {
+        console.error(
+          `[spawnCustomItem] Failed to apply component "${componentName}" ` +
+            `to entity ${targetEntity}:`,
+          _error,
+        );
+      }
+    }
+  }
+
+  if (!mainEntity) {
+    throw new Error('[spawnCustomItem] Failed to resolve main entity');
+  }
+
+  return mainEntity;
+}

--- a/packages/asset-packs/test/spawn.test.ts
+++ b/packages/asset-packs/test/spawn.test.ts
@@ -20,7 +20,7 @@ const CORE_SYNC_COMPONENTS = 'core-schema::Sync-Components';
 function buildEngine(): IEngine {
   const engine = Engine();
   getExplorerComponents(engine); // registers core components
-  defineAllComponents(engine);   // registers asset-packs components
+  defineAllComponents(engine); // registers asset-packs components
   return engine;
 }
 
@@ -46,7 +46,11 @@ function singleEntityComposite(): AssetComposite {
         name: CORE_TRANSFORM,
         data: {
           '0': {
-            json: { position: { x: 1, y: 2, z: 3 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } },
+            json: {
+              position: { x: 1, y: 2, z: 3 },
+              rotation: { x: 0, y: 0, z: 0, w: 1 },
+              scale: { x: 1, y: 1, z: 1 },
+            },
           },
         },
       },
@@ -68,7 +72,11 @@ function multiEntityComposite(): AssetComposite {
         name: CORE_TRANSFORM,
         data: {
           '0': {
-            json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } },
+            json: {
+              position: { x: 0, y: 0, z: 0 },
+              rotation: { x: 0, y: 0, z: 0, w: 1 },
+              scale: { x: 1, y: 1, z: 1 },
+            },
           },
           '512': {
             json: {
@@ -99,10 +107,18 @@ function multiRootComposite(): AssetComposite {
         name: CORE_TRANSFORM,
         data: {
           '0': {
-            json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } },
+            json: {
+              position: { x: 0, y: 0, z: 0 },
+              rotation: { x: 0, y: 0, z: 0, w: 1 },
+              scale: { x: 1, y: 1, z: 1 },
+            },
           },
           '512': {
-            json: { position: { x: 2, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } },
+            json: {
+              position: { x: 2, y: 0, z: 0 },
+              rotation: { x: 0, y: 0, z: 0, w: 1 },
+              scale: { x: 1, y: 1, z: 1 },
+            },
           },
         },
       },
@@ -225,7 +241,15 @@ describe('spawnCustomItem', () => {
         components: [
           {
             name: CORE_TRANSFORM,
-            data: { '0': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } } },
+            data: {
+              '0': {
+                json: {
+                  position: { x: 0, y: 0, z: 0 },
+                  rotation: { x: 0, y: 0, z: 0, w: 1 },
+                  scale: { x: 1, y: 1, z: 1 },
+                },
+              },
+            },
           },
           {
             name: ComponentName.ACTIONS,
@@ -237,7 +261,11 @@ describe('spawnCustomItem', () => {
                     {
                       name: 'play',
                       type: 'play_sound',
-                      jsonPayload: JSON.stringify({ src: '{assetPath}/sound.mp3', loop: false, volume: 1 }),
+                      jsonPayload: JSON.stringify({
+                        src: '{assetPath}/sound.mp3',
+                        loop: false,
+                        volume: 1,
+                      }),
                     },
                   ],
                 },
@@ -248,14 +276,9 @@ describe('spawnCustomItem', () => {
       };
 
       const Actions = engine.getComponent(ComponentName.ACTIONS) as any;
-      const root = spawnCustomItem(
-        engine,
-        actionComposite,
-        Transform_,
-        Triggers_,
-        undefined,
-        { basePath: 'assets/custom/my-item' },
-      );
+      const root = spawnCustomItem(engine, actionComposite, Transform_, Triggers_, undefined, {
+        basePath: 'assets/custom/my-item',
+      });
       const actions = Actions.getOrNull(root);
       expect(actions).not.toBeNull();
       const payload = JSON.parse(actions!.value[0].jsonPayload);
@@ -271,7 +294,15 @@ describe('spawnCustomItem', () => {
         components: [
           {
             name: CORE_TRANSFORM,
-            data: { '0': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } } },
+            data: {
+              '0': {
+                json: {
+                  position: { x: 0, y: 0, z: 0 },
+                  rotation: { x: 0, y: 0, z: 0, w: 1 },
+                  scale: { x: 1, y: 1, z: 1 },
+                },
+              },
+            },
           },
           {
             name: ComponentName.ACTIONS,
@@ -320,7 +351,15 @@ describe('spawnCustomItem', () => {
         components: [
           {
             name: CORE_TRANSFORM,
-            data: { '0': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } } },
+            data: {
+              '0': {
+                json: {
+                  position: { x: 0, y: 0, z: 0 },
+                  rotation: { x: 0, y: 0, z: 0, w: 1 },
+                  scale: { x: 1, y: 1, z: 1 },
+                },
+              },
+            },
           },
           {
             name: CORE_SYNC_COMPONENTS,
@@ -331,9 +370,7 @@ describe('spawnCustomItem', () => {
         ],
       };
 
-      expect(() =>
-        spawnCustomItem(engine, syncComposite, Transform_, Triggers_),
-      ).not.toThrow();
+      expect(() => spawnCustomItem(engine, syncComposite, Transform_, Triggers_)).not.toThrow();
     });
 
     it('should call sdkHelpers.syncEntity when sdkHelpers is provided', () => {
@@ -343,7 +380,15 @@ describe('spawnCustomItem', () => {
         components: [
           {
             name: CORE_TRANSFORM,
-            data: { '0': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } } },
+            data: {
+              '0': {
+                json: {
+                  position: { x: 0, y: 0, z: 0 },
+                  rotation: { x: 0, y: 0, z: 0, w: 1 },
+                  scale: { x: 1, y: 1, z: 1 },
+                },
+              },
+            },
           },
           {
             name: CORE_SYNC_COMPONENTS,
@@ -366,7 +411,15 @@ describe('spawnCustomItem', () => {
         components: [
           {
             name: CORE_TRANSFORM,
-            data: { '0': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } } },
+            data: {
+              '0': {
+                json: {
+                  position: { x: 0, y: 0, z: 0 },
+                  rotation: { x: 0, y: 0, z: 0, w: 1 },
+                  scale: { x: 1, y: 1, z: 1 },
+                },
+              },
+            },
           },
           {
             name: 'non-existent::UnknownComponent-v99',
@@ -386,9 +439,9 @@ describe('spawnCustomItem', () => {
   describe('when composite is empty', () => {
     it('should throw an error', () => {
       const empty: AssetComposite = { version: 1, components: [] };
-      expect(() =>
-        spawnCustomItem(engine, empty, Transform_, Triggers_),
-      ).toThrow('[spawnCustomItem] Composite contains no entities');
+      expect(() => spawnCustomItem(engine, empty, Transform_, Triggers_)).toThrow(
+        '[spawnCustomItem] Composite contains no entities',
+      );
     });
   });
 });

--- a/packages/asset-packs/test/spawn.test.ts
+++ b/packages/asset-packs/test/spawn.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IEngine, TransformComponentExtended } from '@dcl/ecs';
+import { Engine } from '@dcl/ecs';
+import type { AssetComposite, TriggersComponent } from '../src/definitions';
+import { ComponentName } from '../src/enums';
+import { getExplorerComponents } from '../src/components';
+import { defineAllComponents } from '../src/versioning/registry';
+import { spawnCustomItem } from '../src/spawn';
+
+// Component name constants — mirrors those used in spawn.ts
+const CORE_TRANSFORM = 'core::Transform';
+const CORE_GLTF_CONTAINER = 'core::GltfContainer';
+const CORE_SYNC_COMPONENTS = 'core-schema::Sync-Components';
+
+/**
+ * Build an engine with:
+ *  - all core ECS components (GltfContainer, AudioSource, etc.) via getExplorerComponents
+ *  - all asset-packs versioned components (Actions, Triggers, etc.) via defineAllComponents
+ */
+function buildEngine(): IEngine {
+  const engine = Engine();
+  getExplorerComponents(engine); // registers core components
+  defineAllComponents(engine);   // registers asset-packs components
+  return engine;
+}
+
+/** Retrieve the Transform component from the engine (typed). */
+function getTransform(engine: IEngine): TransformComponentExtended {
+  return engine.getComponent(CORE_TRANSFORM) as TransformComponentExtended;
+}
+
+/** Retrieve the Triggers component from the engine (typed). */
+function getTriggers(engine: IEngine): TriggersComponent {
+  return engine.getComponent(ComponentName.TRIGGERS) as TriggersComponent;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function singleEntityComposite(): AssetComposite {
+  return {
+    version: 1,
+    components: [
+      {
+        name: CORE_TRANSFORM,
+        data: {
+          '0': {
+            json: { position: { x: 1, y: 2, z: 3 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } },
+          },
+        },
+      },
+      {
+        name: CORE_GLTF_CONTAINER,
+        data: {
+          '0': { json: { src: '{assetPath}/model.glb' } },
+        },
+      },
+    ],
+  };
+}
+
+function multiEntityComposite(): AssetComposite {
+  return {
+    version: 1,
+    components: [
+      {
+        name: CORE_TRANSFORM,
+        data: {
+          '0': {
+            json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } },
+          },
+          '512': {
+            json: {
+              parent: 0,
+              position: { x: 0, y: 1, z: 0 },
+              rotation: { x: 0, y: 0, z: 0, w: 1 },
+              scale: { x: 1, y: 1, z: 1 },
+            },
+          },
+        },
+      },
+      {
+        name: CORE_GLTF_CONTAINER,
+        data: {
+          '0': { json: { src: '{assetPath}/body.glb' } },
+          '512': { json: { src: '{assetPath}/head.glb' } },
+        },
+      },
+    ],
+  };
+}
+
+function multiRootComposite(): AssetComposite {
+  return {
+    version: 1,
+    components: [
+      {
+        name: CORE_TRANSFORM,
+        data: {
+          '0': {
+            json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } },
+          },
+          '512': {
+            json: { position: { x: 2, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } },
+          },
+        },
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('spawnCustomItem', () => {
+  let engine: IEngine;
+  let Transform_: TransformComponentExtended;
+  let Triggers_: TriggersComponent;
+
+  beforeEach(() => {
+    engine = buildEngine();
+    Transform_ = getTransform(engine);
+    Triggers_ = getTriggers(engine);
+  });
+
+  describe('when given a single-entity composite', () => {
+    it('should create exactly one new entity', () => {
+      const before = Array.from(engine.getEntitiesWith(Transform_)).length;
+      spawnCustomItem(engine, singleEntityComposite(), Transform_, Triggers_);
+      const after = Array.from(engine.getEntitiesWith(Transform_)).length;
+      expect(after).toBe(before + 1);
+    });
+
+    it('should return the spawned entity', () => {
+      const root = spawnCustomItem(engine, singleEntityComposite(), Transform_, Triggers_);
+      expect(typeof root).toBe('number');
+    });
+
+    it('should apply the caller-specified spawn position to the entity', () => {
+      const root = spawnCustomItem(
+        engine,
+        singleEntityComposite(),
+        Transform_,
+        Triggers_,
+        undefined,
+        { position: { x: 5, y: 6, z: 7 } },
+      );
+      const t = Transform_.get(root);
+      expect(t.position).toEqual({ x: 5, y: 6, z: 7 });
+    });
+  });
+
+  describe('when given a multi-entity composite (parent/child)', () => {
+    it('should create multiple entities', () => {
+      const before = Array.from(engine.getEntitiesWith(Transform_)).length;
+      spawnCustomItem(engine, multiEntityComposite(), Transform_, Triggers_);
+      const after = Array.from(engine.getEntitiesWith(Transform_)).length;
+      expect(after).toBeGreaterThan(before + 1);
+    });
+
+    it('should return the root entity', () => {
+      const root = spawnCustomItem(engine, multiEntityComposite(), Transform_, Triggers_);
+      expect(typeof root).toBe('number');
+    });
+
+    it('should set the caller-specified position on the root entity', () => {
+      const root = spawnCustomItem(
+        engine,
+        multiEntityComposite(),
+        Transform_,
+        Triggers_,
+        undefined,
+        { position: { x: 10, y: 0, z: 0 } },
+      );
+      const t = Transform_.get(root);
+      expect(t.position).toEqual({ x: 10, y: 0, z: 0 });
+    });
+  });
+
+  describe('when given a multi-root composite', () => {
+    it('should create a synthetic wrapper entity and return it', () => {
+      const before = Array.from(engine.getEntitiesWith(Transform_)).length;
+      const root = spawnCustomItem(engine, multiRootComposite(), Transform_, Triggers_);
+      const after = Array.from(engine.getEntitiesWith(Transform_)).length;
+      // 2 root entities + 1 synthetic wrapper = 3 new entities
+      expect(after).toBe(before + 3);
+      // Returned entity is the wrapper
+      const t = Transform_.get(root);
+      expect(t).toBeDefined();
+    });
+  });
+
+  describe('when called twice with the same composite', () => {
+    it('should produce two independent root entities with different IDs', () => {
+      const root1 = spawnCustomItem(engine, singleEntityComposite(), Transform_, Triggers_);
+      const root2 = spawnCustomItem(engine, singleEntityComposite(), Transform_, Triggers_);
+      expect(root1).not.toBe(root2);
+    });
+  });
+
+  describe('when basePath is provided', () => {
+    it('should replace {assetPath} in GltfContainer.src', () => {
+      const GltfContainer = engine.getComponent(CORE_GLTF_CONTAINER) as any;
+      const root = spawnCustomItem(
+        engine,
+        singleEntityComposite(),
+        Transform_,
+        Triggers_,
+        undefined,
+        { basePath: 'assets/custom/my-monster' },
+      );
+      const gltf = GltfContainer.getOrNull(root);
+      expect(gltf).not.toBeNull();
+      expect(gltf!.src).toBe('assets/custom/my-monster/model.glb');
+      expect(gltf!.src).not.toContain('{assetPath}');
+    });
+  });
+
+  describe('when Actions component has {assetPath} in PLAY_SOUND payload', () => {
+    it('should replace {assetPath} with basePath', () => {
+      const actionComposite: AssetComposite = {
+        version: 1,
+        components: [
+          {
+            name: CORE_TRANSFORM,
+            data: { '0': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } } },
+          },
+          {
+            name: ComponentName.ACTIONS,
+            data: {
+              '0': {
+                json: {
+                  id: '{self}',
+                  value: [
+                    {
+                      name: 'play',
+                      type: 'play_sound',
+                      jsonPayload: JSON.stringify({ src: '{assetPath}/sound.mp3', loop: false, volume: 1 }),
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      const Actions = engine.getComponent(ComponentName.ACTIONS) as any;
+      const root = spawnCustomItem(
+        engine,
+        actionComposite,
+        Transform_,
+        Triggers_,
+        undefined,
+        { basePath: 'assets/custom/my-item' },
+      );
+      const actions = Actions.getOrNull(root);
+      expect(actions).not.toBeNull();
+      const payload = JSON.parse(actions!.value[0].jsonPayload);
+      expect(payload.src).toBe('assets/custom/my-item/sound.mp3');
+      expect(payload.src).not.toContain('{assetPath}');
+    });
+  });
+
+  describe('when Triggers component has {self:ComponentName} ID references', () => {
+    it('should remap ID references to real integers', () => {
+      const triggersComposite: AssetComposite = {
+        version: 1,
+        components: [
+          {
+            name: CORE_TRANSFORM,
+            data: { '0': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } } },
+          },
+          {
+            name: ComponentName.ACTIONS,
+            data: {
+              '0': {
+                json: {
+                  id: '{self}',
+                  value: [{ name: 'open', type: 'set_state', jsonPayload: '{"state":"open"}' }],
+                },
+              },
+            },
+          },
+          {
+            name: ComponentName.TRIGGERS,
+            data: {
+              '0': {
+                json: {
+                  value: [
+                    {
+                      type: 'on_click',
+                      actions: [{ id: `{self:${ComponentName.ACTIONS}}`, name: 'open' }],
+                      conditions: [],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      const root = spawnCustomItem(engine, triggersComposite, Transform_, Triggers_);
+      const triggers = Triggers_.getOrNull(root);
+      expect(triggers).not.toBeNull();
+      const actionId = triggers!.value[0].actions[0].id;
+      // Should be a real integer, not a placeholder string
+      expect(typeof actionId).toBe('number');
+      expect(actionId).toBeGreaterThan(0);
+    });
+  });
+
+  describe('when SyncComponents is present but sdkHelpers is not provided', () => {
+    it('should not throw', () => {
+      const syncComposite: AssetComposite = {
+        version: 1,
+        components: [
+          {
+            name: CORE_TRANSFORM,
+            data: { '0': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } } },
+          },
+          {
+            name: CORE_SYNC_COMPONENTS,
+            data: {
+              '0': { json: { value: ['core::Transform'] } },
+            },
+          },
+        ],
+      };
+
+      expect(() =>
+        spawnCustomItem(engine, syncComposite, Transform_, Triggers_),
+      ).not.toThrow();
+    });
+
+    it('should call sdkHelpers.syncEntity when sdkHelpers is provided', () => {
+      const syncEntity = vi.fn();
+      const syncComposite: AssetComposite = {
+        version: 1,
+        components: [
+          {
+            name: CORE_TRANSFORM,
+            data: { '0': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } } },
+          },
+          {
+            name: CORE_SYNC_COMPONENTS,
+            data: {
+              '0': { json: { value: ['core::Transform'] } },
+            },
+          },
+        ],
+      };
+
+      spawnCustomItem(engine, syncComposite, Transform_, Triggers_, { syncEntity });
+      expect(syncEntity).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('when composite contains an unknown/missing component', () => {
+    it('should not throw and should still return the root entity', () => {
+      const unknownComposite: AssetComposite = {
+        version: 1,
+        components: [
+          {
+            name: CORE_TRANSFORM,
+            data: { '0': { json: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 } } } },
+          },
+          {
+            name: 'non-existent::UnknownComponent-v99',
+            data: { '0': { json: { value: 'foo' } } },
+          },
+        ],
+      };
+
+      let root: number | undefined;
+      expect(() => {
+        root = spawnCustomItem(engine, unknownComposite, Transform_, Triggers_);
+      }).not.toThrow();
+      expect(root).toBeDefined();
+    });
+  });
+
+  describe('when composite is empty', () => {
+    it('should throw an error', () => {
+      const empty: AssetComposite = { version: 1, components: [] };
+      expect(() =>
+        spawnCustomItem(engine, empty, Transform_, Triggers_),
+      ).toThrow('[spawnCustomItem] Composite contains no entities');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `spawnCustomItem()` in `@dcl/asset-packs` — a runtime function that instantiates a Custom Item composite (from `composite.json`) as a live entity tree, enabling scene developers to dynamically spawn Custom Items (e.g. wave spawners, procedural content) without any editor-only dependencies.
- Adapts the editor's `addAsset()` algorithm: allocates fresh entity IDs via `engine.addEntity()`, resolves `{assetPath}` placeholders, remaps `{self:…}` / `{N:…}` cross-references in Actions/Triggers, handles multi-root composites with a synthetic wrapper, and skips unknown components gracefully.
- 15 unit tests covering single/multi-entity spawns, multi-root composites, `{assetPath}` replacement, ID remapping, SyncComponents handling, and graceful degradation.

## Plan

### Root Cause Analysis

There is currently no runtime-safe way to instantiate a Custom Item from its composite definition. The relevant existing functions are editor-only:
- `addAsset()` in `packages/inspector/src/lib/sdk/operations/add-asset/index.ts` — uses `EditorComponents` (`Nodes`, `CustomAsset`, `Config`, `updateSelectedEntity`) which do not exist at runtime.
- `addChild()` — requires the `Nodes` editor component.
- `clone()` in `packages/asset-packs/src/clone.ts` — clones an *existing* entity tree, cannot instantiate from JSON.
- `Composite.instance()` from `@dcl/ecs` — uses `EMM_DIRECT_MAPPING`, collides with existing scene entities on repeated spawns.

### Key Implementation Decisions

- **Entity IDs**: Uses `engine.addEntity()` for fresh IDs (never `Composite.instance()` which would collide)
- **Multi-root composites**: Creates a synthetic wrapper entity, returns it as root
- **ID remapping**: Pre-generates IDs for `COMPONENTS_WITH_ID` before the component loop so `{self:ComponentName}` references in Triggers resolve correctly
- **Unknown components**: Caught per `addAsset()`'s pattern (try/catch around `engine.getComponent()`)
- **SyncComponents**: Delegates to `sdkHelpers.syncEntity()` if provided; logs and skips if not
- **`{assetPath}` replacement**: Inline helpers (mirrors `parseMaterial()`/`parseTexture()` from `add-asset/utils.ts`) without inspector dependency

## Changes

```
packages/asset-packs/src/spawn.ts         (new) — spawnCustomItem() + SpawnCustomItemOptions
packages/asset-packs/src/definitions.ts   (mod) — export * from './spawn'
packages/asset-packs/test/spawn.test.ts   (new) — 15 unit tests
```

## Testing

- `vitest run test/` in `packages/asset-packs` → 25 passed (15 new spawn tests + 10 deep-merge)
- `tsc --noEmit -p tsconfig.lib.json` → no errors in new files (only pre-existing environment issues with `protobufjs/minimal` in ecs generated types)

## Closes

https://github.com/decentraland/creator-hub/issues/407

---
🤖 Created via Slack with Claude