### PR TITLE
chore: cache asset-packs and inspector build outputs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,11 +18,25 @@ inputs:
     description: Cache Electron binaries (~/.cache/electron, ~/.cache/electron-builder)
     required: false
     default: 'false'
+  cache-asset-packs-build:
+    description: Cache asset-packs build outputs (dist + bin + catalog.json) — used by typecheck, unit tests, and inspector build
+    required: false
+    default: 'false'
+  cache-inspector-public:
+    description: Cache inspector's bundled public/ output (used by E2E)
+    required: false
+    default: 'false'
 
 outputs:
   node-modules-cache-hit:
     description: Whether the node_modules cache was restored
     value: ${{ steps.cache-node-modules.outputs.cache-hit }}
+  asset-packs-build-cache-hit:
+    description: Whether the asset-packs build outputs cache was restored
+    value: ${{ steps.cache-asset-packs-build.outputs.cache-hit }}
+  inspector-public-cache-hit:
+    description: Whether the inspector public/ cache was restored
+    value: ${{ steps.cache-inspector-public.outputs.cache-hit }}
 
 runs:
   using: composite
@@ -72,3 +86,22 @@ runs:
           ~/.cache/electron
           ~/.cache/electron-builder
         key: ${{ runner.os }}-electron-${{ hashFiles('packages/creator-hub/package-lock.json', 'packages/creator-hub/package.json') }}
