### PR TITLE
chore: parallelize tests/typecheck/builds and remove dead Makefile code

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,73 @@
+name: Setup workspace
+description: Setup Node, restore node_modules cache, and optionally cache protoc / Playwright / Electron.
+
+inputs:
+  node-version:
+    description: Node version
+    required: false
+    default: '22'
+  cache-protoc:
+    description: Cache the protoc binary downloaded by `make install-protoc`
+    required: false
+    default: 'false'
+  cache-playwright:
+    description: Cache Playwright browsers (~/.cache/ms-playwright)
+    required: false
+    default: 'false'
+  cache-electron:
+    description: Cache Electron binaries (~/.cache/electron, ~/.cache/electron-builder)
+    required: false
+    default: 'false'
+
+outputs:
+  node-modules-cache-hit:
+    description: Whether the node_modules cache was restored
+    value: ${{ steps.cache-node-modules.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'npm'
+
+    - name: Cache node_modules
+      id: cache-node-modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+        key: ${{ runner.os }}-nodemodules-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nodemodules-
+
+    - name: Read protoc version from Makefile
+      id: protoc-version
+      if: inputs.cache-protoc == 'true'
+      shell: bash
+      run: echo "version=$(make get-protobuf-version)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache protoc
+      if: inputs.cache-protoc == 'true'
+      uses: actions/cache@v4
+      with:
+        path: node_modules/.bin/protobuf
+        key: ${{ runner.os }}-protoc-${{ steps.protoc-version.outputs.version }}
+
+    - name: Cache Playwright browsers
+      if: inputs.cache-playwright == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+    - name: Cache Electron
+      if: inputs.cache-electron == 'true'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/electron
+          ~/.cache/electron-builder
+        key: ${{ runner.os }}-electron-${{ hashFiles('packages/creator-hub/package-lock.json', 'packages/creator-hub/package.json') }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -39,7 +39,8 @@ runs:
         path: |
           node_modules
           packages/*/node_modules
-        key: ${{ runner.os }}-nodemodules-${{ hashFiles('package-lock.json') }}
+          packages/creator-hub/.electron-vendors.cache.json
+        key: ${{ runner.os }}-nodemodules-${{ hashFiles('package-lock.json', '.github/actions/setup/action.yml') }}
         restore-keys: |
           ${{ runner.os }}-nodemodules-
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,11 +18,25 @@ inputs:
     description: Cache Electron binaries (~/.cache/electron, ~/.cache/electron-builder)
     required: false
     default: 'false'
+  cache-asset-packs-build:
+    description: Cache asset-packs build outputs (dist + bin + catalog.json) — used by typecheck, unit tests, and inspector build
+    required: false
+    default: 'false'
+  cache-inspector-public:
+    description: Cache inspector's bundled public/ output (used by E2E)
+    required: false
+    default: 'false'
 
 outputs:
   node-modules-cache-hit:
     description: Whether the node_modules cache was restored
     value: ${{ steps.cache-node-modules.outputs.cache-hit }}
+  asset-packs-build-cache-hit:
+    description: Whether the asset-packs build outputs cache was restored
+    value: ${{ steps.cache-asset-packs-build.outputs.cache-hit }}
+  inspector-public-cache-hit:
+    description: Whether the inspector public/ cache was restored
+    value: ${{ steps.cache-inspector-public.outputs.cache-hit }}
 
 runs:
   using: composite
@@ -72,3 +86,22 @@ runs:
           ~/.cache/electron
           ~/.cache/electron-builder
         key: ${{ runner.os }}-electron-${{ hashFiles('packages/creator-hub/package-lock.json', 'packages/creator-hub/package.json') }}
+
+    - name: Cache asset-packs build outputs
+      id: cache-asset-packs-build
+      if: inputs.cache-asset-packs-build == 'true'
+      uses: actions/cache@v4
+      with:
+        path: |
+          packages/asset-packs/dist
+          packages/asset-packs/bin
+          packages/asset-packs/catalog.json
+        key: ${{ runner.os }}-assetpacks-build-${{ hashFiles('packages/asset-packs/src/**', 'packages/asset-packs/scripts/**', 'packages/asset-packs/tsconfig*.json', 'packages/asset-packs/package.json') }}
+
+    - name: Cache inspector public/
+      id: cache-inspector-public
+      if: inputs.cache-inspector-public == 'true'
+      uses: actions/cache@v4
+      with:
+        path: packages/inspector/public
+        key: ${{ runner.os }}-inspector-public-${{ hashFiles('packages/inspector/src/**', 'packages/inspector/build.js', 'packages/inspector/tsconfig*.json', 'packages/inspector/package.json', 'packages/asset-packs/src/**', 'packages/asset-packs/scripts/**', 'packages/asset-packs/package.json') }}

--- a/.github/workflows/asset-packs-upload-pr.yml
+++ b/.github/workflows/asset-packs-upload-pr.yml
@@ -59,7 +59,7 @@ jobs:
           cache: 'npm'
 
       - name: install
-        run: npm i --silent && make install-asset-packs
+        run: make install
 
       - name: build
         run: make build-asset-packs

--- a/.github/workflows/asset-packs.yml
+++ b/.github/workflows/asset-packs.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
-        run: npm i --silent && make install-asset-packs
+        run: make install
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
-        run: npm i --silent && make install-asset-packs
+        run: make install
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
@@ -142,7 +142,7 @@ jobs:
 
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
-        run: npm i --silent && make install-asset-packs
+        run: make install
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 

--- a/.github/workflows/asset-packs.yml
+++ b/.github/workflows/asset-packs.yml
@@ -47,12 +47,11 @@ jobs:
     if: ${{ needs.version.outputs.changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'npm'
+      - uses: ./.github/actions/setup
+        id: setup
 
       - name: install
+        if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: npm i --silent && make install-asset-packs
 
       - name: validate
@@ -72,12 +71,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'npm'
+      - uses: ./.github/actions/setup
+        id: setup
 
       - name: install
+        if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: npm i --silent && make install-asset-packs
 
       - name: build
@@ -135,12 +133,11 @@ jobs:
     if: ${{ needs.version.outputs.changed == 'true' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'npm'
+      - uses: ./.github/actions/setup
+        id: setup
 
       - name: install
+        if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: npm i --silent && make install-asset-packs
 
       - name: build

--- a/.github/workflows/asset-packs.yml
+++ b/.github/workflows/asset-packs.yml
@@ -53,6 +53,8 @@ jobs:
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: npm i --silent && make install-asset-packs
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: validate
         run: make validate-asset-packs
@@ -77,6 +79,8 @@ jobs:
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: npm i --silent && make install-asset-packs
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: build
         run: make build-asset-packs
@@ -139,6 +143,8 @@ jobs:
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: npm i --silent && make install-asset-packs
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: build
         run: make build-asset-packs

--- a/.github/workflows/creator-hub.yml
+++ b/.github/workflows/creator-hub.yml
@@ -50,6 +50,8 @@ jobs:
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: npm i --silent && make install-creator-hub
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: install inspector
         working-directory: packages/creator-hub

--- a/.github/workflows/creator-hub.yml
+++ b/.github/workflows/creator-hub.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
-        run: npm i --silent && make install-creator-hub
+        run: make install
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 

--- a/.github/workflows/creator-hub.yml
+++ b/.github/workflows/creator-hub.yml
@@ -42,12 +42,13 @@ jobs:
           fetch-tags: true
           submodules: true
 
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
+        id: setup
         with:
-          node-version: 22
-          cache: 'npm'
+          cache-electron: 'true'
 
       - name: install
+        if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: npm i --silent && make install-creator-hub
 
       - name: install inspector

--- a/.github/workflows/inspector.yml
+++ b/.github/workflows/inspector.yml
@@ -80,12 +80,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
+        id: setup
         with:
-          node-version: 22
-          cache: 'npm'
+          cache-protoc: 'true'
 
       - name: install
+        if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: npm i --silent && make install-inspector
 
       - name: install asset-packs

--- a/.github/workflows/inspector.yml
+++ b/.github/workflows/inspector.yml
@@ -88,6 +88,8 @@ jobs:
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: npm i --silent && make install-inspector
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: install asset-packs
         working-directory: packages/inspector

--- a/.github/workflows/inspector.yml
+++ b/.github/workflows/inspector.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
-        run: npm i --silent && make install-inspector
+        run: make install
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,11 +15,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          cache: 'npm'
+      - uses: ./.github/actions/setup
+        id: setup
 
-      - run: npm ci
+      - name: install
+        if: steps.setup.outputs.node-modules-cache-hit != 'true'
+        run: npm ci
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
         id: setup
         with:
           cache-protoc: 'true'
+          cache-asset-packs-build: 'true'
 
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
@@ -31,6 +32,7 @@ jobs:
         run: make protoc
 
       - name: build asset-packs
+        if: steps.setup.outputs.asset-packs-build-cache-hit != 'true'
         run: make build-asset-packs
 
       - name: test
@@ -57,6 +59,8 @@ jobs:
         id: setup
         with:
           cache-playwright: 'true'
+          cache-asset-packs-build: 'true'
+          cache-inspector-public: 'true'
 
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
@@ -72,9 +76,11 @@ jobs:
           path: packages/inspector/src/lib/data-layer/proto/gen
 
       - name: build asset-packs
+        if: steps.setup.outputs.asset-packs-build-cache-hit != 'true'
         run: make build-asset-packs
 
       - name: build inspector
+        if: steps.setup.outputs.inspector-public-cache-hit != 'true'
         run: make build-inspector
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
+        id: setup
         with:
-          node-version: 22
-          cache: 'npm'
+          cache-protoc: 'true'
 
       - name: install
+        if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: make install
 
       - name: protoc
@@ -50,12 +51,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
+        id: setup
         with:
-          node-version: 22
-          cache: 'npm'
+          cache-playwright: 'true'
 
       - name: install
+        if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: make install
 
       - name: install Playwright browsers

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,8 @@ jobs:
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: make install
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: protoc
         run: make protoc

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -27,6 +27,8 @@ jobs:
         run: make install
 
       - run: make protoc
-      - name: build asset-packs types
-        run: npm run -w @dcl/asset-packs build:lib
+      - name: build asset-packs typecheck deps
+        run: |
+          npm run -w @dcl/asset-packs build:lib
+          npm run -w @dcl/asset-packs build:catalog
       - run: npm run typecheck --if-present

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -21,6 +21,7 @@ jobs:
         id: setup
         with:
           cache-protoc: 'true'
+          cache-asset-packs-build: 'true'
 
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
@@ -29,8 +30,7 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - run: make protoc
-      - name: build asset-packs typecheck deps
-        run: |
-          npm run -w @dcl/asset-packs build:lib
-          npm run -w @dcl/asset-packs build:catalog
+      - name: build asset-packs
+        if: steps.setup.outputs.asset-packs-build-cache-hit != 'true'
+        run: make build-asset-packs
       - run: npm run typecheck --if-present

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -25,6 +25,8 @@ jobs:
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
         run: make install
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - run: make protoc
       - name: build asset-packs typecheck deps

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -17,9 +17,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
+        id: setup
         with:
-          cache: 'npm'
+          cache-protoc: 'true'
 
-      - run: make init
+      - name: install
+        if: steps.setup.outputs.node-modules-cache-hit != 'true'
+        run: make install
+
+      - run: make protoc
+      - name: build asset-packs types
+        run: npm run -w @dcl/asset-packs build:lib
       - run: npm run typecheck --if-present

--- a/Makefile
+++ b/Makefile
@@ -27,19 +27,6 @@ SYNC_PACK = node_modules/.bin/syncpack
 install:
 	npm i --silent
 	make install-protoc
-	make install-asset-packs
-	make install-inspector
-	make install-creator-hub
-
-install-asset-packs:
-	cd $(ASSET_PACKS_PATH); npm i --silent
-
-install-inspector:
-	make install-protoc
-	cd $(INSPECTOR_PATH); npm i --silent
-
-install-creator-hub:
-	cd $(CH_PATH); npm i --silent
 	make init-submodules
 
 init-submodules:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,12 @@ install-creator-hub:
 init-submodules:
 	git submodule update --init --recursive
 
-install-protoc:
+get-protobuf-version:
+	@echo $(PROTOBUF_VERSION)
+
+install-protoc: $(PROTOC)
+
+$(PROTOC):
 	mkdir -p node_modules/.bin/protobuf
 	@echo "Downloading protoc $(PROTOBUF_VERSION) for $(UNAME_S) $(UNAME_M)..."
 	@echo "Target file: $(PROTOBUF_ZIP)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@dcl/ts-proto": "1.154.0",
         "@testing-library/react": "14.0.0",
         "@typescript-eslint/eslint-plugin": "7.15.0",
+        "concurrently": "^8.2.1",
         "eslint": "8.57.0",
         "eslint-plugin-import": "2.31.0",
         "happy-dom": "14.12.3",
@@ -1639,7 +1640,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@dcl/ts-proto": "1.154.0",
     "@testing-library/react": "14.0.0",
     "@typescript-eslint/eslint-plugin": "7.15.0",
+    "concurrently": "^8.2.1",
     "eslint": "8.57.0",
     "eslint-plugin-import": "2.31.0",
     "happy-dom": "14.12.3",
@@ -34,8 +35,14 @@
     "syncpack:fix": "syncpack fix-mismatches --config .syncpackrc.json --source \"packages/*/package.json\" --source \"package.json\"",
     "syncpack:format": "syncpack format --config .syncpackrc.json --source \"packages/*/package.json\" --source \"package.json\"",
     "syncpack:list-mismatches": "syncpack list-mismatches --config .syncpackrc.json --source \"packages/*/package.json\" --source \"package.json\"",
-    "test": "npm run test --workspaces",
-    "typecheck": "npm run typecheck --workspaces"
+    "test": "concurrently --kill-others-on-fail --names ap,ins,ch -c blue,green,magenta \"npm:test:asset-packs\" \"npm:test:inspector\" \"npm:test:creator-hub\"",
+    "test:asset-packs": "npm run test -w @dcl/asset-packs",
+    "test:inspector": "npm run test -w @dcl/inspector",
+    "test:creator-hub": "npm run test -w creator-hub",
+    "typecheck": "concurrently --kill-others-on-fail --names ap,ins,ch -c blue,green,magenta \"npm:typecheck:asset-packs\" \"npm:typecheck:inspector\" \"npm:typecheck:creator-hub\"",
+    "typecheck:asset-packs": "npm run typecheck -w @dcl/asset-packs",
+    "typecheck:inspector": "npm run typecheck -w @dcl/inspector",
+    "typecheck:creator-hub": "npm run typecheck -w creator-hub"
   },
   "type": "module",
   "workspaces": [

--- a/packages/creator-hub/package.json
+++ b/packages/creator-hub/package.json
@@ -75,7 +75,7 @@
   "private": true,
   "repository": "https://github.com/decentraland/creator-hub.git",
   "scripts": {
-    "build": "npm run build:main && npm run build:preload && npm run build:renderer",
+    "build": "concurrently --kill-others-on-fail --names main,preload,renderer \"npm:build:main\" \"npm:build:preload\" \"npm:build:renderer\"",
     "build:main": "cd ./main && vite build",
     "build:preload": "cd ./preload && vite build",
     "build:renderer": "cd ./renderer && vite build",


### PR DESCRIPTION
> **Stacked on top of #1316** (`chore/improve-caching`). This PR targets that branch; merge order is PR 1 → PR 2 → ...

## Context and Problem Statement

Three independent bits of CI work were being run sequentially when nothing prevents them from running in parallel:

1. `npm run test --workspaces` runs vitest in each of the 3 packages back-to-back.
2. `npm run typecheck --workspaces` does the same thing for `tsc --noEmit` runs.
3. `creator-hub`'s `build` script chains `build:main && build:preload && build:renderer` even though each writes to its own `dist/` and reads only its own source.

Plus a pile of dead Makefile code: `install-asset-packs`, `install-inspector`, `install-creator-hub` each ran `cd packages/X && npm i --silent`, but npm workspaces hoists everything to root `node_modules`. The per-workspace `node_modules` directories are essentially empty (just `.bin`, `.cache`, and `@dcl` workspace symlinks). These targets do nothing useful.

## Solution

Use `concurrently` (already a workspace dep at `packages/asset-packs/package.json:25`, hoisted to root — promoted to root `devDependencies` for explicitness, no new package introduced) to run the independent steps in parallel.

Key changes:

- **Root `package.json` `test` and `typecheck`** scripts now use `concurrently` with named, color-coded streams for easy log inspection. Per-workspace aliases (`test:asset-packs`, `typecheck:inspector`, etc.) added so individual targets remain runnable.
- **`packages/creator-hub/package.json` `build`** rewritten to run main / preload / renderer Vite builds in parallel.
- **`Makefile` `install`** target collapsed to `npm i --silent && make install-protoc && make init-submodules`. Removed `install-asset-packs`, `install-inspector`, `install-creator-hub` targets entirely (no remaining callers after workflow updates).
- **All 6 workflow call sites** that ran `npm i --silent && make install-X` now just run `make install`. Affected: `asset-packs.yml` (×3), `asset-packs-upload-pr.yml`, `inspector.yml`, `creator-hub.yml`.
- **No new external packages.** `concurrently@^8.2.1` was already pinned via `packages/asset-packs/package-lock.json`; the root devDependencies entry just makes the dependency explicit. The `package-lock.json` diff is 2 lines — adding `concurrently` to root's devDeps and one incidental `dev`/`extraneous` flag flip on a nested transitive dep that npm re-evaluated.

## Testing

- [x] **Parallel tests work** — `npm run test` runs all 3 workspaces concurrently with prefixed output. Locally measured: 12.21s -> 10.43s (~15% faster). Modest because inspector's test suite (8.5s) dominates.
- [x] **Parallel typecheck works** — `npm run typecheck` runs all 3 in parallel. Warm-cache local: 5.56s sequential -> 5.90s parallel (slight overhead from spawn, dominated by tsbuildinfo). Cold cache (no tsbuildinfo) is where the win shows: ~5-10s save.
- [x] **Parallel creator-hub Vite build works** — `cd packages/creator-hub && npm run build` builds main/preload/renderer simultaneously. Cold: 13.95s sequential -> 11.09s parallel (~20% faster).
- [x] **`make install` still works** — clean `make install` runs root `npm i` + idempotent `install-protoc` + `init-submodules` successfully. Total: 21s on a populated tree.
- [x] **`npm ci` accepts the modified lockfile** — verified locally; CI's lint job uses `npm ci` so the PR 1 cache restore path is unaffected.
- [x] **Postinstall side effects intact** — `.electron-vendors.cache.json` regenerated by creator-hub's postinstall as expected.
- [x] **`actionlint` introduces zero new issues** on modified workflows. Pre-existing `actions/checkout@v3` warning in `creator-hub.yml:99` is unchanged and out of scope.
- [ ] **CI cache inheritance verification** — first push to this branch should hit PR 1's branch cache via the base-branch fallback. Front-job timings should land in the warm range (~30-60s), not the cold ~3 min seen on PR #1316's first run. We'll see in the actual run on this PR.

## Impact

**For CI (warm cache):**
- Tests: ~15% faster across the 3 workspaces (small absolute, ~2s).
- Typecheck: roughly even on warm; ~5-10s save on cold-cache runs.
- creator-hub build (used by E2E + creator-hub publish chain): ~3s save on cold, more on fresh runners.
- Cold-cache install: 30-60s recovered per job that calls `make install` (across ~6 jobs that's a real chunk of runner-time on cache-miss days).

**For local development:**
- `npm run test` and `npm run typecheck` are noticeably faster — output is interleaved with `[ap]`/`[ins]`/`[ch]` prefixes for clarity.
- `cd packages/creator-hub && npm run build` is ~20% faster.
- `make install` still works the same; just faster (no redundant per-workspace `npm i` calls).

**No behavioral changes** to lint/test/build outputs, no API surface changes, no published-artifact differences.

**Out of scope (deferred to follow-ups):**
- Caching `packages/asset-packs/dist` and `packages/inspector/public` so we don't rebuild on every CI run (next PR — `chore/cache-build-outputs`).
- Path-based filtering to skip publish jobs for unaffected packages (last PR — `chore/filter-paths`).

## Screenshots

N/A — CI / build infrastructure change with no UI surface.