### PR TITLE
copy values

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "permissions": {
+    "allow": ["Bash(xargs cat)", "Bash(make typecheck *)"]
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "permissions": {
-    "allow": ["Bash(xargs cat)", "Bash(make typecheck *)"]
-  },
   "hooks": {
     "PostToolUse": [
       {

--- a/packages/inspector/src/components/Container/Container.tsx
+++ b/packages/inspector/src/components/Container/Container.tsx
@@ -2,10 +2,12 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io';
 import { FiAlertTriangle as WarningIcon } from 'react-icons/fi';
 import { VscTrash as RemoveIcon } from 'react-icons/vsc';
+import { MdContentCopy as CopyIcon, MdContentPaste as PasteIcon } from 'react-icons/md';
 import cx from 'classnames';
 import { Button } from '../Button';
 import { InfoTooltip } from '../ui/InfoTooltip';
 import MoreOptionsMenu from '../EntityInspector/MoreOptionsMenu';
+import { useComponentClipboard } from '../../hooks/sdk/useComponentClipboard';
 
 /**
  * ContainerContent is a wrapper component that allows returning both main content
@@ -79,27 +81,54 @@ const Container: React.FC<React.PropsWithChildren<Props>> = props => {
 
   const finalRightContent = rightContentFromChildren || props.rightContent;
 
+  const {
+    onCopyValues,
+    onPasteValues,
+    enabled: clipboardEnabled,
+  } = useComponentClipboard(props.entity, props.component);
+
+  const hasMenu = !!props.onRemoveContainer || clipboardEnabled;
+
   const shouldRenderRightContent = useMemo(() => {
-    return finalRightContent || props.onRemoveContainer;
-  }, [finalRightContent, props.onRemoveContainer]);
+    return finalRightContent || hasMenu;
+  }, [finalRightContent, hasMenu]);
 
   const renderRightContent = useCallback(() => {
     return (
       <div className="RightContent">
         {finalRightContent}
-        {props.onRemoveContainer && (
+        {hasMenu && (
           <MoreOptionsMenu>
-            <Button
-              className="RemoveButton"
-              onClick={props.onRemoveContainer}
-            >
-              <RemoveIcon /> Delete Component
-            </Button>
+            {clipboardEnabled ? (
+              <Button onClick={onCopyValues}>
+                <CopyIcon /> Copy values
+              </Button>
+            ) : null}
+            {clipboardEnabled ? (
+              <Button onClick={onPasteValues}>
+                <PasteIcon /> Paste values
+              </Button>
+            ) : null}
+            {props.onRemoveContainer ? (
+              <Button
+                className="RemoveButton"
+                onClick={props.onRemoveContainer}
+              >
+                <RemoveIcon /> Delete Component
+              </Button>
+            ) : null}
           </MoreOptionsMenu>
         )}
       </div>
     );
-  }, [finalRightContent, props.onRemoveContainer]);
+  }, [
+    finalRightContent,
+    hasMenu,
+    clipboardEnabled,
+    onCopyValues,
+    onPasteValues,
+    props.onRemoveContainer,
+  ]);
 
   return (
     <div

--- a/packages/inspector/src/components/Container/types.ts
+++ b/packages/inspector/src/components/Container/types.ts
@@ -1,3 +1,6 @@
+import type { Entity } from '@dcl/ecs';
+import type { Component } from '../../lib/sdk/components';
+
 export type Props = {
   label?: string;
   className?: string;
@@ -8,4 +11,6 @@ export type Props = {
   gap?: boolean;
   variant?: 'minimal';
   onRemoveContainer?: () => void;
+  component?: Component<any>;
+  entity?: Entity | Entity[];
 };

--- a/packages/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
@@ -1314,6 +1314,8 @@ export default withSdk<Props>(({ sdk, entity: entityId, initialOpen = true }) =>
           type="help"
         />
       }
+      component={Actions}
+      entity={entityId}
       onRemoveContainer={handleRemove}
     >
       {actions.map((action: Action, idx: number) => {

--- a/packages/inspector/src/components/EntityInspector/AnimatorInspector/AnimatorInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/AnimatorInspector/AnimatorInspector.tsx
@@ -121,6 +121,8 @@ export default withSdk<Props>(({ sdk, entity: entityId, initialOpen = true }) =>
           type="help"
         />
       }
+      component={Animator}
+      entity={entityId}
       onRemoveContainer={handleRemove}
     >
       {states.map(($, idx) => (

--- a/packages/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.tsx
@@ -72,6 +72,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           type="help"
         />
       }
+      component={AudioSource}
+      entity={entities}
       onRemoveContainer={handleRemove}
     >
       <Block>

--- a/packages/inspector/src/components/EntityInspector/AudioStreamInspector/AudioStreamInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/AudioStreamInspector/AudioStreamInspector.tsx
@@ -59,6 +59,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           type="help"
         />
       }
+      component={AudioStream}
+      entity={entities}
       onRemoveContainer={handleRemove}
     >
       <Block label="Url">

--- a/packages/inspector/src/components/EntityInspector/AvatarAttachInspector/AvatarAttachInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/AvatarAttachInspector/AvatarAttachInspector.tsx
@@ -86,6 +86,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           type="help"
         />
       }
+      component={AvatarAttach}
+      entity={entities}
       onRemoveContainer={handleRemove}
     >
       <Block>

--- a/packages/inspector/src/components/EntityInspector/BillboardInspector/BillboardInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/BillboardInspector/BillboardInspector.tsx
@@ -65,6 +65,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           type="help"
         />
       }
+      component={Billboard}
+      entity={entities}
       onRemoveContainer={handleRemove}
     >
       <Block>

--- a/packages/inspector/src/components/EntityInspector/CounterBarInspector/CounterBarInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/CounterBarInspector/CounterBarInspector.tsx
@@ -42,6 +42,8 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
         />
       }
       initialOpen={initialOpen}
+      component={CounterBar}
+      entity={entity}
       onRemoveContainer={handleRemove}
     >
       <TextField

--- a/packages/inspector/src/components/EntityInspector/CounterInspector/CounterInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/CounterInspector/CounterInspector.tsx
@@ -51,6 +51,8 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           type="help"
         />
       }
+      component={Counter}
+      entity={entity}
       onRemoveContainer={handleRemove}
     >
       <TextField

--- a/packages/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
@@ -63,6 +63,8 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           type="help"
         />
       }
+      component={GltfContainer}
+      entity={entity}
       onRemoveContainer={handleRemove}
     >
       <Block>

--- a/packages/inspector/src/components/EntityInspector/GltfNodeModifiersInspector/GltfNodeModifiersInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/GltfNodeModifiersInspector/GltfNodeModifiersInspector.tsx
@@ -111,6 +111,8 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           type="help"
         />
       }
+      component={GltfNodeModifiers}
+      entity={entity}
       onRemoveContainer={handleRemove}
     >
       {swapsValue.map((_, idx) => (

--- a/packages/inspector/src/components/EntityInspector/LightSourceInspector/LightSourceInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/LightSourceInspector/LightSourceInspector.tsx
@@ -64,6 +64,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           type="help"
         />
       }
+      component={LightSource}
+      entity={entities}
       onRemoveContainer={handleRemove}
     >
       <Block>

--- a/packages/inspector/src/components/EntityInspector/MaterialInspector/MaterialInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/MaterialInspector/MaterialInspector.tsx
@@ -45,6 +45,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           type="help"
         />
       }
+      component={Material}
+      entity={entities}
       onRemoveContainer={handleRemove}
     >
       <Block>

--- a/packages/inspector/src/components/EntityInspector/MeshColliderInspector/MeshColliderInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/MeshColliderInspector/MeshColliderInspector.tsx
@@ -57,6 +57,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           type="help"
         />
       }
+      component={MeshCollider}
+      entity={entities}
       onRemoveContainer={handleRemove}
     >
       <Block>

--- a/packages/inspector/src/components/EntityInspector/MeshRendererInspector/MeshRendererInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/MeshRendererInspector/MeshRendererInspector.tsx
@@ -73,6 +73,8 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           type="help"
         />
       }
+      component={MeshRenderer}
+      entity={entity}
       onRemoveContainer={handleRemove}
     >
       <Block>

--- a/packages/inspector/src/components/EntityInspector/MoreOptionsMenu/MoreOptionsMenu.tsx
+++ b/packages/inspector/src/components/EntityInspector/MoreOptionsMenu/MoreOptionsMenu.tsx
@@ -12,7 +12,7 @@ export const MoreOptionsMenu = ({
   options,
   icon,
 }: {
-  children?: JSX.Element | JSX.Element[];
+  children?: React.ReactNode;
   options?: OptionProp[];
   icon?: JSX.Element;
 }) => {
@@ -31,6 +31,14 @@ export const MoreOptionsMenu = ({
     setShowMoreOptions(false);
   }, [showMoreOptions, setShowMoreOptions]);
 
+  const handleContentClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      setShowMoreOptions(false);
+    },
+    [setShowMoreOptions],
+  );
+
   const ref = useOutsideClick(handleClosePanel);
 
   return (
@@ -47,7 +55,7 @@ export const MoreOptionsMenu = ({
       {showMoreOptions && (
         <div
           className="MoreOptionsContent"
-          onClick={handleClosePanel}
+          onClick={handleContentClick}
         >
           {options
             ? options.map((opt, i) => (

--- a/packages/inspector/src/components/EntityInspector/NftShapeInspector/NftShapeInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/NftShapeInspector/NftShapeInspector.tsx
@@ -91,6 +91,8 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           type="help"
         />
       }
+      component={NftShape}
+      entity={entity}
       onRemoveContainer={handleRemove}
     >
       <Block

--- a/packages/inspector/src/components/EntityInspector/PlaceholderInspector/PlaceholderInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/PlaceholderInspector/PlaceholderInspector.tsx
@@ -55,6 +55,8 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           type="help"
         />
       }
+      component={Placeholder}
+      entity={entity}
       onRemoveContainer={handleRemove}
     >
       <Block>

--- a/packages/inspector/src/components/EntityInspector/PointerEventsInspector/PointerEventsInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/PointerEventsInspector/PointerEventsInspector.tsx
@@ -92,6 +92,8 @@ export default withSdk<Props>(({ sdk, entity: entityId, initialOpen = true }) =>
           type="help"
         />
       }
+      component={PointerEvents}
+      entity={entityId}
       onRemoveContainer={handleRemoveComponent}
     >
       {pointerEvents.map(($, idx) => (

--- a/packages/inspector/src/components/EntityInspector/RewardInspector/RewardInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/RewardInspector/RewardInspector.tsx
@@ -25,6 +25,8 @@ export const RewardInspector = withSdk<Props>(({ sdk, entity, initialOpen = true
     <Container
       label="Rewards"
       initialOpen={initialOpen}
+      component={Rewards}
+      entity={entity}
       rightContent={
         <InfoTooltip
           text="Rewards enables the campaign configuration for giveaways."

--- a/packages/inspector/src/components/EntityInspector/ScriptInspector/ScriptInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/ScriptInspector/ScriptInspector.tsx
@@ -377,6 +377,8 @@ export default withSdk<Props>(({ sdk, entity: entityId, initialOpen = true }) =>
       label="Script"
       className="ScriptInspector"
       initialOpen={initialOpen}
+      component={Script}
+      entity={entityId}
       onRemoveContainer={handleRemove}
       rightContent={
         <InfoTooltip

--- a/packages/inspector/src/components/EntityInspector/StatesInspector/StatesInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/StatesInspector/StatesInspector.tsx
@@ -113,6 +113,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           type="help"
         />
       }
+      component={States}
+      entity={entities}
       onRemoveContainer={handleDelete}
     >
       {items.length > 0 ? (

--- a/packages/inspector/src/components/EntityInspector/SyncComponentsInspector/SyncComponentsInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/SyncComponentsInspector/SyncComponentsInspector.tsx
@@ -108,6 +108,8 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           type="help"
         />
       }
+      component={SyncComponents}
+      entity={entity}
       onRemoveContainer={handleRemove}
     >
       Select the components of this item to sync so all users see the same changes in the scene.

--- a/packages/inspector/src/components/EntityInspector/TextShapeInspector/TextShapeInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/TextShapeInspector/TextShapeInspector.tsx
@@ -50,6 +50,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           type="help"
         />
       }
+      component={TextShape}
+      entity={entities}
       onRemoveContainer={handleRemove}
     >
       <Block>

--- a/packages/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
@@ -54,6 +54,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
       label="Transform"
       className="Transform"
       initialOpen={initialOpen}
+      component={Transform}
+      entity={entities}
       rightContent={
         <InfoTooltip
           text="Transform defines the position, rotation, and scale of an entity in 3D space. Every entity has a Transform component that determines where and how it appears in the scene."

--- a/packages/inspector/src/components/EntityInspector/TriggerInspector/TriggerInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/TriggerInspector/TriggerInspector.tsx
@@ -342,6 +342,8 @@ export default withSdk<Props>(({ sdk, entity: entityId, initialOpen = true }) =>
           type="help"
         />
       }
+      component={Triggers}
+      entity={entityId}
       onRemoveContainer={handleRemove}
     >
       {triggers.map((trigger: Trigger, triggerIdx: number) => {

--- a/packages/inspector/src/components/EntityInspector/TweenInspector/TweenInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/TweenInspector/TweenInspector.tsx
@@ -116,6 +116,8 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           type="help"
         />
       }
+      component={Tween}
+      entity={entity}
       onRemoveContainer={handleRemove}
     >
       <Block label="Tween Type">

--- a/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/VideoPlayerInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/VideoPlayerInspector.tsx
@@ -99,6 +99,8 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           type="help"
         />
       }
+      component={VideoPlayer}
+      entity={entity}
       onRemoveContainer={handleRemove}
     >
       <Block

--- a/packages/inspector/src/components/EntityInspector/VirtualCameraInspector/VirtualCameraInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/VirtualCameraInspector/VirtualCameraInspector.tsx
@@ -103,6 +103,8 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           type="help"
         />
       }
+      component={VirtualCamera}
+      entity={entity}
       onRemoveContainer={handleRemove}
     >
       <Block label="Default Transition Mode">

--- a/packages/inspector/src/components/EntityInspector/VisibilityComponentInspector/VisibilityComponentInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/VisibilityComponentInspector/VisibilityComponentInspector.tsx
@@ -64,6 +64,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           type="help"
         />
       }
+      component={VisibilityComponent}
+      entity={entities}
       onRemoveContainer={handleRemove}
     >
       <Block>

--- a/packages/inspector/src/hooks/sdk/useComponentClipboard.ts
+++ b/packages/inspector/src/hooks/sdk/useComponentClipboard.ts
@@ -1,0 +1,156 @@
+import { useCallback } from 'react';
+import type { Entity, LastWriteWinElementSetComponentDefinition } from '@dcl/ecs';
+
+import type { Component } from '../../lib/sdk/components';
+import { useSnackbar } from '../useSnackbar';
+import { useSdk } from './useSdk';
+import { getComponentValue, isLastWriteWinComponent } from './useComponentValue';
+
+const CLIPBOARD_TAG = '__dclComponent';
+const TRANSFORM_COMPONENT_NAME = 'core::Transform';
+
+type ClipboardPayload = {
+  [CLIPBOARD_TAG]: string;
+  value: unknown;
+};
+
+let memoryClipboard: string | null = null;
+
+const writeClipboard = async (text: string): Promise<void> => {
+  memoryClipboard = text;
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+  } catch {
+    // fall through to legacy fallback
+  }
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.opacity = '0';
+    textarea.style.pointerEvents = 'none';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+  } catch {
+    // memoryClipboard already set; inspector→inspector paste still works
+  }
+};
+
+const readClipboard = async (): Promise<string> => {
+  try {
+    if (navigator.clipboard?.readText) {
+      return await navigator.clipboard.readText();
+    }
+  } catch {
+    // fall through
+  }
+  return memoryClipboard ?? '';
+};
+
+const toEntities = (target: Entity | Entity[]): Entity[] =>
+  Array.isArray(target) ? target : [target];
+
+const getDisplayName = (componentName: string): string => {
+  const match = componentName.match(/[^:]*$/);
+  return (match && match[0]) || componentName;
+};
+
+const stripParentForTransform = (componentName: string, value: unknown): unknown => {
+  if (componentName !== TRANSFORM_COMPONENT_NAME || !value || typeof value !== 'object') {
+    return value;
+  }
+  const { parent: _parent, ...rest } = value as Record<string, unknown>;
+  return rest;
+};
+
+export const useComponentClipboard = <T>(
+  target?: Entity | Entity[] | null,
+  component?: Component<T> | null,
+) => {
+  const sdk = useSdk();
+  const { pushNotification } = useSnackbar();
+
+  const enabled = !!target && !!component;
+
+  const onCopyValues = useCallback(async () => {
+    if (!component || !target) return;
+    const entities = toEntities(target);
+    if (entities.length === 0) return;
+    try {
+      const value = getComponentValue(entities[0], component);
+      const normalized = stripParentForTransform(component.componentName, value);
+      const payload: ClipboardPayload = {
+        [CLIPBOARD_TAG]: component.componentName,
+        value: normalized,
+      };
+      await writeClipboard(JSON.stringify(payload, null, 2));
+      await pushNotification('success', `${getDisplayName(component.componentName)} values copied`);
+    } catch (error) {
+      console.error('Failed to copy component values', error);
+      await pushNotification('error', 'Failed to copy values');
+    }
+  }, [target, component, pushNotification]);
+
+  const onPasteValues = useCallback(async () => {
+    if (!sdk || !component || !target) return;
+    const entities = toEntities(target);
+    if (entities.length === 0) return;
+
+    const raw = await readClipboard();
+
+    let parsed: ClipboardPayload | null = null;
+    try {
+      const candidate = JSON.parse(raw);
+      if (
+        candidate &&
+        typeof candidate === 'object' &&
+        typeof candidate[CLIPBOARD_TAG] === 'string'
+      ) {
+        parsed = candidate as ClipboardPayload;
+      }
+    } catch {
+      // not JSON, fall through to mismatch error
+    }
+
+    const targetName = getDisplayName(component.componentName);
+
+    if (!parsed) {
+      await pushNotification('error', `Clipboard does not contain ${targetName} values`);
+      return;
+    }
+
+    if (parsed[CLIPBOARD_TAG] !== component.componentName) {
+      const sourceName = getDisplayName(parsed[CLIPBOARD_TAG]);
+      await pushNotification('error', `Cannot paste ${sourceName} values into ${targetName}`);
+      return;
+    }
+
+    if (!isLastWriteWinComponent(component)) {
+      await pushNotification('error', `Paste not supported for ${targetName}`);
+      return;
+    }
+
+    try {
+      const value = stripParentForTransform(component.componentName, parsed.value) as T;
+      const lwwComponent = component as LastWriteWinElementSetComponentDefinition<T>;
+      for (const entity of entities) {
+        sdk.operations.updateValue(lwwComponent, entity, value as Partial<T>);
+      }
+      await sdk.operations.dispatch();
+      await pushNotification('success', `${targetName} values pasted`);
+    } catch (error) {
+      console.error('Failed to paste component values', error);
+      await pushNotification('error', 'Failed to paste values');
+    }
+  }, [target, component, sdk, pushNotification]);
+
+  return { onCopyValues, onPasteValues, enabled };
+};


### PR DESCRIPTION
On every component in the inspector, we added two new functions to the three dots menu.

- Copy values
- Paste values

When clicking on copy values, we copy to clipboard the data that is configured into this component.  When pasting, we overwrite any configuration of this component. This should only work when copying from the same component. If I try to paste values from a Transform into a Material, it should not attempt to paste anything, it should simply not work and display a toast with an error message.