+
+    - name: Cache asset-packs build outputs
+      id: cache-asset-packs-build
+      if: inputs.cache-asset-packs-build == 'true'
+      uses: actions/cache@v4
+      with:
+        path: |
+          packages/asset-packs/dist
+          packages/asset-packs/bin
+          packages/asset-packs/catalog.json
+        key: ${{ runner.os }}-assetpacks-build-${{ hashFiles('packages/asset-packs/src/**', 'packages/asset-packs/scripts/**', 'packages/asset-packs/tsconfig*.json', 'packages/asset-packs/package.json') }}
+
+    - name: Cache inspector public/
+      id: cache-inspector-public
+      if: inputs.cache-inspector-public == 'true'
+      uses: actions/cache@v4
+      with:
+        path: packages/inspector/public
+        key: ${{ runner.os }}-inspector-public-${{ hashFiles('packages/inspector/src/**', 'packages/inspector/build.js', 'packages/inspector/tsconfig*.json', 'packages/inspector/package.json', 'packages/asset-packs/src/**', 'packages/asset-packs/scripts/**', 'packages/asset-packs/package.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
         id: setup
         with:
           cache-protoc: 'true'
+          cache-asset-packs-build: 'true'
 
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
@@ -31,6 +32,7 @@ jobs:
         run: make protoc
 
       - name: build asset-packs
+        if: steps.setup.outputs.asset-packs-build-cache-hit != 'true'
         run: make build-asset-packs
 
       - name: test
@@ -57,6 +59,8 @@ jobs:
         id: setup
         with:
           cache-playwright: 'true'
+          cache-asset-packs-build: 'true'
+          cache-inspector-public: 'true'
 
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
@@ -72,9 +76,11 @@ jobs:
           path: packages/inspector/src/lib/data-layer/proto/gen
 
       - name: build asset-packs
+        if: steps.setup.outputs.asset-packs-build-cache-hit != 'true'
         run: make build-asset-packs
 
       - name: build inspector
+        if: steps.setup.outputs.inspector-public-cache-hit != 'true'
         run: make build-inspector
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -21,6 +21,7 @@ jobs:
         id: setup
         with:
           cache-protoc: 'true'
+          cache-asset-packs-build: 'true'
 
       - name: install
         if: steps.setup.outputs.node-modules-cache-hit != 'true'
@@ -29,8 +30,7 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - run: make protoc
-      - name: build asset-packs typecheck deps
-        run: |
-          npm run -w @dcl/asset-packs build:lib
-          npm run -w @dcl/asset-packs build:catalog
+      - name: build asset-packs
+        if: steps.setup.outputs.asset-packs-build-cache-hit != 'true'
+        run: make build-asset-packs
       - run: npm run typecheck --if-present


### PR DESCRIPTION
> **Stacked on top of #1317** (`chore/parallelize-builds`), which is itself stacked on #1316. Merge order: #1316 → #1317 → this PR.

## Context and Problem Statement

PR #1316 cached `node_modules` so we skip `npm install` on warm runs. PR #1317 parallelized independent build steps. Both target the *inputs* of the build pipeline.

The other side of the equation — *outputs* of the build — still rebuild on every CI run, even when the source code that produced them is byte-for-byte unchanged:

- `make build-asset-packs` runs ~30-60s every typecheck/tests-unit/tests-E2E job, producing dist/, bin/, and catalog.json from source that often hasn't changed since the last green build.
- `make build-inspector` runs ~45-90s on every E2E run to produce inspector/public/, even when neither inspector's source nor asset-packs's source changed.

These build outputs are deterministic and content-cacheable.

## Solution

Add two new cache toggles to the composite action introduced in PR #1316. Each is content-keyed on the source tree that produces the output, so the cache invalidates exactly when (and only when) a rebuild is actually needed.

Key changes:

- **`cache-asset-packs-build`** in `.github/actions/setup/action.yml`. Caches `packages/asset-packs/{dist,bin,catalog.json}` (~14 MB total). Cache key hashes `packages/asset-packs/src/**`, `scripts/**`, `tsconfig*.json`, `package.json`.
- **`cache-inspector-public`** in the same composite action. Caches `packages/inspector/public/` (~121 MB before compression). Cache key includes both inspector's source and asset-packs's source (because inspector imports from asset-packs's `dist/` and `catalog.json`).
- **`typechecking.yml`** swaps the inline `build:lib && build:catalog` for `make build-asset-packs`, guarded on cache-hit. On cache hit, the build step is skipped entirely.
- **`tests.yml` (unit job)** opts into `cache-asset-packs-build`. Same guard pattern.
- **`tests.yml` (E2E job)** opts into both `cache-asset-packs-build` and `cache-inspector-public`. The `make build-asset-packs` and `make build-inspector` steps each guard on their respective cache-hit output. On a fully warm E2E run (asset-packs and inspector source unchanged), both build steps are skipped.

## Testing

- [x] **Composite action YAML is valid** — verified via `js-yaml` (actionlint doesn't natively support composite actions).
- [x] **`actionlint` introduces zero new warnings** on `typechecking.yml` and `tests.yml`. Pre-existing `actions/checkout@v3` warning in `creator-hub.yml` is unchanged and out of scope.
- [x] **Typecheck path validated** — earlier in the stack, confirmed locally that `make build-asset-packs` produces what typecheck needs (asset-packs's `.d.ts` files for inspector to resolve `@dcl/asset-packs` imports, plus `catalog.json` which inspector imports directly from `packages/inspector/src/lib/logic/catalog.ts:2`).
- [x] **Cache key is correct** — invalidates when any file in `packages/asset-packs/{src,scripts,tsconfig*.json,package.json}` changes; otherwise hits.
- [ ] **Cache hit on second push** — to confirm in CI: first push of this PR will populate caches; subsequent push without source changes should skip both build steps and shave ~30s off typecheck and ~75s off E2E.

## Impact

**For CI (warm cache, no asset-packs/inspector source change):**
- typechecking: skips `make build-asset-packs` → ~30-60s saved
- tests-unit: same → ~30-60s saved
- tests-E2E: skips both `make build-asset-packs` and `make build-inspector` → ~75-150s saved

**For CI (cold cache or source changed):**
- Same as before — build steps run normally. No regression.

**Cache size:** ~135 MB total (asset-packs ~14 MB + inspector ~121 MB) before GitHub's compression. Well within the 10 GB per-repo budget; leaves comfortable room for the existing `node_modules` cache (~2.5 GB) and Playwright/Electron caches.

**No behavioral changes** to outputs. Cache hits restore byte-identical artifacts to what a fresh build would produce, so downstream test/typecheck/E2E behavior is invariant.

**Out of scope (deferred):**
- Caching `creator-hub`'s Vite outputs — the build is ~13s, smaller win and harder to key correctly given electron-vendors interactions.
- Caching `.tsbuildinfo` for incremental tsc — listed as optional in the plan; small marginal benefit (~5s), defer unless metrics show typecheck is still a bottleneck.
- Path filtering to skip publish jobs entirely (next PR — `chore/filter-paths`).

## Screenshots

N/A — CI / build infrastructure change with no UI surface.