### PR TITLE
fix: cascade asset-packs version bumps into inspector publish

### DIFF
--- a/.github/workflows/inspector.yml
+++ b/.github/workflows/inspector.yml
@@ -32,16 +32,16 @@ jobs:
       contents: read
       id-token: write
     outputs:
-      changed: ${{ steps.check-changed.outputs.changed }}
-      version: ${{ steps.version.outputs.version }}
-      previous_version: ${{ steps.version.outputs.previous_version }}
+      changed: ${{ steps.effective-version.outputs.changed }}
+      version: ${{ steps.effective-version.outputs.version }}
+      previous_version: ${{ steps.semantic-version.outputs.previous_version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Bump release version
-        id: version
+        id: semantic-version
         uses: paulhatch/semantic-version@v5.4.0
         with:
           tag_prefix: "@dcl/inspector@"
@@ -54,14 +54,31 @@ jobs:
           user_format_type: "json"
           change_path: "packages/inspector"
 
-      # build inspector if either inspector or asset-packs changed
-      - name: Check if build is needed
-        id: check-changed
+      # Force a patch bump when only @dcl/asset-packs changed: inspector source
+      # references @dcl/asset-packs via `file:../asset-packs`, so dependency-only
+      # bumps don't touch packages/inspector and semantic-version returns an
+      # unchanged version. Without the patch bump, `npm publish` would try to
+      # republish the same version (rejected by the registry), and downstream
+      # creator-hub would install a stale inspector tarball pinning the old
+      # asset-packs.
+      - name: Compute effective version
+        id: effective-version
+        env:
+          INSPECTOR_CHANGED: ${{ steps.semantic-version.outputs.changed }}
+          ASSET_PACKS_CHANGED: ${{ inputs.asset_packs_changed }}
+          SEMVER_VERSION: ${{ steps.semantic-version.outputs.version }}
+          PREVIOUS_VERSION: ${{ steps.semantic-version.outputs.previous_version }}
         run: |
-          if [[ "${{ steps.version.outputs.changed }}" == "true" || "${{ inputs.asset_packs_changed }}" == "true" ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
+          if [[ "$INSPECTOR_CHANGED" == "true" ]]; then
+            echo "version=$SEMVER_VERSION" >> "$GITHUB_OUTPUT"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$ASSET_PACKS_CHANGED" == "true" ]]; then
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$PREVIOUS_VERSION"
+            echo "version=${MAJOR}.${MINOR}.$((PATCH + 1))" >> "$GITHUB_OUTPUT"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "version=$SEMVER_VERSION" >> "$GITHUB_OUTPUT"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
   publish:

--- a/.github/workflows/inspector.yml
+++ b/.github/workflows/inspector.yml
@@ -32,8 +32,8 @@ jobs:
       contents: read
       id-token: write
     outputs:
-      changed: ${{ steps.effective-version.outputs.changed }}
-      version: ${{ steps.effective-version.outputs.version }}
+      changed: ${{ steps.detect-changes.outputs.changed }}
+      version: ${{ steps.detect-changes.outputs.version }}
       previous_version: ${{ steps.semantic-version.outputs.previous_version }}
     steps:
       - uses: actions/checkout@v4
@@ -61,8 +61,8 @@ jobs:
       # republish the same version (rejected by the registry), and downstream
       # creator-hub would install a stale inspector tarball pinning the old
       # asset-packs.
-      - name: Compute effective version
-        id: effective-version
+      - name: Detect inspector/asset-packs changes
+        id: detect-changes
         env:
           INSPECTOR_CHANGED: ${{ steps.semantic-version.outputs.changed }}
           ASSET_PACKS_CHANGED: ${{ inputs.asset_packs_changed }}


### PR DESCRIPTION
## Context and Problem Statement

In our `asset-packs` → `inspector` → `creator-hub` publish pipeline, the inspector package silently fails to release a new artifact when only `asset-packs` is bumped, which means downstream creator-hub builds end up with the previous asset-packs.

Root cause:
- `packages/inspector/package.json` references `@dcl/asset-packs` via `file:../asset-packs` (intentional — needed for monorepo local dev). Asset-packs version bumps therefore touch zero files inside `packages/inspector/`.
- `.github/workflows/inspector.yml` runs `paulhatch/semantic-version@v5.4.0` with `change_path: "packages/inspector"`. With no commits inside that path, it returns `changed=false` and `version=<previous>`.
- The previous `check-changed` step correctly OR'd in `inputs.asset_packs_changed`, so the `publish` job ran — but the `npm version` step still received the unchanged version. `npm publish` then either rejected the duplicate (403) or no-op'd it.
- The orchestrator (`ci.yml`) reports `inspector_changed=true` to creator-hub, which runs `npm install @dcl/inspector@<unchanged-version>` and pulls the OLD tarball, still pinning the OLD asset-packs. Result: a fresh creator-hub electron build that doesn't actually contain the new asset-packs.

`creator-hub.yml` is not affected — its `paulhatch/semantic-version` has no `change_path`, so any commit anywhere bumps it.

## Solution

Replace the `check-changed` step in the inspector workflow's `version` job with an `effective-version` step that computes the version the publish chain should use:

- If inspector itself has qualifying commits → use semantic-version's bump (preserves today's major/minor/patch behavior).
- Else if `asset_packs_changed == true` → force a patch bump from `previous_version`, so `npm publish` produces a brand-new artifact embedding the new asset-packs reference.
- Else → unchanged version, `changed=false`, publish skipped (same as today).

Key changes:
- Renamed the `paulhatch/semantic-version` step id from `version` to `semantic-version` to disambiguate from the parent job.
- Re-pointed `version` job outputs (`changed`, `version`) at the new `effective-version` step; `previous_version` continues to come straight from semantic-version (used by the release-notes job).
- Folded the OR logic from `check-changed` into the new step so version and changed cannot drift.
- Pass step inputs into the run script via `env:` (not direct `${{ }}` interpolation) per workflow-injection best practice.
- All downstream jobs/steps (`publish`, `release`, `notify`) already read through `needs.version.outputs.*` — no other workflow changes needed.

The alternative (asset-packs publish job pushes a commit to main bumping inspector's `package.json`) was rejected: it would replace the `file:../asset-packs` reference with a registry version, breaking local dev workflows, and it requires CI write access to main plus introduces commit churn.

## Testing

- [x] Bash logic for `effective-version` validated locally with 6 cases (both changed; inspector only; asset-packs only; neither; low version; multi-digit). All pass.
- [x] YAML parses cleanly (`js-yaml`); `version` job step ids: `semantic-version`, `effective-version`; outputs re-pointed correctly.
- [ ] On this PR specifically: asset-packs job `changed=false` (no asset-packs files touched), inspector job `effective-version.changed=false`, no inspector publish — i.e., the workflow is a no-op for this PR but proves it parses and runs.
- [ ] Post-merge follow-up on the next asset-packs-only `feat:`/`fix:` commit on main: confirm `@dcl/inspector` patch-bumps on npm, the `@dcl/inspector@<new>` git tag/release appear, and the creator-hub matrix builds embed the new asset-packs.

## Impact

- Removes a silent failure mode where asset-packs library bumps (including pack/glb additions, since those regenerate `catalog.json` which IS in the published artifact) didn't actually reach end-user creator-hub builds.
- Inspector will now publish a patch bump on every asset-packs bump even if its own source is untouched. That's intentional — the published inspector tarball *is* a different artifact (different `@dcl/asset-packs` registry version pinned) and warrants a new version.
- No changes to local dev workflows; the `file:../asset-packs` reference stays.

## Screenshots

N/A — CI/CD workflow change, no UI surface.