### PR TITLE
Experiment: Asset catalog expanded

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,16 @@
 {
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(curl -s -L \"https://studio.dclregenesislabs.xyz/\")",
+      "Bash(xargs ls:*)",
+      "Bash(curl -s -L \"https://studio.dclregenesislabs.xyz/assets\")",
+      "Bash(curl -s -L \"https://studio.dclregenesislabs.xyz/api/assets\")",
+      "Bash(curl -sL https://raw.githubusercontent.com/decentraland/sdk-skills/main/add-3d-models/SKILL.md)",
+      "Bash(curl -sL https://raw.githubusercontent.com/decentraland/sdk-skills/main/add-3d-models/references/model-catalog.md)",
+      "WebFetch(domain:studio.dclregenesislabs.xyz)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3317,72 +3317,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@electron/windows-sign": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cross-dirname": "^0.1.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
-        "minimist": "^1.2.8",
-        "postject": "^1.0.0-alpha.6"
-      },
-      "bin": {
-        "electron-windows-sign": "bin/electron-windows-sign.js"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -11757,15 +11691,6 @@
     "node_modules/creator-hub": {
       "resolved": "packages/creator-hub",
       "link": true
-    },
-    "node_modules/cross-dirname": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -21995,36 +21920,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postject": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "commander": "^9.4.0"
-      },
-      "bin": {
-        "postject": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/postject/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/prelude-ls": {

--- a/packages/creator-hub/main/src/security-restrictions.ts
+++ b/packages/creator-hub/main/src/security-restrictions.ts
@@ -50,7 +50,11 @@ const ALLOWED_EXTERNAL_ORIGINS = new Set<AllowedOrigins<typeof IS_DEV>>([
 
 app.on('ready', () => {
   const filter = {
-    urls: ['https://studios.decentraland.org/*'],
+    urls: [
+      'https://studios.decentraland.org/*',
+      'https://studio-api.dclregenesislabs.xyz/*',
+      'https://models.dclregenesislabs.xyz/*',
+    ],
   };
 
   session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {

--- a/packages/creator-hub/main/src/security-restrictions.ts
+++ b/packages/creator-hub/main/src/security-restrictions.ts
@@ -50,11 +50,7 @@ const ALLOWED_EXTERNAL_ORIGINS = new Set<AllowedOrigins<typeof IS_DEV>>([
 
 app.on('ready', () => {
   const filter = {
-    urls: [
-      'https://studios.decentraland.org/*',
-      'https://studio-api.dclregenesislabs.xyz/*',
-      'https://models.dclregenesislabs.xyz/*',
-    ],
+    urls: ['https://studios.decentraland.org/*', 'https://models.dclregenesislabs.xyz/*'],
   };
 
   session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
@@ -63,12 +59,14 @@ app.on('ready', () => {
   });
 
   session.defaultSession.webRequest.onHeadersReceived(filter, (details, callback) => {
-    callback({
-      responseHeaders: {
-        'Access-Control-Allow-Origin': ['*'],
-        ...details.responseHeaders,
-      },
-    });
+    const responseHeaders = { ...details.responseHeaders };
+    for (const key of Object.keys(responseHeaders)) {
+      if (key.toLowerCase() === 'access-control-allow-origin') {
+        delete responseHeaders[key];
+      }
+    }
+    responseHeaders['Access-Control-Allow-Origin'] = ['*'];
+    callback({ responseHeaders });
   });
 });
 

--- a/packages/inspector/src/components/Assets/Assets.tsx
+++ b/packages/inspector/src/components/Assets/Assets.tsx
@@ -11,6 +11,7 @@ import {
   getCatalogSource,
   isSmart,
 } from '../../lib/logic/catalog';
+import { fetchExternalCatalog } from '../../lib/logic/external-catalog';
 import { getConfig } from '../../lib/logic/config';
 import { getSceneClient } from '../../lib/rpc/scene';
 import { useSnackbar } from '../../hooks/useSnackbar';
@@ -91,6 +92,7 @@ function Assets({ isAssetsPanelCollapsed }: { isAssetsPanelCollapsed: boolean })
 
   const config = getConfig();
   const [catalog, setCatalog] = useState<AssetPack[]>([]);
+  const [externalCatalog, setExternalCatalog] = useState<AssetPack[]>([]);
   const [catalogUnavailable, setCatalogUnavailable] = useState(false);
 
   useEffect(() => {
@@ -106,11 +108,18 @@ function Assets({ isAssetsPanelCollapsed }: { isAssetsPanelCollapsed: boolean })
           'Could not load the asset catalog. Please check your connection and try again.',
         );
       });
+    fetchExternalCatalog()
+      .then(packs => setExternalCatalog(packs))
+      .catch(err => console.warn('Failed to load external catalog:', err));
   }, []);
 
   const filteredCatalog = config.disableSmartItems
     ? catalog.map(removeSmartItems).filter(assetPack => assetPack.assets.length > 0)
     : catalog;
+
+  const filteredExternalCatalog = config.disableSmartItems
+    ? externalCatalog.map(removeSmartItems).filter(assetPack => assetPack.assets.length > 0)
+    : externalCatalog;
 
   const assetToRename = useAppSelector(selectAssetToRename);
   const stagedCustomAsset = useAppSelector(selectStagedCustomAsset);
@@ -349,7 +358,10 @@ function Assets({ isAssetsPanelCollapsed }: { isAssetsPanelCollapsed: boolean })
                   </p>
                 </div>
               ) : (
-                <AssetsCatalog catalog={filteredCatalog} />
+                <AssetsCatalog
+                  catalog={filteredCatalog}
+                  externalCatalog={filteredExternalCatalog}
+                />
               ))}
             {tab === AssetsTab.FileSystem && <ProjectAssetExplorer />}
             {tab === AssetsTab.CustomAssets && <CustomAssets />}

--- a/packages/inspector/src/components/AssetsCatalog/AssetsCatalog.css
+++ b/packages/inspector/src/components/AssetsCatalog/AssetsCatalog.css
@@ -38,3 +38,43 @@
   overflow-y: auto;
   overflow-x: hidden;
 }
+
+.assets-catalog .search-results-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0 24px;
+}
+
+.search-results-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.search-results-divider {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 0 0;
+  border-top: 1px solid var(--base-09, #333);
+}
+
+.search-results-divider .section-title {
+  margin: 0;
+  color: var(--base-01);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: normal;
+  white-space: nowrap;
+}
+
+.search-results-divider .section-subtitle {
+  color: var(--base-06);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: normal;
+}

--- a/packages/inspector/src/components/AssetsCatalog/AssetsCatalog.tsx
+++ b/packages/inspector/src/components/AssetsCatalog/AssetsCatalog.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { AssetPack } from '../../lib/logic/catalog';
+import type { Asset } from '@dcl/asset-packs';
+
+import { type AssetPack, isGround } from '../../lib/logic/catalog';
 import { analytics, Event } from '../../lib/logic/analytics';
 
 import { Header } from './Header';
@@ -8,9 +10,43 @@ import { Themes } from './Themes';
 import { Categories } from './Categories';
 import { Assets } from './Assets';
 
-import { Props } from './types';
+import type { Props } from './types';
 
 import './AssetsCatalog.css';
+
+function searchAssets(assets: Asset[], searchLower: string): Asset[] {
+  const starts: Asset[] = [];
+  const includes: Asset[] = [];
+
+  for (const asset of assets) {
+    const name = (asset.name || '').toLowerCase();
+    const description = (asset.description || '').toLowerCase();
+    const tags = (asset.tags || []).map(tag => (tag || '').toLowerCase());
+
+    const nameStarts = name.split(' ').some(word => word.startsWith(searchLower));
+    const tagStarts = tags.some(tag => tag.startsWith(searchLower));
+
+    if (nameStarts || tagStarts) {
+      starts.push(asset);
+    } else {
+      const nameIncludes = name.includes(searchLower);
+      const descriptionIncludes = description.includes(searchLower);
+      const tagIncludes = tags.some(tag => tag.includes(searchLower));
+
+      if (nameIncludes || descriptionIncludes || tagIncludes) {
+        includes.push(asset);
+      }
+    }
+  }
+
+  return [...starts, ...includes];
+}
+
+interface SearchResults {
+  curated: Asset[];
+  ground: Asset[];
+  external: Asset[];
+}
 
 const AssetsCatalog: React.FC<Props> = ({ catalog, externalCatalog = [] }) => {
   const [selectedTheme, setSelectedTheme] = useState<AssetPack>();
@@ -30,54 +66,42 @@ const AssetsCatalog: React.FC<Props> = ({ catalog, externalCatalog = [] }) => {
 
   const allCatalogs = useMemo(() => [...catalog, ...externalCatalog], [catalog, externalCatalog]);
 
-  const filteredCatalog = useMemo(() => {
+  const searchResults = useMemo<SearchResults>(() => {
     const trimmedSearch = search.trim();
-    if (!trimmedSearch) return [];
+    if (!trimmedSearch) return { curated: [], ground: [], external: [] };
 
     const searchLower = trimmedSearch.toLowerCase();
-    const assets = selectedTheme
-      ? selectedTheme.assets
-      : allCatalogs.flatMap(theme => theme.assets);
 
-    const starts: AssetPack['assets'] = [];
-    const includes: AssetPack['assets'] = [];
-
-    for (const asset of assets) {
-      const name = (asset.name || '').toLowerCase();
-      const description = (asset.description || '').toLowerCase();
-      const tags = (asset.tags || []).map(tag => (tag || '').toLowerCase());
-
-      // Priority 1: name word or tag starts with search term
-      const nameStarts = name.split(' ').some(word => word.startsWith(searchLower));
-      const tagStarts = tags.some(tag => tag.startsWith(searchLower));
-
-      if (nameStarts || tagStarts) {
-        starts.push(asset);
-      } else {
-        // Priority 2: search term appears anywhere in name, description, or tags
-        const nameIncludes = name.includes(searchLower);
-        const descriptionIncludes = description.includes(searchLower);
-        const tagIncludes = tags.some(tag => tag.includes(searchLower));
-
-        if (nameIncludes || descriptionIncludes || tagIncludes) {
-          includes.push(asset);
-        }
-      }
+    if (selectedTheme) {
+      const results = searchAssets(selectedTheme.assets, searchLower);
+      return { curated: results, ground: [], external: [] };
     }
 
-    // Return high-priority matches first, then lower-priority matches
-    return [...starts, ...includes];
-  }, [allCatalogs, selectedTheme, search]);
+    const curatedAssets = catalog.flatMap(theme => theme.assets);
+    const externalAssets = externalCatalog.flatMap(theme => theme.assets);
+
+    const curatedResults = searchAssets(curatedAssets, searchLower);
+    const externalResults = searchAssets(externalAssets, searchLower);
+
+    return {
+      curated: curatedResults.filter(a => !isGround(a)),
+      ground: curatedResults.filter(a => isGround(a)),
+      external: externalResults,
+    };
+  }, [allCatalogs, catalog, externalCatalog, selectedTheme, search]);
+
+  const totalResults =
+    searchResults.curated.length + searchResults.ground.length + searchResults.external.length;
 
   useEffect(() => {
     if (search) {
       analytics.track(Event.SEARCH_ITEM, {
         keyword: search,
-        itemsFound: filteredCatalog.length,
+        itemsFound: totalResults,
         category: selectedTheme?.name,
       });
     }
-  }, [search, filteredCatalog]);
+  }, [search, totalResults]);
 
   const renderEmptySearch = useCallback(() => {
     const ctaMethod = selectedTheme ? handleThemeChange : () => undefined;
@@ -102,12 +126,45 @@ const AssetsCatalog: React.FC<Props> = ({ catalog, externalCatalog = [] }) => {
   }, [search, selectedTheme, handleThemeChange]);
 
   const renderAssets = useCallback(() => {
-    if (filteredCatalog.length > 0) {
-      return <Assets assets={filteredCatalog} />;
+    if (totalResults === 0) return renderEmptySearch();
+
+    const { curated, ground, external } = searchResults;
+    const showSections = !selectedTheme && (ground.length > 0 || external.length > 0);
+
+    if (!showSections) {
+      return <Assets assets={curated} />;
     }
 
-    return renderEmptySearch();
-  }, [filteredCatalog, renderEmptySearch]);
+    return (
+      <div className="search-results-container">
+        {curated.length > 0 && (
+          <div className="search-results-section">
+            <Assets assets={curated} />
+          </div>
+        )}
+        {ground.length > 0 && (
+          <div className="search-results-section">
+            <div className="search-results-divider">
+              <h4 className="section-title">Ground Tiles</h4>
+              <span className="section-subtitle">
+                {ground.length} items — placed across all parcels
+              </span>
+            </div>
+            <Assets assets={ground} />
+          </div>
+        )}
+        {external.length > 0 && (
+          <div className="search-results-section">
+            <div className="search-results-divider">
+              <h4 className="section-title">Additional Catalogs</h4>
+              <span className="section-subtitle">{external.length} items</span>
+            </div>
+            <Assets assets={external} />
+          </div>
+        )}
+      </div>
+    );
+  }, [searchResults, totalResults, selectedTheme, renderEmptySearch]);
 
   if (!catalog) {
     return null;

--- a/packages/inspector/src/components/AssetsCatalog/AssetsCatalog.tsx
+++ b/packages/inspector/src/components/AssetsCatalog/AssetsCatalog.tsx
@@ -12,7 +12,7 @@ import { Props } from './types';
 
 import './AssetsCatalog.css';
 
-const AssetsCatalog: React.FC<Props> = ({ catalog }) => {
+const AssetsCatalog: React.FC<Props> = ({ catalog, externalCatalog = [] }) => {
   const [selectedTheme, setSelectedTheme] = useState<AssetPack>();
   const [search, setSearch] = useState<string>('');
 
@@ -28,12 +28,16 @@ const AssetsCatalog: React.FC<Props> = ({ catalog }) => {
     [setSearch],
   );
 
+  const allCatalogs = useMemo(() => [...catalog, ...externalCatalog], [catalog, externalCatalog]);
+
   const filteredCatalog = useMemo(() => {
     const trimmedSearch = search.trim();
     if (!trimmedSearch) return [];
 
     const searchLower = trimmedSearch.toLowerCase();
-    const assets = selectedTheme ? selectedTheme.assets : catalog.flatMap(theme => theme.assets);
+    const assets = selectedTheme
+      ? selectedTheme.assets
+      : allCatalogs.flatMap(theme => theme.assets);
 
     const starts: AssetPack['assets'] = [];
     const includes: AssetPack['assets'] = [];
@@ -63,7 +67,7 @@ const AssetsCatalog: React.FC<Props> = ({ catalog }) => {
 
     // Return high-priority matches first, then lower-priority matches
     return [...starts, ...includes];
-  }, [catalog, selectedTheme, search]);
+  }, [allCatalogs, selectedTheme, search]);
 
   useEffect(() => {
     if (search) {
@@ -128,6 +132,7 @@ const AssetsCatalog: React.FC<Props> = ({ catalog }) => {
         <div className="assets-catalog-theme-container">
           <Themes
             catalog={catalog}
+            externalCatalog={externalCatalog}
             onClick={handleThemeChange}
           />
         </div>

--- a/packages/inspector/src/components/AssetsCatalog/Themes/Themes.css
+++ b/packages/inspector/src/components/AssetsCatalog/Themes/Themes.css
@@ -23,10 +23,28 @@
 
 .asset-catalog-section-divider {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
-  padding: 8px 0 0;
+  margin-top: 12px;
+  padding: 12px 0 0;
   border-top: 1px solid var(--base-09, #333);
+  cursor: pointer;
+  user-select: none;
+}
+
+.asset-catalog-section-divider .section-chevron {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 6px solid var(--base-06, #999);
+  transition: transform 0.15s ease;
+  flex-shrink: 0;
+}
+
+.asset-catalog-section-divider .section-chevron.expanded {
+  transform: rotate(90deg);
 }
 
 .asset-catalog-section-divider .section-title {

--- a/packages/inspector/src/components/AssetsCatalog/Themes/Themes.css
+++ b/packages/inspector/src/components/AssetsCatalog/Themes/Themes.css
@@ -1,9 +1,15 @@
+.asset-catalog-themes-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .asset-catalog-themes {
   display: grid;
   margin: 0 auto;
   max-width: 1440px;
   width: 100%;
-  height: 100%;
   grid-template-columns: repeat(6, 1fr);
   grid-template-rows: max-content;
   gap: 12px;
@@ -13,6 +19,30 @@
   .asset-catalog-themes {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
+}
+
+.asset-catalog-section-divider {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 0 0;
+  border-top: 1px solid var(--base-09, #333);
+}
+
+.asset-catalog-section-divider .section-title {
+  margin: 0;
+  color: var(--base-01);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: normal;
+  white-space: nowrap;
+}
+
+.asset-catalog-section-divider .section-subtitle {
+  color: var(--base-06);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: normal;
 }
 
 .asset-catalog-themes .theme {

--- a/packages/inspector/src/components/AssetsCatalog/Themes/Themes.tsx
+++ b/packages/inspector/src/components/AssetsCatalog/Themes/Themes.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { getContentsUrl } from '../../../lib/logic/catalog';
 import type { Props } from './types';
 import './Themes.css';
@@ -26,6 +26,9 @@ const ThemeCard: React.FC<{ value: Props['catalog'][number]; onClick: Props['onC
 );
 
 const Themes: React.FC<Props> = ({ catalog, externalCatalog, onClick }) => {
+  const [externalExpanded, setExternalExpanded] = useState(false);
+  const toggleExternal = useCallback(() => setExternalExpanded(prev => !prev), []);
+
   return (
     <div className="asset-catalog-themes-container">
       <div className="asset-catalog-themes">
@@ -39,21 +42,27 @@ const Themes: React.FC<Props> = ({ catalog, externalCatalog, onClick }) => {
       </div>
       {externalCatalog && externalCatalog.length > 0 && (
         <>
-          <div className="asset-catalog-section-divider">
+          <div
+            className="asset-catalog-section-divider"
+            onClick={toggleExternal}
+          >
+            <span className={`section-chevron ${externalExpanded ? 'expanded' : ''}`} />
             <h3 className="section-title">Additional Catalogs</h3>
             <span className="section-subtitle">
               {externalCatalog.reduce((sum, pack) => sum + pack.assets.length, 0)} items
             </span>
           </div>
-          <div className="asset-catalog-themes">
-            {externalCatalog.map(value => (
-              <ThemeCard
-                key={value.id}
-                value={value}
-                onClick={onClick}
-              />
-            ))}
-          </div>
+          {externalExpanded && (
+            <div className="asset-catalog-themes">
+              {externalCatalog.map(value => (
+                <ThemeCard
+                  key={value.id}
+                  value={value}
+                  onClick={onClick}
+                />
+              ))}
+            </div>
+          )}
         </>
       )}
     </div>

--- a/packages/inspector/src/components/AssetsCatalog/Themes/Themes.tsx
+++ b/packages/inspector/src/components/AssetsCatalog/Themes/Themes.tsx
@@ -1,29 +1,61 @@
 import React from 'react';
 import { getContentsUrl } from '../../../lib/logic/catalog';
-import { Props } from './types';
+import type { Props } from './types';
 import './Themes.css';
 
-const Themes: React.FC<Props> = ({ catalog, onClick }) => {
+const ThemeCard: React.FC<{ value: Props['catalog'][number]; onClick: Props['onClick'] }> = ({
+  value,
+  onClick,
+}) => (
+  <div
+    key={value.id}
+    className="theme"
+    data-test-id={value.id}
+    data-test-label={value.name}
+    onClick={() => onClick(value)}
+  >
+    <img
+      src={getContentsUrl(value.thumbnail)}
+      alt={value.name}
+    />
+    <div className="theme-info">
+      <h4 className="theme-info-name">{value.name}</h4>
+      <div className="theme-info-items">{value.assets.length} items</div>
+    </div>
+  </div>
+);
+
+const Themes: React.FC<Props> = ({ catalog, externalCatalog, onClick }) => {
   return (
-    <div className="asset-catalog-themes">
-      {catalog.map(value => (
-        <div
-          key={value.id}
-          className="theme"
-          data-test-id={value.id}
-          data-test-label={value.name}
-          onClick={() => onClick(value)}
-        >
-          <img
-            src={getContentsUrl(value.thumbnail)}
-            alt={value.name}
+    <div className="asset-catalog-themes-container">
+      <div className="asset-catalog-themes">
+        {catalog.map(value => (
+          <ThemeCard
+            key={value.id}
+            value={value}
+            onClick={onClick}
           />
-          <div className="theme-info">
-            <h4 className="theme-info-name">{value.name}</h4>
-            <div className="theme-info-items">{value.assets.length} items</div>
+        ))}
+      </div>
+      {externalCatalog && externalCatalog.length > 0 && (
+        <>
+          <div className="asset-catalog-section-divider">
+            <h3 className="section-title">Free 3D Models</h3>
+            <span className="section-subtitle">
+              {externalCatalog.reduce((sum, pack) => sum + pack.assets.length, 0)} models
+            </span>
           </div>
-        </div>
-      ))}
+          <div className="asset-catalog-themes">
+            {externalCatalog.map(value => (
+              <ThemeCard
+                key={value.id}
+                value={value}
+                onClick={onClick}
+              />
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/packages/inspector/src/components/AssetsCatalog/Themes/Themes.tsx
+++ b/packages/inspector/src/components/AssetsCatalog/Themes/Themes.tsx
@@ -40,9 +40,9 @@ const Themes: React.FC<Props> = ({ catalog, externalCatalog, onClick }) => {
       {externalCatalog && externalCatalog.length > 0 && (
         <>
           <div className="asset-catalog-section-divider">
-            <h3 className="section-title">Free 3D Models</h3>
+            <h3 className="section-title">Additional Catalogs</h3>
             <span className="section-subtitle">
-              {externalCatalog.reduce((sum, pack) => sum + pack.assets.length, 0)} models
+              {externalCatalog.reduce((sum, pack) => sum + pack.assets.length, 0)} items
             </span>
           </div>
           <div className="asset-catalog-themes">

--- a/packages/inspector/src/components/AssetsCatalog/Themes/types.ts
+++ b/packages/inspector/src/components/AssetsCatalog/Themes/types.ts
@@ -2,5 +2,6 @@ import type { AssetPack } from '../../../lib/logic/catalog';
 
 export interface Props {
   catalog: AssetPack[];
+  externalCatalog?: AssetPack[];
   onClick: (value: AssetPack) => void;
 }

--- a/packages/inspector/src/components/AssetsCatalog/types.ts
+++ b/packages/inspector/src/components/AssetsCatalog/types.ts
@@ -2,4 +2,5 @@ import type { AssetPack } from '../../lib/logic/catalog';
 
 export interface Props {
   catalog: AssetPack[];
+  externalCatalog?: AssetPack[];
 }

--- a/packages/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/inspector/src/components/Renderer/Renderer.tsx
@@ -363,6 +363,9 @@ const Renderer: React.FC = () => {
         try {
           const url = getContentFetchUrl(path, contentHash);
           const response = await fetch(url);
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status} ${response.statusText}`);
+          }
           const content = new Uint8Array(await response.arrayBuffer());
           if (path.endsWith(THUMBNAIL_PATH)) {
             thumbnail = content;
@@ -371,13 +374,14 @@ const Renderer: React.FC = () => {
           }
         } catch (err) {
           // eslint-disable-next-line no-console
-          console.error('Error fetching an asset import ' + path);
+          console.error('Error fetching an asset import ' + path, err);
         }
       }),
     );
 
     // Use direct data layer interface to ensure proper sequencing with undo system
     const content = new Map(Object.entries(fileContent));
+    let importSucceeded = false;
     if (content.size > 0) {
       const dataLayer = getDataLayerInterface();
       if (dataLayer) {
@@ -387,6 +391,7 @@ const Renderer: React.FC = () => {
           assetPackageName,
         });
         dispatch(getAssetCatalog()); // Refresh catalog after import
+        importSucceeded = true;
       }
     }
 
@@ -401,6 +406,12 @@ const Renderer: React.FC = () => {
 
     if (!isMounted()) return;
     setIsLoading(false);
+
+    if (!importSucceeded) {
+      // eslint-disable-next-line no-console
+      console.error('Asset import failed: no files were downloaded for', asset.name);
+      return;
+    }
 
     const model: AssetNodeItem = {
       type: 'asset',

--- a/packages/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/inspector/src/components/Renderer/Renderer.tsx
@@ -327,6 +327,9 @@ const Renderer: React.FC = () => {
    */
   const getContentFetchUrl = useCallback(
     (path: string, contentHash: string) => {
+      if (contentHash.startsWith('http://') || contentHash.startsWith('https://')) {
+        return contentHash;
+      }
       let url = `${config.contentUrl}/contents/${contentHash}`;
       if (path.endsWith(THUMBNAIL_PATH)) url += '?resize';
       return url;

--- a/packages/inspector/src/lib/logic/catalog.ts
+++ b/packages/inspector/src/lib/logic/catalog.ts
@@ -84,6 +84,7 @@ export function fetchLatestCatalog(): Promise<AssetPack[]> {
 }
 
 export function getContentsUrl(hash: string) {
+  if (hash.startsWith('http://') || hash.startsWith('https://')) return hash;
   const config = getConfig();
   return `${config.contentUrl}/contents/${hash}`;
 }

--- a/packages/inspector/src/lib/logic/external-catalog.ts
+++ b/packages/inspector/src/lib/logic/external-catalog.ts
@@ -1,0 +1,124 @@
+import type { Asset, AssetPack } from '@dcl/asset-packs';
+
+const EXTERNAL_CATALOG_URL = 'https://studio-api.dclregenesislabs.xyz/api/catalog';
+const FETCH_TIMEOUT_MS = 15_000;
+
+interface ExternalAsset {
+  id: string;
+  name: string;
+  filename: string;
+  url: string;
+  collection: string;
+  category: string;
+  subcategory: string;
+  tags: string[];
+  source: string;
+  description: string;
+  width: number;
+  height: number;
+  depth: number;
+  triangles: number;
+  vertices: number;
+  fileSize: number;
+  thumbnailUrl: string;
+  animations?: string[];
+}
+
+interface ExternalCatalog {
+  collections: { name: string; source: string; assetCount: number }[];
+  assets: ExternalAsset[];
+}
+
+const CATEGORY_DISPLAY_NAMES: Record<string, string> = {
+  prop: 'Props',
+  structure: 'Structures',
+  decoration: 'Decorations',
+  character: 'Characters',
+  effect: 'Effects',
+  signage: 'Signage',
+  nature: 'Nature',
+  appliance: 'Appliances',
+  ground: 'Ground',
+  fixture: 'Fixtures',
+  lighting: 'Lighting',
+  vehicle: 'Vehicles',
+  furniture: 'Furniture',
+  uncategorized: 'Other',
+};
+
+function transformAsset(external: ExternalAsset): Asset {
+  return {
+    id: external.id,
+    name: external.name,
+    category: external.category || 'uncategorized',
+    tags: external.tags || [],
+    description: external.description,
+    composite: {
+      version: 1,
+      components: [
+        {
+          name: 'core::GltfContainer',
+          data: {
+            '0': {
+              json: {
+                src: `{assetPath}/${external.filename}`,
+              },
+            },
+          },
+        },
+      ],
+    },
+    contents: {
+      [external.filename]: external.url,
+      'thumbnail.png': external.thumbnailUrl,
+    },
+  };
+}
+
+let _fetchPromise: Promise<AssetPack[]> | null = null;
+let _externalCatalog: AssetPack[] = [];
+
+export function fetchExternalCatalog(): Promise<AssetPack[]> {
+  if (_fetchPromise) return _fetchPromise;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  _fetchPromise = fetch(EXTERNAL_CATALOG_URL, { signal: controller.signal })
+    .then(async response => {
+      if (!response.ok) throw new Error(`Failed to fetch external catalog: ${response.status}`);
+      const data: ExternalCatalog = await response.json();
+
+      // Group assets by category
+      const byCategory = new Map<string, Asset[]>();
+      for (const ext of data.assets) {
+        if (!ext.thumbnailUrl || !ext.url) continue;
+        const asset = transformAsset(ext);
+        const category = ext.category || 'uncategorized';
+        const list = byCategory.get(category) ?? [];
+        list.push(asset);
+        byCategory.set(category, list);
+      }
+
+      // Create one pack per category, sorted by asset count descending
+      _externalCatalog = Array.from(byCategory.entries())
+        .sort(([, a], [, b]) => b.length - a.length)
+        .map(([category, assets]) => ({
+          id: `external-${category}`,
+          name: CATEGORY_DISPLAY_NAMES[category] ?? category,
+          thumbnail: assets[0]?.contents['thumbnail.png'] ?? '',
+          assets,
+        }));
+
+      return _externalCatalog;
+    })
+    .finally(() => clearTimeout(timeoutId))
+    .catch(err => {
+      console.warn('Failed to fetch external catalog:', err);
+      _externalCatalog = [];
+      _fetchPromise = null;
+      return _externalCatalog;
+    });
+
+  return _fetchPromise;
+}

--- a/packages/inspector/src/lib/logic/external-catalog.ts
+++ b/packages/inspector/src/lib/logic/external-catalog.ts
@@ -38,7 +38,7 @@ const CATEGORY_DISPLAY_NAMES: Record<string, string> = {
   signage: 'Signage',
   nature: 'Nature',
   appliance: 'Appliances',
-  ground: 'Ground',
+  ground: 'Ground & Terrain',
   fixture: 'Fixtures',
   lighting: 'Lighting',
   vehicle: 'Vehicles',
@@ -50,7 +50,7 @@ function transformAsset(external: ExternalAsset): Asset {
   return {
     id: external.id,
     name: external.name,
-    category: external.category || 'uncategorized',
+    category: external.category === 'ground' ? 'terrain' : external.category || 'uncategorized',
     tags: external.tags || [],
     description: external.description,
     composite: {


### PR DESCRIPTION
# Try adding full catalog from skills

Changes

New file

[external-catalog.ts](vscode-webview://0fq2c6ipkbec230v283cmb1pjok6s1n66m6hgqm9g76qdsqf8spk/packages/inspector/src/lib/logic/external-catalog.ts) — Fetches 5,769 free 3D models from studio-api.dclregenesislabs.xyz/api/catalog, transforms them into AssetPack[] format grouped by category (Props, Structures, Decorations, Characters, Effects, Signage, Nature, Appliances, Ground, Fixtures, Lighting, Vehicles, Furniture). Each asset gets a proper GltfContainer composite so it can be dragged into scenes.

Modified files

[catalog.ts:87](vscode-webview://0fq2c6ipkbec230v283cmb1pjok6s1n66m6hgqm9g76qdsqf8spk/packages/inspector/src/lib/logic/catalog.ts#L87) — getContentsUrl now passes through full URLs (for external thumbnails/models)
[Renderer.tsx:330](vscode-webview://0fq2c6ipkbec230v283cmb1pjok6s1n66m6hgqm9g76qdsqf8spk/packages/inspector/src/components/Renderer/Renderer.tsx#L330) — getContentFetchUrl also passes through full URLs, so drag-and-drop import works for external assets
[Assets.tsx](vscode-webview://0fq2c6ipkbec230v283cmb1pjok6s1n66m6hgqm9g76qdsqf8spk/packages/inspector/src/components/Assets/Assets.tsx) — Fetches external catalog in parallel alongside existing catalog, passes it as externalCatalog prop
[AssetsCatalog.tsx](vscode-webview://0fq2c6ipkbec230v283cmb1pjok6s1n66m6hgqm9g76qdsqf8spk/packages/inspector/src/components/AssetsCatalog/AssetsCatalog.tsx) — Merges both catalogs for search, passes externalCatalog to Themes
[Themes.tsx](vscode-webview://0fq2c6ipkbec230v283cmb1pjok6s1n66m6hgqm9g76qdsqf8spk/packages/inspector/src/components/AssetsCatalog/Themes/Themes.tsx) — Shows existing packs first, then a "Free 3D Models" section divider with total count, then external category packs
[Themes.css](vscode-webview://0fq2c6ipkbec230v283cmb1pjok6s1n66m6hgqm9g76qdsqf8spk/packages/inspector/src/components/AssetsCatalog/Themes/Themes.css) — Styles for the section divider and new container layout
Type files updated to accept externalCatalog? prop

How it works

On load, the external catalog API is fetched in parallel with the existing DCL catalog
Assets are grouped into 14 category-based packs (Props: 941, Structures: 870, etc.)
They appear below the existing packs under a "Free 3D Models" divider with total model count
Thumbnails use the external API's CDN URLs directly
Search works across both catalogs — searching "tree" finds matches in both existing and external assets
Drag-and-drop into scenes works because the Renderer's import function handles full URLs for fetching the GLB files