### PR TITLE
Experiment: Edit non-main composites

### DIFF
--- a/COMPOSITE_INSTANCING_PLAN.md
+++ b/COMPOSITE_INSTANCING_PLAN.md
@@ -1,0 +1,451 @@
+# Plan: Nested Composites, Sub-Composite Editing & Template/Instance Overrides
+
+> Status: **DRAFT for review** — edit freely. Owner: @nearnshaw
+> Branch: `edit-asset`
+
+## 1. Goal
+
+Today you can switch which composite file the inspector edits, but only through the
+new dropdown (`CompositeSelector`), and each composite is edited in isolation. We want
+to turn composites into **reusable templates that can be nested and instanced**, with a
+clear, deliberate distinction between editing the *template* (affects all instances) and
+editing a single *instance* (a local override).
+
+Concretely, for a scene like:
+
+```
+Scene
+  House          ← an instance of House.composite
+    Table        ← an instance of Table.composite
+    Table        ← another instance of the SAME Table.composite
+```
+
+We want to be able to:
+
+1. **Open a sub-composite from the entity tree** (e.g. open `House`, edit it, return to the
+   main scene and see the changes) — not just from the dropdown.
+2. **Nest composites** (House contains Tables; Tables can be opened too).
+3. **Propagate template edits to all instances** — change `Table.composite` and *both*
+   tables update.
+4. **Override a single instance** — change *this* table without affecting the others, with a
+   clear visual signal that the value is overridden.
+5. **Revert an instance to template defaults** — undo all local overrides.
+6. **Stop flattening on instance** — keep a live reference back to the source composite
+   instead of copying all entities into the main composite (today's behavior).
+
+**We take direct inspiration from Godot's instanced-scene UX** (see §3). Godot solves
+exactly this problem — instancing a scene file into another scene, opening it for editing,
+overriding individual properties on one instance, and reverting them — with a small, proven
+set of affordances. We borrow those *interaction patterns*, but **keep our own element names**
+(`composite`, `entity`) — we do **not** rename anything to Godot's "scene" / "node".
+
+---
+
+## 2. Current state (what exists today)
+
+### 2.1 The composite model (from `@dcl/ecs`)
+- A composite is a `Composite.Definition`: `{ version, components: CompositeComponent[] }`,
+  stored on disk as `.composite` / `.composite.json` (JSON) or `.composite.bin` (binary).
+- **`CompositeRoot` is the SDK's native nesting mechanism.** An entity carrying the
+  `CompositeRoot` component holds `{ src: string, entities: { src, dest }[] }` — a reference
+  to another composite file plus an entity-id mapping. **This is the key primitive we
+  should build on.** It already exists; we are mostly not using it from the inspector.
+- `Composite.instance(engine, resource, manager, { entityMapping })` loads a composite into
+  the engine, recursively resolving `CompositeRoot` children via the `CompositeManager`.
+
+### 2.2 The new dropdown (this branch, `edit-asset`)
+- UI: [CompositeSelector/component.tsx](packages/creator-hub/renderer/src/components/CompositeSelector/component.tsx)
+  + modals [CreateComposite](packages/creator-hub/renderer/src/components/Modals/CreateComposite/component.tsx)
+  and [ManageComposites](packages/creator-hub/renderer/src/components/Modals/ManageComposites/component.tsx).
+- Disk ops: [preload/src/modules/composites.ts](packages/creator-hub/preload/src/modules/composites.ts)
+  (`listComposites`, `createComposite`, `deleteComposite`, `duplicateComposite`). New
+  composites are created under `assets/custom/<folder>/composite.json`.
+- Inspector reads the active composite via the `compositePath` config/URL param
+  ([config.ts](packages/inspector/src/lib/logic/config.ts)); `getCurrentCompositePath()` /
+  `isAltCompositeMode()` in [fs-utils.ts](packages/inspector/src/lib/data-layer/host/fs-utils.ts)
+  drive UI adaptations (hide ground/spawn points, allow root rename, relabel root in tree, etc.).
+- **Switching composites = re-point the inspector at a different file and reload.** Each is
+  edited standalone; there is no live nesting in the UI yet.
+
+### 2.3 The flattening problem
+- [add-asset/index.ts](packages/inspector/src/lib/sdk/operations/add-asset/index.ts) instances
+  an asset by **expanding all of its entities into the main composite**: it creates new
+  entities, deep-copies every component, remaps ids, resolves `{assetPath}` placeholders, and
+  remaps trigger/action references. The only back-reference kept is `CustomAsset.assetId` on the
+  root entity. The link to the source composite is otherwise lost.
+- Consequence today: ✅ you can tell which asset was used; ❌ no overrides vs defaults;
+  ❌ editing the source does not update instances; ❌ no "revert to source".
+
+### 2.4 What `dumpEngineToComposite` already does (and doesn't)
+[engine-to-composite.ts](packages/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts):
+- It **already handles `CompositeRoot`**: child-composite entities are added to `ignoreEntities`
+  and only `{ src, entities: [] }` is written for the root — i.e. the child's own entities are
+  NOT duplicated into the parent on save. Good foundation.
+- ⚠️ **It writes `entities: []` (empty) and has explicit `TODO`s about overrides** — so any
+  per-instance override on a child entity is currently dropped on save. Closing this gap is
+  central to this feature.
+
+### 2.5 Tree / hierarchy
+- Hierarchy is stored in a dedicated `Nodes` component on `ROOT` (not `Transform.parent`):
+  [lib/sdk/components/index.ts](packages/inspector/src/lib/sdk/components/index.ts),
+  [lib/sdk/nodes.ts](packages/inspector/src/lib/sdk/nodes.ts),
+  [lib/sdk/tree.ts](packages/inspector/src/lib/sdk/tree.ts).
+- Tree UI: [Tree.tsx](packages/inspector/src/components/Tree/Tree.tsx) +
+  [Hierarchy.tsx](packages/inspector/src/components/Hierarchy/Hierarchy.tsx) +
+  [useTree.ts](packages/inspector/src/hooks/sdk/useTree.ts).
+- Context menus: [Tree/ContextMenu](packages/inspector/src/components/Tree/ContextMenu/ContextMenu.tsx)
+  and [Hierarchy/ContextMenu](packages/inspector/src/components/Hierarchy/ContextMenu/ContextMenu.tsx)
+  (rename, add child, duplicate, delete, create custom item, add component).
+
+---
+
+## 3. Reference: how Godot does this (UX we borrow)
+
+Godot's instanced-scene workflow is the closest established solution to what we want. The
+relevant affordances, and how we map each onto composites/entities (**without renaming our
+elements**):
+
+| Godot affordance | What it does in Godot | Our adaptation |
+|------------------|-----------------------|----------------|
+| **Scene tabs** (top bar) | Each open scene is a tab; you switch scenes by clicking tabs, and history back/forward arrows navigate the stack. | **Decided against tabs for v1.** Navigation is a **breadcrumb** (Scene › House › Table) plus the existing `CompositeSelector` dropdown. Only one composite is open in the inspector at a time; opening a sub-composite switches the active composite. (Tabs remain a possible later addition.) |
+| **"Open in Editor"** — a small clapperboard/film-slate icon shown to the right of an instanced node in the Scene dock | One click opens the instanced scene's own file for editing (in its own tab). | A per-row **"open" icon on instance entities** in the entity tree → switches the active composite to that instance's source (House, Table). This is the answer to "open House/Table from the tree". |
+| **Instance Child Scene** (chain-link button) | Adds a scene as an instance (single node, not flattened) rather than building nodes by hand. | Adding a composite-backed asset creates a `CompositeRoot` instance, not a flattened copy (§5.1). Instance entities get a distinct icon, like Godot's. |
+| **Editable Children** (right-click toggle) | Reveals an instance's internal nodes so you can override them locally; internal nodes render with a distinct (lighter / linked) style and can be overridden but not removed. | We keep the *behavior* but **not the "Editable children" label** — in the UI we speak in terms of the **composite** and its entities. An instance's child entities are editable in place (edits become overrides). Following Godot, you **cannot delete** a child entity, but you **can delete its components** — in practice neutralizing it locally (§6.3, Q7). |
+| **Property revert arrow** (Inspector) | An overridden property shows a curved **revert arrow** next to it; clicking resets it to the instance/template default. Non-overridden properties show no arrow. | Same affordance in our EntityInspector: overridden fields show a revert control; click = drop that override (§6.4). This is *the* signal distinguishing "overridden" from "inherited from template". |
+| **Make Local** (right-click) | Breaks the link and converts the instance into plain, editable nodes (the old flatten behavior). | Right-click an instance → **"Make local"** = the explicit unpack/flatten escape hatch (replaces today's implicit always-flatten). |
+| **Save Branch as Scene** (right-click) | Extracts a subtree into a new scene file and instances it back in place. | Right-click a subtree → **"Save as composite"** — turns e.g. a hand-built House into a reusable composite and replaces it in place with an instance. Complements the existing "Create Custom Item". |
+| **File watching / auto-reload** | Editing a source scene updates all its instances automatically. | Editing a template composite propagates to instances on reload/switch (live propagation is a stretch goal — §5.3). |
+
+Key Godot principles worth keeping:
+- **Instance by default, flatten only on demand.** You almost always work with a live link;
+  "Make Local" is the deliberate exception.
+- **Overrides are visible and per-property.** The revert arrow makes it obvious, field by
+  field, what deviates from the template — no hidden state.
+- **Editing the source is a separate, explicit context.** You leave the parent (open the
+  sub-composite in its own tab) to change the template for everyone; you stay in the parent
+  (with editable children) to override just this instance. The two are never ambiguous.
+
+Sources: [Godot — editing instanced children / editable children](https://godotforums.org/d/24716-how-to-alter-instanced-scene-s-children),
+[Improve Editable Children (godot-proposals #4092)](https://github.com/godotengine/godot-proposals/discussions/4092),
+[Make instance local / editable children via tool](https://forum.godotengine.org/t/is-it-possible-to-make-scene-instance-local-or-editable-children-through-tool/10341).
+
+---
+
+## 4. Core concepts / vocabulary (proposed)
+
+We keep our element names (`composite`, `entity`) and borrow Godot's *interaction* names where
+they fit. Proposed working vocabulary:
+
+| Term | Meaning |
+|------|---------|
+| **Template (composite)** | A `.composite` file describing a reusable group of entities (House, Table). The source of truth. |
+| **Instance** | A placement of a template inside another composite, represented by a `CompositeRoot` entity pointing at the template `src`. |
+| **Child entity** | An entity belonging to an instance's source composite. Editable in place (edits create overrides); its components can be removed, but the entity itself cannot be deleted (Q7). |
+| **Override** | A per-instance change to a component value (or a removed component) that differs from the template. Stored as a delta on the instance, not in the template. |
+| **Revert** | Removing overrides so the instance matches the template again (whole-instance, per-entity, or per-component). The revert arrow does this per field. |
+| **Make local** | Break the instance link and flatten it into plain entities (Godot label kept). |
+| **Edit template** | Opening the template composite itself and changing it → propagates to all instances. |
+
+**Decided (§9):** UI keeps Godot's **"Make local"** and **revert** labels. We **avoid the
+"Editable children" term** and speak in terms of the **composite** and its entities. Copy
+leans toward plain "composite" over "Template".
+
+---
+
+## 5. Target data model
+
+### 5.1 Instancing = `CompositeRoot`, not flattening
+When the user adds/instances a composite (House, Table), create **one entity with a
+`CompositeRoot` component** referencing the template's `src`, instead of expanding all
+entities into the parent. `Composite.instance()` already expands `CompositeRoot` children at
+load time, so the entities still appear in the tree — but on disk the parent composite only
+stores the reference, and the children live in the template file.
+
+```
+House.composite (template)         main.composite (parent)
+  entities: Table x2                  CompositeRoot { src: "House.composite", entities: [...] }
+```
+
+### 5.2 Overrides — RESOLVED by the Phase 0 spike
+
+> Spike done against `@dcl/ecs@7.15.2` (source: `node_modules/@dcl/ecs/dist/composite/instance.js`,
+> `composite/components.js`, `engine/lww-element-set-component-definition.js`) and
+> `@dcl/sdk-commands` (`dist/logic/composite.js`). Findings below are verified against code,
+> not assumed. Phase 0 summary in §7.
+
+**Verdict: Option A (native layering) is impossible; Option B (sidecar) is required.**
+
+Why A is dead — three independent blockers:
+1. **No schema slot.** `CompositeRoot` (`composite::root`) is literally
+   `{ src: String, entities: Array<{ src: Entity, dest: Entity }> }`. There is **nowhere** to
+   store override values.
+2. **`Composite.instance` uses `create()`, not `createOrReplace()`.** It instances children
+   *first*, then copies the parent's own components with `componentDefinition.create(targetEntity, …)`,
+   which **throws `"[create] Component … already exists"`** if that entity already has the
+   component. So you cannot have the parent composite shadow a child's component — it would error,
+   not override. There is no merge / last-write-wins step.
+3. **It's an unimplemented, deprecated feature.** The instancing code carries a `TODO`:
+   *"in the future, the instanciation is first, then the overrides (to parameterize Composite,
+   e.g. house with different wall colors)"* — and the whole `Composite` API + `CompositeRoot` are
+   tagged `@deprecated: "composite is not being supported so far, please do not use this feature"`.
+
+**Decided mechanism — (B) sidecar override component.** Define an inspector-managed component,
+e.g. `CompositeOverrides`, holding `{ childSrcEntity, componentName, op: 'set' | 'remove', value? }[]`.
+After `Composite.instance` expands an instance, we apply these deltas onto the resolved engine
+entities (`createOrReplace` for `set`, `deleteFrom` for `remove`). Revert = drop a delta. This is
+the only option that natively expresses **component removal** (Q7).
+
+Two hard implementation constraints the spike surfaced:
+
+- **Key overrides by template `src` entity-id, not engine entity-id.** With `EMM_DIRECT_MAPPING`
+  (what the inspector uses, [composite-provider.ts:128-131](packages/inspector/src/lib/data-layer/host/composite-provider.ts#L128)),
+  an instance's **root** entity is deterministic, but its **internal** entities are allocated via
+  `engine.addEntity()` at load → their numbers are **not stable across reloads**. So a delta keyed
+  by engine (`dest`) entity would break on reload. Key by the template-internal `src` id (stable),
+  and resolve `src → dest` after instancing via the `{src,dest}` map that `Composite.instance`
+  stamps onto the `CompositeRoot.entities` array.
+- **Overrides do NOT survive the standard build by themselves** — see §5.4. This is the big one.
+
+### 5.3 Propagation — confirmed working through the build, for free
+- Editing a template file and reloading re-instances it everywhere → instances pick up changes
+  automatically **for non-overridden values**. Overridden values stay as the instance's local
+  delta. (This is Godot's "edit the source → all instances update" behavior.)
+- **Spike confirms this needs zero SDK changes.** Both the editor's loader and the publish build
+  (`@dcl/sdk-commands` `getAllComposites`) call `Composite.instance`, which recursively expands
+  `CompositeRoot` children. So nesting + "edit template → all instances update" works end-to-end
+  today. **This is why nesting/propagation can ship before overrides** (see re-phasing in §7).
+- **Decided: propagate on switch.** v1 re-instances templates when you switch the active
+  composite. Because we have **no tabs**, you won't see an edited template reflected in its
+  instances until you switch the inspector back to the composite that contains them — accepted v1
+  limitation, not a bug. Live propagation across an already-open view is a follow-up.
+
+### 5.4 Runtime / build reality — overrides need an editor-side bake
+The publish/preview build (`@dcl/sdk-commands` → `getAllComposites`,
+`dist/logic/composite.js`) globs `**/*.composite`, instances each into a fresh engine with
+`Composite.instance`, and dumps the **flattened** result to `main.crdt` via the inspector's own
+`dumpEngineToCrdtCommands`. Consequences:
+
+- ✅ **Nesting reaches the runtime** — children are expanded and baked into `main.crdt`.
+- ❌ **Sidecar overrides are invisible to this build.** `getAllComposites` does its *own*
+  `Composite.instance` and never runs our override-application step, and `Composite.instance`
+  ignores unknown components. So the runtime would get **template defaults, not your overrides**.
+- ⚠️ **File-extension gotcha.** The build glob is `**/*.composite`; the dropdown currently creates
+  `assets/custom/<name>/composite.json`. A `.json` sub-composite referenced as a `src` won't be
+  picked up by the build. Sub-composites that participate in nesting must be `.composite`.
+
+**Therefore overrides require one of:**
+- **(I) Editor-side bake (recommended for v1):** on export/publish, the inspector writes the
+  buildable composite with instances **flattened and overrides applied** (the editor keeps the
+  rich nested+overrides representation for editing; the artifact the build consumes is flat). No
+  SDK changes; self-contained.
+- **(II) Implement composite overrides in `@dcl/ecs`** (the SDK's own `TODO`): the proper
+  long-term fix, but means owning/un-deprecating that primitive and coordinating an SDK release.
+- **(III) Defer overrides** entirely and ship nesting + propagation first (§7 Milestone A), which
+  needs none of this.
+
+### 5.3 Propagation
+- Editing a template file and reloading re-instances it everywhere → instances pick up changes
+  automatically **for non-overridden values**. Overridden values stay as the instance's local
+  delta. (This is Godot's "edit the source → all instances update" behavior.)
+- **Decided: propagate on switch.** v1 re-instances templates when you switch the active
+  composite. Because we have **no tabs**, you won't see an edited template reflected in its
+  instances until you switch the inspector back to the composite that contains them — that's an
+  accepted limitation for v1, not a bug. Live propagation across an already-open view is a
+  follow-up.
+
+---
+
+## 6. Feature breakdown & UX
+
+### 6.1 Open a sub-composite from the entity tree
+- Borrowing Godot's **"Open in Editor"**: show a small **"open" icon on instance rows** in the
+  entity tree, plus a context-menu **"Edit template"** action (and/or double-click).
+- This switches the inspector's active composite to that instance's `src` (reuse the existing
+  `compositePath` switch path the dropdown already uses).
+- **Navigation: breadcrumb + existing dropdown — no tabs (decided).** A breadcrumb
+  (Scene › House › Table) shows the path and lets you click back up; the `CompositeSelector`
+  dropdown stays as the "open another composite" entry point. Only one composite is open at a
+  time. On returning to the parent, re-load so template edits are visible (§5.3).
+- Reuse `isAltCompositeMode()` adaptations; extend them to drive the multi-level breadcrumb.
+
+### 6.2 Nesting (House → Table → …)
+- Recursive: opening House shows its Tables; each Table is itself an instance you can open.
+- Guard against **cyclic references** (A contains B contains A). Detect on add and on open;
+  block with a clear error.
+
+### 6.3 Template edit vs instance override — the signal
+- **Editing the composite's child entities:** an instance's children are visible and editable
+  in place (we use "composite"/"entity" wording, **not** "Editable children"). Editing any
+  child value produces a local override on that instance.
+- **Deletion rules (Q7, Godot-style):** you **cannot delete** a child entity that comes from
+  the template, but you **can delete its components**. Removing all of an entity's meaningful
+  components is the way to "make it as if the entity isn't there" for this instance, without
+  touching the template or sibling instances. A removed component is itself an override (it must
+  persist and be reversible — see §5.2 (B) `op: 'remove'`).
+- **Override = revert arrow:** when a component field on an instanced entity differs from the
+  template, show the **revert arrow** next to that field in the EntityInspector. Its presence is
+  the override signal; its absence means "inherited from template". No separate chip needed,
+  though a subtle highlight on the field label can reinforce it.
+- Editing a field on an instance creates the override automatically (deliberate, visible via the
+  arrow appearing).
+- Offer an explicit **"Apply to template"** action to push an instance's value up to the
+  template (affecting all instances) vs. leaving it local.
+
+### 6.4 Revert to defaults
+- Per-field: click the **revert arrow** → drop that override, field snaps back to the template
+  value.
+- Per-entity / per-instance: context-menu **"Revert all overrides"** → the instance matches the
+  template again.
+- Must update the live engine and persist (remove the delta from the chosen override store).
+
+### 6.5 Add / instance / unpack flow (replace implicit flattening)
+- New assets dragged in become `CompositeRoot` instances (§5.1) by default — **instance by
+  default**, Godot-style.
+- **"Make local"** (right-click) is the explicit unpack/flatten action, replacing today's
+  always-flatten behavior.
+- **"Save as composite"** (Godot's "Save Branch as Scene") turns a hand-built subtree into a
+  reusable composite + instance in place. Complements existing "Create Custom Item".
+- **Migration: no auto-convert (decided).** Existing flattened scenes stay as-is; the new
+  instancing model applies only to newly added items. We do not retroactively turn legacy
+  `CustomAsset` copies into `CompositeRoot` instances.
+
+---
+
+## 7. Implementation phases
+
+> **The spike re-shaped the phasing.** Nesting + propagation work through the existing build with
+> **zero SDK changes** (§5.3); per-instance overrides need the export-bake decision (§5.4). So the
+> work splits into two milestones, and **Milestone A is shippable on its own**.
+
+### Phase 0 — SDK spike ✅ DONE
+Findings recorded in §5.2 / §5.3 / §5.4. Headlines:
+- `CompositeRoot` = `{ src, entities:[{src,dest}] }` — no override slot.
+- `Composite.instance` instances children then `create()`s parent components (throws on dup, no
+  merge); overrides are an explicit unimplemented `TODO`; the API is `@deprecated`.
+- Nesting + propagation already expand at editor-load **and** publish-build time → ship without SDK
+  changes.
+- Overrides must use a **sidecar component** keyed by template `src` id, and be **baked on export**
+  (§5.4) because `@dcl/sdk-commands` re-instances composites and won't see our deltas.
+- Watch-outs: sub-composites must be `.composite` (build glob), not `composite.json`; SDK
+  `@deprecated` tag is a strategic risk (§10).
+
+---
+
+### Milestone A — Nesting, sub-composite editing & propagation (no SDK changes)
+
+#### Phase A1 — Instance instead of flatten
+- Change [add-asset](packages/inspector/src/lib/sdk/operations/add-asset/index.ts) (and the
+  Renderer drop handlers) to create a `CompositeRoot` instance for composite-backed assets.
+- Ensure `Composite.instance()` expansion populates the tree correctly (Nodes hierarchy from
+  the instanced entities), with a distinct instance icon.
+- Ensure [engine-to-composite.ts](packages/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts)
+  round-trips instances (it already skips child entities; verify save/reload is stable).
+- Make sub-composite files `.composite` so the publish build's `**/*.composite` glob picks them up
+  (§5.4 gotcha); align the dropdown's `composite.json` creation accordingly.
+- Add **"Make local"** (flatten) as the explicit escape hatch.
+
+#### Phase A2 — Open sub-composite from the tree + breadcrumb
+- "Open in Editor" icon + context-menu "Edit template" / double-click on instance entities →
+  switch `compositePath`.
+- **Breadcrumb** navigation (no tabs); extend `isAltCompositeMode` adaptations to multi-level.
+- Back navigation reloads parent so template edits show (propagation on switch, §5.3).
+- Cycle guard: SDK throws on recursive `src`; pre-validate in the UI for a friendly message.
+
+#### Phase A3 — Propagation verification
+- Confirm template edits show on all instances after switching back (editor) and after publish
+  build (runtime). Mostly test/validation, since the mechanism is already there.
+
+---
+
+### Milestone B — Per-instance overrides (gated on §5.4 export-bake decision)
+
+#### Phase B0 — Decide the override→runtime path (§5.4: I / II / III)
+**Decision required before B1.** Recommended: **(I) editor-side bake** for v1.
+
+#### Phase B1 — Override store + apply
+- Implement the `CompositeOverrides` sidecar (§5.2), keyed by template `src` id, with
+  `op: 'set' | 'remove'` (removal satisfies Q7).
+- Apply deltas after `Composite.instance`, resolving `src → dest` from `CompositeRoot.entities`.
+- Persist via `dumpEngineToComposite` (replace the `entities: []` / `TODO`).
+- Child entities editable in place; template-owned entities can't be deleted but their components
+  can (§6.3).
+
+#### Phase B2 — Override UI
+- EntityInspector: revert-arrow indicators, create-override-on-edit, **"Apply to template"**.
+
+#### Phase B3 — Revert
+- Per-field revert (arrow), per-instance "Revert all overrides"; wire into undo/redo + autosave.
+
+#### Phase B4 — Export bake + "Save as composite" + polish
+- Implement the chosen export bake (flatten instances + apply overrides into the buildable
+  artifact) and verify overrides render in preview/publish.
+- "Save as composite" (extract subtree → template + instance).
+- Error states, edge cases, i18n strings, e2e tests.
+
+---
+
+## 8. Key files to touch
+
+| Area | File(s) |
+|------|---------|
+| Instancing (de-flatten) | [add-asset/index.ts](packages/inspector/src/lib/sdk/operations/add-asset/index.ts), [Renderer.tsx](packages/inspector/src/components/Renderer/Renderer.tsx) |
+| Save/dump + overrides | [engine-to-composite.ts](packages/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts) |
+| Load/instance | [composite-provider.ts](packages/inspector/src/lib/data-layer/host/composite-provider.ts), [fs-composite-provider.ts](packages/inspector/src/lib/data-layer/host/utils/fs-composite-provider.ts) |
+| Active-composite switching / breadcrumb | [fs-utils.ts](packages/inspector/src/lib/data-layer/host/fs-utils.ts), [config.ts](packages/inspector/src/lib/logic/config.ts), [useEditor.ts](packages/creator-hub/renderer/src/hooks/useEditor.ts), [CompositeSelector](packages/creator-hub/renderer/src/components/CompositeSelector/component.tsx) |
+| Tree + context menu (open icon, make local, save as composite) | [useTree.ts](packages/inspector/src/hooks/sdk/useTree.ts), [Hierarchy.tsx](packages/inspector/src/components/Hierarchy/Hierarchy.tsx), [Hierarchy/ContextMenu](packages/inspector/src/components/Hierarchy/ContextMenu/ContextMenu.tsx), [Tree/ContextMenu](packages/inspector/src/components/Tree/ContextMenu/ContextMenu.tsx) |
+| Override UI (revert arrow) | [EntityInspector](packages/inspector/src/components/EntityInspector/EntityInspector.tsx), [EntityHeader.tsx](packages/inspector/src/components/EntityInspector/EntityHeader/EntityHeader.tsx) |
+| Disk ops / modals (creator-hub) | [composites.ts](packages/creator-hub/preload/src/modules/composites.ts), [CreateComposite](packages/creator-hub/renderer/src/components/Modals/CreateComposite/component.tsx), [ManageComposites](packages/creator-hub/renderer/src/components/Modals/ManageComposites/component.tsx) |
+| Publish/build (reference; export bake — §5.4) | `@dcl/sdk-commands` `dist/logic/composite.js` `getAllComposites` (consumes `**/*.composite`, emits `main.crdt`) |
+| i18n | [en.json](packages/creator-hub/renderer/src/modules/store/translation/locales/en.json) |
+
+---
+
+## 9. Open questions / decisions
+
+### Still open
+1. **Override → runtime path** *(the one real decision left, gated before Milestone B)* — how
+   per-instance overrides reach the published scene, given that `@dcl/sdk-commands` re-instances
+   composites and ignores our sidecar deltas (§5.4). Options: **(I) editor-side bake** (recommended
+   for v1, no SDK changes), **(II) implement composite overrides in `@dcl/ecs`** (proper, but owns
+   a deprecated SDK primitive), **(III) defer overrides** and ship Milestone A only. §5.4, §7 Phase B0
+2. **SDK deprecation stance** — `Composite`/`CompositeRoot` are `@deprecated` in `@dcl/ecs`. Confirm
+   with the protocol/SDK team that nesting will remain supported (the publish build still uses it)
+   before building on it long-term. §10
+
+### Decided (incl. Phase 0 spike outcomes)
+- **Override storage mechanism** — **(B) sidecar `CompositeOverrides`**, keyed by template `src`
+  id, `op: 'set'|'remove'`. Native layering (A) proven impossible by the spike. §5.2
+- **Nesting/propagation need no SDK changes** — expand at editor-load and publish-build. §5.3
+3. **Navigation model** — **breadcrumb + existing dropdown, no tabs** for v1. §6.1
+3. **Legacy migration** — **no auto-convert**; new model applies to newly added items only. §6.5
+4. **Vocabulary in UI** — keep **"Make local"** and **revert**; **avoid "Editable children"**,
+   use "composite"/"entity" wording; lean to plain "composite" over "Template". §4
+5. **Propagation** — **propagate on switch**; with no tabs, instances reflect template edits
+   only after switching the inspector back to the containing composite (accepted v1 limitation). §5.3
+6. **Editing scope default** — confirmed: editing an opened Table is a **template** edit
+   (affects all instances); overriding stays local on the instance. §6.3
+7. **Child-entity rules** — confirmed (Godot-style): **cannot delete** a template-owned child
+   entity, but **can delete its components** to neutralize it locally. Removal is a persisted,
+   reversible override. §6.3, §5.2(B)
+
+---
+
+## 10. Risks
+
+- **SDK deprecation (highest strategic risk):** `Composite` / `CompositeRoot` carry
+  `@deprecated: "composite is not being supported so far, please do not use this feature"` in
+  `@dcl/ecs`. The publish build still uses them, but we'd be building on a primitive flagged for
+  removal. **Action:** confirm the roadmap with the protocol/SDK team; ideally get composite
+  (and its override `TODO`) officially supported — that would also unlock override option (II).
+- **Overrides don't survive the standard build (§5.4):** sidecar deltas are invisible to
+  `@dcl/sdk-commands`; Milestone B is blocked until the export-bake path (Phase B0) is chosen and
+  built. Nesting/propagation (Milestone A) are unaffected.
+- **Entity-id instability:** instanced children get `addEntity()` ids that change across loads, so
+  overrides must key on template `src` ids and resolve via `CompositeRoot.entities` (§5.2). Getting
+  this wrong silently corrupts overrides.
+- **Id remapping complexity:** overrides + nesting + triggers/actions that reference entities by id
+  is the historically fragile area (see add-asset's existing remapping).
+- **Round-trip stability:** save → reload must be idempotent (no entity duplication, stable ids).
+- **File-extension mismatch (§5.4):** sub-composites must be `.composite` to be globbed by the
+  build; the dropdown currently writes `composite.json`.
+- **Performance:** deep nesting re-instanced on every reload/switch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -285,7 +285,6 @@
       "integrity": "sha512-zIVQt/XfE2zTFrcPEf8R+KRaRD1++XHMPRhxXM2kVA6NA6Aq/cFCUyYOYYwSbWLF/XeToaX1auYGn3IoZKruPQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1125,7 +1124,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1525,8 +1523,7 @@
       "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-8.7.0.tgz",
       "integrity": "sha512-6yVCq4lidd6B9xnyL2Ubs6v+IX6tHX3SmoMDUrrrIMYUSW/qPIG1qRWs3+3bD9gvTM8A+UY+tcMPsHkaLVnaRA==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@babylonjs/gui": {
       "version": "8.7.0",
@@ -1534,7 +1531,6 @@
       "integrity": "sha512-nW7I3jRDs2J2QWtFut/ARQf7JA/GH8OR2LTxjH2q5LcohSGn6qyqzv8T7FVsz8U++AghF/LxKP8BCqcPZu4ihw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@babylonjs/core": "^8.0.0"
       }
@@ -1581,7 +1577,6 @@
       "integrity": "sha512-zInwTu07IOK7Iwl783lFxzf27TM5C9HEU/E13FyxlWitM5k2WA8dlUJK4dFdTj8ieD1a3MVDU5PdpwZTXdYpSA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@babylonjs/core": "^8.0.0",
         "babylonjs-gltf2interface": "^8.0.0"
@@ -1593,7 +1588,6 @@
       "integrity": "sha512-v2240oEPEPSOsw9cuQva8Q3yBQvFyCfrkgfWXEDL9fJBmUHmylK6pPZZArwIx4gm50azkpltGjRdcK7R6/vScg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@babylonjs/core": "^8.0.0"
       }
@@ -1808,8 +1802,7 @@
       "version": "7.15.2",
       "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.15.2.tgz",
       "integrity": "sha512-4Ek1kIHCh3XuyGH/wzui+Ss2Fw6C/T/8Gow3WLgixzB8yV8PgiBDonUSIXF0Aj7PWGJAJiGnmuzJM0gK6923Rw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.1.0",
@@ -2803,7 +2796,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3368,68 +3360,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@electron/windows-sign": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "cross-dirname": "^0.1.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
-        "minimist": "^1.2.8",
-        "postject": "^1.0.0-alpha.6"
-      },
-      "bin": {
-        "electron-windows-sign": "bin/electron-windows-sign.js"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -3514,7 +3444,6 @@
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3561,7 +3490,6 @@
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -4772,7 +4700,6 @@
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -5113,7 +5040,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5135,7 +5061,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.1.tgz",
       "integrity": "sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -5148,7 +5073,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.1.tgz",
       "integrity": "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -5572,7 +5496,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz",
       "integrity": "sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -5589,7 +5512,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.1.tgz",
       "integrity": "sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.1",
         "@opentelemetry/resources": "2.5.1",
@@ -5607,7 +5529,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
       "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5644,7 +5565,6 @@
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -5829,7 +5749,6 @@
       "integrity": "sha512-x3aWtX3GmQfEvn8dh0ovPbsXgK9JjpiR24wKztpGbZP8JZUWWvUgKrvnWZ/T/4iphOBftyVc9VrIwhAnsM+OFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redux-saga/symbols": "^1.2.1",
         "@redux-saga/types": "^1.3.1"
@@ -5840,8 +5759,7 @@
       "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.2.1.tgz",
       "integrity": "sha512-3dh+uDvpBXi7EUp/eO+N7eFM4xKaU4yuGBXc50KnZGzIrR/vlvkTFQsX13zsY8PB6sCFYAgROfPSRUj8331QSA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@redux-saga/types": {
       "version": "1.3.1",
@@ -8287,7 +8205,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
       "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -8372,7 +8289,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -8384,7 +8300,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -8555,6 +8470,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -8584,6 +8500,7 @@
       "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "7.18.0",
         "@typescript-eslint/visitor-keys": "7.18.0"
@@ -8602,6 +8519,7 @@
       "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "7.18.0",
         "eslint-visitor-keys": "^3.4.3"
@@ -8723,6 +8641,7 @@
       "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
       },
@@ -8737,6 +8656,7 @@
       "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "7.18.0",
         "@typescript-eslint/visitor-keys": "7.18.0",
@@ -8766,6 +8686,7 @@
       "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "7.18.0",
         "eslint-visitor-keys": "^3.4.3"
@@ -9127,7 +9048,6 @@
       "integrity": "sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/node": "^20.3.1",
         "@types/node-fetch": "^2.5.12",
@@ -9224,7 +9144,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9279,7 +9198,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10087,7 +10005,6 @@
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -10435,7 +10352,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11878,14 +11794,6 @@
       "resolved": "packages/creator-hub",
       "link": true
     },
-    "node_modules/cross-dirname": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -12319,7 +12227,6 @@
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -12409,7 +12316,6 @@
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -12822,7 +12728,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -13553,6 +13458,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -13573,6 +13479,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -13937,7 +13844,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -18107,6 +18013,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -22054,7 +21961,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -22108,34 +22014,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postject": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "commander": "^9.4.0"
-      },
-      "bin": {
-        "postject": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/postject/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -22274,7 +22152,6 @@
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -22684,7 +22561,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -22763,7 +22639,6 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -23241,8 +23116,7 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-logger": {
       "version": "3.0.6",
@@ -23260,7 +23134,6 @@
       "integrity": "sha512-QLIn/q+7MX/B+MkGJ/K6R3//60eJ4QNy65eqPsJrfGezbxdh1Jx+37VRKE2K4PsJnNET5JufJtgWdT30WBa+6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redux-saga/core": "^1.4.2"
       }
@@ -23659,7 +23532,6 @@
       "integrity": "sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -25338,6 +25210,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -25401,6 +25274,7 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -25413,6 +25287,7 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -25434,6 +25309,7 @@
       "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -25448,6 +25324,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -25568,7 +25445,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26037,7 +25913,6 @@
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26690,7 +26565,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -27855,7 +27729,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/packages/creator-hub/preload/src/index.ts
+++ b/packages/creator-hub/preload/src/index.ts
@@ -16,3 +16,4 @@ export * as pkg from './services/pkg';
 export * as settings from './modules/settings';
 export * as scene from './modules/scene';
 export * as custom from './modules/custom';
+export * as composites from './modules/composites';

--- a/packages/creator-hub/preload/src/modules/composites.ts
+++ b/packages/creator-hub/preload/src/modules/composites.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Dirent } from 'node:fs';
+
+import type { CompositeEntry } from '/shared/types/composites';
+
+const ASSETS_DIR = 'assets';
+const MAIN_COMPOSITE_RELATIVE = 'assets/scene/main.composite';
+const GENERIC_NAMES = new Set(['composite.json', 'main.composite']);
+
+export type { CompositeEntry };
+
+function isCompositeFile(name: string): boolean {
+  return (
+    name.endsWith('.composite') || name === 'composite.json' || name.endsWith('.composite.json')
+  );
+}
+
+function toDisplayName(relativePath: string): string {
+  const parts = relativePath.split('/');
+  const fileName = parts[parts.length - 1];
+  if (GENERIC_NAMES.has(fileName)) {
+    return parts.length >= 2 ? parts[parts.length - 2] : fileName;
+  }
+  return fileName.replace(/\.composite(\.json)?$/i, '');
+}
+
+async function collectComposites(
+  projectPath: string,
+  currentRelative: string,
+  acc: string[],
+): Promise<void> {
+  const absDir = path.join(projectPath, currentRelative);
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(absDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const rel = currentRelative ? `${currentRelative}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      await collectComposites(projectPath, rel, acc);
+    } else if (entry.isFile() && isCompositeFile(entry.name)) {
+      acc.push(rel);
+    }
+  }
+}
+
+async function isValidJsonComposite(absolutePath: string): Promise<boolean> {
+  try {
+    const handle = await fs.open(absolutePath, 'r');
+    try {
+      const buffer = Buffer.alloc(64);
+      const { bytesRead } = await handle.read(buffer, 0, 64, 0);
+      const head = buffer.subarray(0, bytesRead).toString('utf8').trimStart();
+      return head.startsWith('{') || head.startsWith('[');
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return false;
+  }
+}
+
+export async function listComposites(projectPath: string): Promise<CompositeEntry[]> {
+  const found: string[] = [];
+  await collectComposites(projectPath, ASSETS_DIR, found);
+
+  const normalized = found.map(p => p.split(path.sep).join('/'));
+  const withoutMain = normalized.filter(p => p !== MAIN_COMPOSITE_RELATIVE).sort();
+
+  // Filter out json files whose contents aren't actually JSON (e.g. corrupted
+  // composite.json files in asset-packs that contain an XML error page from a
+  // failed S3 download). `.composite` binary files are not validated here.
+  const validated = await Promise.all(
+    withoutMain.map(async rel => {
+      if (!rel.endsWith('.json')) return rel;
+      const absolute = path.join(projectPath, rel);
+      const ok = await isValidJsonComposite(absolute);
+      return ok ? rel : null;
+    }),
+  );
+
+  return [
+    { relativePath: MAIN_COMPOSITE_RELATIVE, displayName: 'Main scene', isMain: true },
+    ...validated
+      .filter((rel): rel is string => rel !== null)
+      .map(rel => ({
+        relativePath: rel,
+        displayName: toDisplayName(rel),
+        isMain: false,
+      })),
+  ];
+}
+
+export async function deleteComposite({
+  projectPath,
+  relativePath,
+}: {
+  projectPath: string;
+  relativePath: string;
+}): Promise<void> {
+  if (relativePath === MAIN_COMPOSITE_RELATIVE) {
+    throw new Error('Cannot delete the main composite');
+  }
+  const absolute = path.join(projectPath, relativePath);
+  if (!absolute.startsWith(path.join(projectPath, ASSETS_DIR))) {
+    throw new Error('Composite path is outside the assets directory');
+  }
+  await fs.rm(absolute);
+}

--- a/packages/creator-hub/preload/src/modules/composites.ts
+++ b/packages/creator-hub/preload/src/modules/composites.ts
@@ -110,3 +110,123 @@ export async function deleteComposite({
   }
   await fs.rm(absolute);
 }
+
+const CUSTOM_DIR = 'custom';
+const FOLDER_NAME_PATTERN = /^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$/;
+
+export function sanitizeCompositeFolderName(rawName: string): string {
+  return rawName
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+export async function createComposite({
+  projectPath,
+  name,
+}: {
+  projectPath: string;
+  name: string;
+}): Promise<CompositeEntry> {
+  const folderName = sanitizeCompositeFolderName(name);
+  if (!folderName || !FOLDER_NAME_PATTERN.test(folderName)) {
+    throw new Error('Invalid composite name');
+  }
+  const relativeFolder = `${ASSETS_DIR}/${CUSTOM_DIR}/${folderName}`;
+  const absoluteFolder = path.join(projectPath, relativeFolder);
+  try {
+    await fs.access(absoluteFolder);
+    throw new Error('A composite with this name already exists');
+  } catch (err: any) {
+    if (err && err.code !== 'ENOENT') throw err;
+  }
+  await fs.mkdir(absoluteFolder, { recursive: true });
+  const compositeRelative = `${relativeFolder}/composite.json`;
+  const compositeAbsolute = path.join(projectPath, compositeRelative);
+  const minimal = {
+    version: 1,
+    components: [
+      {
+        name: 'core-schema::Name',
+        data: {
+          '0': { json: { value: name.trim() } },
+        },
+      },
+    ],
+  };
+  await fs.writeFile(compositeAbsolute, JSON.stringify(minimal, null, 2), 'utf8');
+  return {
+    relativePath: compositeRelative,
+    displayName: folderName,
+    isMain: false,
+  };
+}
+
+function getCompositeFolder(relativePath: string): { folder: string; fileName: string } {
+  const idx = relativePath.lastIndexOf('/');
+  if (idx < 0) return { folder: '', fileName: relativePath };
+  return { folder: relativePath.slice(0, idx), fileName: relativePath.slice(idx + 1) };
+}
+
+async function copyDirectory(src: string, dest: string): Promise<void> {
+  await fs.mkdir(dest, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await copyDirectory(srcPath, destPath);
+    } else if (entry.isFile()) {
+      await fs.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+export async function duplicateComposite({
+  projectPath,
+  relativePath,
+  newName,
+}: {
+  projectPath: string;
+  relativePath: string;
+  newName: string;
+}): Promise<CompositeEntry> {
+  if (relativePath === MAIN_COMPOSITE_RELATIVE) {
+    throw new Error('Cannot duplicate the main composite');
+  }
+  const folderName = sanitizeCompositeFolderName(newName);
+  if (!folderName || !FOLDER_NAME_PATTERN.test(folderName)) {
+    throw new Error('Invalid composite name');
+  }
+  const { folder: sourceFolderRel, fileName } = getCompositeFolder(relativePath);
+  if (!sourceFolderRel) throw new Error('Composite has no parent folder to duplicate');
+
+  const sourceAbs = path.join(projectPath, sourceFolderRel);
+  const destFolderRel = `${ASSETS_DIR}/${CUSTOM_DIR}/${folderName}`;
+  const destAbs = path.join(projectPath, destFolderRel);
+  try {
+    await fs.access(destAbs);
+    throw new Error('A composite with this name already exists');
+  } catch (err: any) {
+    if (err && err.code !== 'ENOENT') throw err;
+  }
+
+  await copyDirectory(sourceAbs, destAbs);
+
+  // Strip any data.json from the duplicate so it doesn't share the source's
+  // custom-item id (asset catalogs key on data.json id).
+  try {
+    await fs.rm(path.join(destAbs, 'data.json'));
+  } catch (err: any) {
+    if (err && err.code !== 'ENOENT') throw err;
+  }
+
+  const newCompositeRelative = `${destFolderRel}/${fileName}`;
+  return {
+    relativePath: newCompositeRelative,
+    displayName: folderName,
+    isMain: false,
+  };
+}

--- a/packages/creator-hub/renderer/src/components/CompositeSelector/component.tsx
+++ b/packages/creator-hub/renderer/src/components/CompositeSelector/component.tsx
@@ -16,6 +16,7 @@ export function CompositeSelector({
   projectTitle,
   onSelect,
   onManage,
+  onCreate,
 }: Props) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const open = Boolean(anchorEl);
@@ -46,6 +47,11 @@ export function CompositeSelector({
     setAnchorEl(null);
     onManage();
   }, [onManage]);
+
+  const handleCreate = useCallback(() => {
+    setAnchorEl(null);
+    onCreate();
+  }, [onCreate]);
 
   return (
     <div className="CompositeSelector">
@@ -78,6 +84,12 @@ export function CompositeSelector({
             </span>
           </MenuItem>
         ))}
+        <MenuItem
+          className="manage-item"
+          onClick={handleCreate}
+        >
+          {t('editor.composites.create')}
+        </MenuItem>
         <MenuItem
           className="manage-item"
           onClick={handleManage}

--- a/packages/creator-hub/renderer/src/components/CompositeSelector/component.tsx
+++ b/packages/creator-hub/renderer/src/components/CompositeSelector/component.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useMemo, useState } from 'react';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { Menu, MenuItem } from 'decentraland-ui2';
+
+import { t } from '/@/modules/store/translation/utils';
+
+import type { Props } from './types';
+
+import './styles.css';
+
+const MAIN_COMPOSITE_RELATIVE = 'assets/scene/main.composite';
+
+export function CompositeSelector({
+  composites,
+  selected,
+  projectTitle,
+  onSelect,
+  onManage,
+}: Props) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const open = Boolean(anchorEl);
+
+  const handleOpen = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setAnchorEl(null);
+  }, []);
+
+  const selectedLabel = useMemo(() => {
+    const entry = composites.find(c => c.relativePath === selected);
+    if (!entry || entry.isMain) return projectTitle;
+    return entry.displayName;
+  }, [composites, selected, projectTitle]);
+
+  const handleSelect = useCallback(
+    (relativePath: string) => {
+      setAnchorEl(null);
+      if (relativePath !== selected) onSelect(relativePath);
+    },
+    [onSelect, selected],
+  );
+
+  const handleManage = useCallback(() => {
+    setAnchorEl(null);
+    onManage();
+  }, [onManage]);
+
+  return (
+    <div className="CompositeSelector">
+      <button
+        type="button"
+        className="CompositeSelectorButton"
+        onClick={handleOpen}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : 'false'}
+      >
+        <span className="label">{selectedLabel}</span>
+        <KeyboardArrowDownIcon />
+      </button>
+      <Menu
+        classes={{ root: 'CompositeSelectorMenu' }}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+        transformOrigin={{ horizontal: 'left', vertical: 'top' }}
+      >
+        {composites.map(entry => (
+          <MenuItem
+            key={entry.relativePath}
+            selected={entry.relativePath === selected}
+            onClick={() => handleSelect(entry.relativePath)}
+          >
+            <span className="composite-name">
+              {entry.isMain ? projectTitle : entry.displayName}
+            </span>
+          </MenuItem>
+        ))}
+        <MenuItem
+          className="manage-item"
+          onClick={handleManage}
+        >
+          {t('editor.composites.manage')}
+        </MenuItem>
+      </Menu>
+    </div>
+  );
+}
+
+export { MAIN_COMPOSITE_RELATIVE };

--- a/packages/creator-hub/renderer/src/components/CompositeSelector/index.ts
+++ b/packages/creator-hub/renderer/src/components/CompositeSelector/index.ts
@@ -1,0 +1,1 @@
+export { CompositeSelector, MAIN_COMPOSITE_RELATIVE } from './component';

--- a/packages/creator-hub/renderer/src/components/CompositeSelector/styles.css
+++ b/packages/creator-hub/renderer/src/components/CompositeSelector/styles.css
@@ -1,0 +1,60 @@
+.CompositeSelector {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 12px;
+}
+
+.CompositeSelectorButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background-color: transparent;
+  border: 1px solid var(--dark-gray);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 13px;
+  max-width: 240px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.CompositeSelectorButton:hover {
+  background-color: var(--dark-gray);
+}
+
+.CompositeSelectorButton .label {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.CompositeSelectorButton svg {
+  font-size: 18px;
+  opacity: 0.7;
+}
+
+.CompositeSelectorMenu .MuiPaper-root {
+  max-width: 320px;
+  min-width: 220px;
+}
+
+.CompositeSelectorMenu .MuiMenuItem-root {
+  font-size: 13px;
+  gap: 8px;
+}
+
+.CompositeSelectorMenu .composite-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.CompositeSelectorMenu .manage-item {
+  border-top: 1px solid var(--dark-gray);
+  font-style: italic;
+  opacity: 0.85;
+}

--- a/packages/creator-hub/renderer/src/components/CompositeSelector/types.ts
+++ b/packages/creator-hub/renderer/src/components/CompositeSelector/types.ts
@@ -6,4 +6,5 @@ export type Props = {
   projectTitle: string;
   onSelect: (relativePath: string) => void;
   onManage: () => void;
+  onCreate: () => void;
 };

--- a/packages/creator-hub/renderer/src/components/CompositeSelector/types.ts
+++ b/packages/creator-hub/renderer/src/components/CompositeSelector/types.ts
@@ -1,0 +1,9 @@
+import type { CompositeEntry } from '/shared/types/composites';
+
+export type Props = {
+  composites: CompositeEntry[];
+  selected: string;
+  projectTitle: string;
+  onSelect: (relativePath: string) => void;
+  onManage: () => void;
+};

--- a/packages/creator-hub/renderer/src/components/EditorPage/component.tsx
+++ b/packages/creator-hub/renderer/src/components/EditorPage/component.tsx
@@ -39,6 +39,7 @@ import { ButtonGroup } from '../Button';
 import { ConnectionStatusIndicator } from '../ConnectionStatusIndicator';
 import { CompositeSelector, MAIN_COMPOSITE_RELATIVE } from '../CompositeSelector';
 import { ManageCompositesModal } from '../Modals/ManageComposites';
+import { CreateCompositeModal } from '../Modals/CreateComposite';
 import { MobileQRCode } from '../Modals/MobileQRCode';
 import { DeployModal } from './DeployModal';
 import { PreviewOptions, PublishOptions } from './MenuOptions';
@@ -91,6 +92,7 @@ export function EditorPage() {
   const [composites, setComposites] = useState<CompositeEntry[]>([]);
   const [selectedComposite, setSelectedComposite] = useState<string>(MAIN_COMPOSITE_RELATIVE);
   const [manageCompositesOpen, setManageCompositesOpen] = useState(false);
+  const [createCompositeOpen, setCreateCompositeOpen] = useState(false);
 
   const projectPath = project?.path;
 
@@ -109,6 +111,7 @@ export function EditorPage() {
   useEffect(() => {
     setSelectedComposite(MAIN_COMPOSITE_RELATIVE);
     setManageCompositesOpen(false);
+    setCreateCompositeOpen(false);
     setComposites([]);
     if (projectPath) {
       void refreshComposites();
@@ -126,6 +129,39 @@ export function EditorPage() {
   const handleCloseManageComposites = useCallback(() => {
     setManageCompositesOpen(false);
   }, []);
+
+  const handleOpenCreateComposite = useCallback(() => {
+    setCreateCompositeOpen(true);
+  }, []);
+
+  const handleCloseCreateComposite = useCallback(() => {
+    setCreateCompositeOpen(false);
+  }, []);
+
+  const handleSubmitCreateComposite = useCallback(
+    async (name: string) => {
+      if (!project) return;
+      const entry = await compositesPreload.createComposite({
+        projectPath: project.path,
+        name,
+      });
+      await refreshComposites();
+      setSelectedComposite(entry.relativePath);
+      setCreateCompositeOpen(false);
+    },
+    [project, refreshComposites],
+  );
+
+  const existingCustomFolderNames = useMemo(() => {
+    const prefix = 'assets/custom/';
+    return composites
+      .filter(c => c.relativePath.startsWith(prefix))
+      .map(c => {
+        const rest = c.relativePath.slice(prefix.length);
+        const slash = rest.indexOf('/');
+        return slash >= 0 ? rest.slice(0, slash) : rest;
+      });
+  }, [composites]);
 
   const handleDeleteComposite = useCallback(
     async (entry: CompositeEntry) => {
@@ -149,6 +185,21 @@ export function EditorPage() {
       }
     },
     [project, refreshComposites, selectedComposite],
+  );
+
+  const handleDuplicateComposite = useCallback(
+    async (entry: CompositeEntry, newName: string) => {
+      if (!project) return;
+      const created = await compositesPreload.duplicateComposite({
+        projectPath: project.path,
+        relativePath: entry.relativePath,
+        newName,
+      });
+      await refreshComposites();
+      setSelectedComposite(created.relativePath);
+      setManageCompositesOpen(false);
+    },
+    [project, refreshComposites],
   );
 
   const isOffline = status === ConnectionStatus.OFFLINE;
@@ -426,13 +477,6 @@ export function EditorPage() {
                 <ArrowBackIosIcon />
               </div>
               <div className="title">{project.title}</div>
-              <CompositeSelector
-                composites={composites}
-                selected={selectedComposite}
-                projectTitle={t('editor.composites.main_scene')}
-                onSelect={handleSelectComposite}
-                onManage={handleOpenManageComposites}
-              />
               <Tooltip title={t('editor.header.actions.refresh')}>
                 <div
                   className="refresh"
@@ -442,6 +486,14 @@ export function EditorPage() {
                   <RefreshIcon />
                 </div>
               </Tooltip>
+              <CompositeSelector
+                composites={composites}
+                selected={selectedComposite}
+                projectTitle={t('editor.composites.main_scene')}
+                onSelect={handleSelectComposite}
+                onManage={handleOpenManageComposites}
+                onCreate={handleOpenCreateComposite}
+              />
             </>
             <div className="actions">
               <Button
@@ -524,8 +576,16 @@ export function EditorPage() {
           <ManageCompositesModal
             open={manageCompositesOpen}
             composites={composites}
+            existingCustomFolderNames={existingCustomFolderNames}
             onClose={handleCloseManageComposites}
             onDelete={handleDeleteComposite}
+            onDuplicate={handleDuplicateComposite}
+          />
+          <CreateCompositeModal
+            open={createCompositeOpen}
+            existingFolderNames={existingCustomFolderNames}
+            onClose={handleCloseCreateComposite}
+            onSubmit={handleSubmitCreateComposite}
           />
         </>
       )}

--- a/packages/creator-hub/renderer/src/components/EditorPage/component.tsx
+++ b/packages/creator-hub/renderer/src/components/EditorPage/component.tsx
@@ -92,26 +92,28 @@ export function EditorPage() {
   const [selectedComposite, setSelectedComposite] = useState<string>(MAIN_COMPOSITE_RELATIVE);
   const [manageCompositesOpen, setManageCompositesOpen] = useState(false);
 
+  const projectPath = project?.path;
+
   const refreshComposites = useCallback(async () => {
-    if (!project) return [] as CompositeEntry[];
+    if (!projectPath) return [] as CompositeEntry[];
     try {
-      const list = await compositesPreload.listComposites(project.path);
+      const list = await compositesPreload.listComposites(projectPath);
       setComposites(list);
       return list;
     } catch (err) {
       console.error('Failed to list composites', err);
       return [] as CompositeEntry[];
     }
-  }, [project]);
+  }, [projectPath]);
 
   useEffect(() => {
     setSelectedComposite(MAIN_COMPOSITE_RELATIVE);
     setManageCompositesOpen(false);
     setComposites([]);
-    if (project) {
+    if (projectPath) {
       void refreshComposites();
     }
-  }, [project?.path, refreshComposites]);
+  }, [projectPath, refreshComposites]);
 
   const handleSelectComposite = useCallback((relativePath: string) => {
     setSelectedComposite(relativePath);
@@ -240,12 +242,14 @@ export function EditorPage() {
     [settings.previewOptions.showWarnings, detectCustomCode],
   );
 
+  const isAltCompositeSelected = selectedComposite !== MAIN_COMPOSITE_RELATIVE;
+
   const handleBack = useCallback(async () => {
     const rpc = iframeRef.current;
-    if (rpc) await refreshProject(rpc);
+    if (rpc) await refreshProject(rpc, { skipThumbnail: isAltCompositeSelected });
     killPreview();
     navigate('/scenes');
-  }, [navigate, iframeRef.current]);
+  }, [navigate, iframeRef.current, refreshProject, killPreview, isAltCompositeSelected]);
 
   const handleOpenPublishModal = useCallback(async () => {
     await handleActionWithWarningCheck(() => openModal('publish'));
@@ -295,33 +299,47 @@ export function EditorPage() {
 
   const handlePublishScene = useCallback(async () => {
     const rpc = iframeRef.current;
-    if (rpc) saveAndGetThumbnail(rpc);
+    if (rpc && !isAltCompositeSelected) saveAndGetThumbnail(rpc);
     await handleOpenPublishModal();
-  }, [saveAndGetThumbnail, handleOpenPublishModal]);
+  }, [saveAndGetThumbnail, handleOpenPublishModal, isAltCompositeSelected]);
 
   const handleDeployWorld = useCallback(async () => {
     if (!project) return;
     const rpc = iframeRef.current;
-    if (rpc) saveAndGetThumbnail(rpc);
+    if (rpc && !isAltCompositeSelected) saveAndGetThumbnail(rpc);
     try {
       await publishScene({ targetContent: config.get('WORLDS_CONTENT_SERVER_URL') });
       executeDeployment(project.path);
     } catch {
       openModal('publish', 'deploy');
     }
-  }, [project, saveAndGetThumbnail, publishScene, executeDeployment, openModal]);
+  }, [
+    project,
+    saveAndGetThumbnail,
+    publishScene,
+    executeDeployment,
+    openModal,
+    isAltCompositeSelected,
+  ]);
 
   const handleDeployLand = useCallback(async () => {
     if (!project) return;
     const rpc = iframeRef.current;
-    if (rpc) saveAndGetThumbnail(rpc);
+    if (rpc && !isAltCompositeSelected) saveAndGetThumbnail(rpc);
     try {
       await publishScene({ target: config.get('PEER_URL') });
       executeDeployment(project.path);
     } catch {
       openModal('publish', 'deploy');
     }
-  }, [project, saveAndGetThumbnail, publishScene, executeDeployment, openModal]);
+  }, [
+    project,
+    saveAndGetThumbnail,
+    publishScene,
+    executeDeployment,
+    openModal,
+    isAltCompositeSelected,
+  ]);
 
   const publishOptions = useMemo(
     () =>

--- a/packages/creator-hub/renderer/src/components/EditorPage/component.tsx
+++ b/packages/creator-hub/renderer/src/components/EditorPage/component.tsx
@@ -7,6 +7,9 @@ import PublicIcon from '@mui/icons-material/Public';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { CircularProgress as Loader, Tooltip } from 'decentraland-ui2';
 
+import { composites as compositesPreload } from '#preload';
+import type { CompositeEntry } from '/shared/types/composites';
+
 import { isClientNotInstalledError } from '/shared/types/client';
 import { isProjectError } from '/shared/types/projects';
 import { isWorkspaceError } from '/shared/types/workspace';
@@ -34,6 +37,8 @@ import { Header } from '../Header';
 import { Row } from '../Row';
 import { ButtonGroup } from '../Button';
 import { ConnectionStatusIndicator } from '../ConnectionStatusIndicator';
+import { CompositeSelector, MAIN_COMPOSITE_RELATIVE } from '../CompositeSelector';
+import { ManageCompositesModal } from '../Modals/ManageComposites';
 import { MobileQRCode } from '../Modals/MobileQRCode';
 import { DeployModal } from './DeployModal';
 import { PreviewOptions, PublishOptions } from './MenuOptions';
@@ -83,6 +88,66 @@ export function EditorPage() {
   const iframeRef = useRef<ReturnType<typeof initRpc>>();
   const [modalState, setModalState] = useState<ModalState>({ type: undefined });
   const [mobileQRData, setMobileQRData] = useState<{ url: string; qr: string } | null>(null);
+  const [composites, setComposites] = useState<CompositeEntry[]>([]);
+  const [selectedComposite, setSelectedComposite] = useState<string>(MAIN_COMPOSITE_RELATIVE);
+  const [manageCompositesOpen, setManageCompositesOpen] = useState(false);
+
+  const refreshComposites = useCallback(async () => {
+    if (!project) return [] as CompositeEntry[];
+    try {
+      const list = await compositesPreload.listComposites(project.path);
+      setComposites(list);
+      return list;
+    } catch (err) {
+      console.error('Failed to list composites', err);
+      return [] as CompositeEntry[];
+    }
+  }, [project]);
+
+  useEffect(() => {
+    setSelectedComposite(MAIN_COMPOSITE_RELATIVE);
+    setManageCompositesOpen(false);
+    setComposites([]);
+    if (project) {
+      void refreshComposites();
+    }
+  }, [project?.path, refreshComposites]);
+
+  const handleSelectComposite = useCallback((relativePath: string) => {
+    setSelectedComposite(relativePath);
+  }, []);
+
+  const handleOpenManageComposites = useCallback(() => {
+    setManageCompositesOpen(true);
+  }, []);
+
+  const handleCloseManageComposites = useCallback(() => {
+    setManageCompositesOpen(false);
+  }, []);
+
+  const handleDeleteComposite = useCallback(
+    async (entry: CompositeEntry) => {
+      if (!project) return;
+      try {
+        await compositesPreload.deleteComposite({
+          projectPath: project.path,
+          relativePath: entry.relativePath,
+        });
+      } catch (err) {
+        console.error('Failed to delete composite', err);
+        return;
+      }
+      const list = await refreshComposites();
+      const stillExists = list.some(c => c.relativePath === selectedComposite);
+      if (!stillExists) {
+        setSelectedComposite(MAIN_COMPOSITE_RELATIVE);
+      }
+      if (list.filter(c => !c.isMain).length === 0) {
+        setManageCompositesOpen(false);
+      }
+    },
+    [project, refreshComposites, selectedComposite],
+  );
 
   const isOffline = status === ConnectionStatus.OFFLINE;
   const showDebugPanel = settings.previewOptions.debugger;
@@ -311,6 +376,10 @@ export function EditorPage() {
     params.append('projectId', project.id);
   }
 
+  if (selectedComposite && selectedComposite !== MAIN_COMPOSITE_RELATIVE) {
+    params.append('compositePath', selectedComposite);
+  }
+
   // iframe src
   const iframeUrl = `${htmlUrl}?${params}`;
 
@@ -339,6 +408,13 @@ export function EditorPage() {
                 <ArrowBackIosIcon />
               </div>
               <div className="title">{project.title}</div>
+              <CompositeSelector
+                composites={composites}
+                selected={selectedComposite}
+                projectTitle={t('editor.composites.main_scene')}
+                onSelect={handleSelectComposite}
+                onManage={handleOpenManageComposites}
+              />
               <Tooltip title={t('editor.header.actions.refresh')}>
                 <div
                   className="refresh"
@@ -427,6 +503,12 @@ export function EditorPage() {
               qr={mobileQRData.qr}
             />
           )}
+          <ManageCompositesModal
+            open={manageCompositesOpen}
+            composites={composites}
+            onClose={handleCloseManageComposites}
+            onDelete={handleDeleteComposite}
+          />
         </>
       )}
     </main>

--- a/packages/creator-hub/renderer/src/components/Modals/CreateComposite/component.tsx
+++ b/packages/creator-hub/renderer/src/components/Modals/CreateComposite/component.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Box, FormGroup, OutlinedInput, Typography } from 'decentraland-ui2';
+
+import { t } from '/@/modules/store/translation/utils';
+
+import { Button } from '../../Button';
+import { Modal, onBackNoop } from '..';
+
+import './styles.css';
+
+type Props = {
+  open: boolean;
+  existingFolderNames: string[];
+  onClose: () => void;
+  onSubmit: (name: string) => Promise<void> | void;
+};
+
+function sanitize(rawName: string): string {
+  return rawName
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+export function CreateCompositeModal({ open, existingFolderNames, onClose, onSubmit }: Props) {
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setName('');
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [open]);
+
+  const handleClose = useCallback(
+    (_event: unknown, reason?: 'backdropClick' | 'escapeKeyDown') => {
+      if (reason === 'backdropClick' || submitting) return;
+      onClose();
+    },
+    [onClose, submitting],
+  );
+
+  const validate = useCallback(
+    (value: string): string | null => {
+      const trimmed = value.trim();
+      if (!trimmed) return t('editor.composites.create_modal.errors.empty');
+      const folder = sanitize(trimmed);
+      if (!folder) return t('editor.composites.create_modal.errors.invalid');
+      if (existingFolderNames.includes(folder)) {
+        return t('editor.composites.create_modal.errors.exists');
+      }
+      return null;
+    },
+    [existingFolderNames],
+  );
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      setName(value);
+      setError(validate(value));
+    },
+    [validate],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    const validationError = validate(name);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await onSubmit(name.trim());
+    } catch (err: any) {
+      setError(err?.message ?? t('editor.composites.create_modal.errors.invalid'));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [name, onSubmit, validate]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        void handleSubmit();
+      }
+    },
+    [handleSubmit],
+  );
+
+  return (
+    <Modal
+      className="CreateCompositeModal"
+      open={open}
+      size="small"
+      title={t('editor.composites.create_modal.title')}
+      onBack={onBackNoop}
+      onClose={handleClose}
+      actions={
+        <>
+          <Button
+            color="secondary"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            {t('modal.cancel')}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={submitting || !!error || !name.trim()}
+          >
+            {t('editor.composites.create_modal.submit')}
+          </Button>
+        </>
+      }
+    >
+      <Box className="CreateCompositeBody">
+        <FormGroup>
+          <Typography variant="body1">{t('editor.composites.create_modal.label')}</Typography>
+          <OutlinedInput
+            autoFocus
+            color="secondary"
+            placeholder={t('editor.composites.create_modal.placeholder')}
+            value={name}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+          />
+          <Typography
+            variant="caption"
+            className="CreateCompositeDescription"
+          >
+            {t('editor.composites.create_modal.description')}
+          </Typography>
+          {error && (
+            <Typography
+              variant="body2"
+              className="CreateCompositeError"
+            >
+              {error}
+            </Typography>
+          )}
+        </FormGroup>
+      </Box>
+    </Modal>
+  );
+}

--- a/packages/creator-hub/renderer/src/components/Modals/CreateComposite/index.ts
+++ b/packages/creator-hub/renderer/src/components/Modals/CreateComposite/index.ts
@@ -1,0 +1,1 @@
+export { CreateCompositeModal } from './component';

--- a/packages/creator-hub/renderer/src/components/Modals/CreateComposite/styles.css
+++ b/packages/creator-hub/renderer/src/components/Modals/CreateComposite/styles.css
@@ -1,0 +1,22 @@
+.CreateCompositeModal .MuiPaper-root {
+  min-width: 420px;
+  max-width: 560px;
+}
+
+.CreateCompositeBody {
+  padding: 8px 0 4px;
+}
+
+.CreateCompositeBody .MuiInputBase-root {
+  margin-top: 8px;
+}
+
+.CreateCompositeDescription {
+  margin-top: 8px;
+  color: var(--clear-divider);
+}
+
+.CreateCompositeError {
+  color: var(--error);
+  margin-top: 8px;
+}

--- a/packages/creator-hub/renderer/src/components/Modals/ManageComposites/component.tsx
+++ b/packages/creator-hub/renderer/src/components/Modals/ManageComposites/component.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useState } from 'react';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { Box, IconButton, Typography } from 'decentraland-ui2';
+
+import { t } from '/@/modules/store/translation/utils';
+import type { CompositeEntry } from '/shared/types/composites';
+
+import { ConfirmationPanel } from '/@/components/ConfirmationPanel';
+import { Modal, onBackNoop } from '..';
+
+import './styles.css';
+
+type Props = {
+  open: boolean;
+  composites: CompositeEntry[];
+  onClose: () => void;
+  onDelete: (entry: CompositeEntry) => Promise<void> | void;
+};
+
+export function ManageCompositesModal({ open, composites, onClose, onDelete }: Props) {
+  const [pendingDelete, setPendingDelete] = useState<CompositeEntry | null>(null);
+
+  const handleClose = useCallback(
+    (_event: unknown, reason?: 'backdropClick' | 'escapeKeyDown') => {
+      if (reason === 'backdropClick') return;
+      onClose();
+    },
+    [onClose],
+  );
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!pendingDelete) return;
+    const entry = pendingDelete;
+    setPendingDelete(null);
+    await onDelete(entry);
+  }, [pendingDelete, onDelete]);
+
+  const handleCancelDelete = useCallback(() => setPendingDelete(null), []);
+
+  const nonMainComposites = composites.filter(c => !c.isMain);
+
+  return (
+    <Modal
+      className="ManageCompositesModal"
+      open={open}
+      size="small"
+      title={t('editor.composites.modal.title')}
+      onBack={onBackNoop}
+      onClose={handleClose}
+    >
+      {pendingDelete ? (
+        <ConfirmationPanel
+          title={t('editor.composites.modal.confirm_title', { name: pendingDelete.displayName })}
+          warning={t('editor.composites.modal.confirm_warning')}
+          cancelLabel={t('modal.cancel')}
+          confirmLabel={t('editor.composites.modal.delete')}
+          onCancel={handleCancelDelete}
+          onConfirm={handleConfirmDelete}
+        />
+      ) : (
+        <Box className="ManageCompositesList">
+          {composites.map(entry => (
+            <Box
+              key={entry.relativePath}
+              className="ManageCompositesRow"
+            >
+              <Box className="ManageCompositesRowInfo">
+                <span className="ManageCompositesRowName">{entry.displayName}</span>
+                <span className="ManageCompositesRowPath">{entry.relativePath}</span>
+              </Box>
+              {entry.isMain ? (
+                <span className="ManageCompositesRowMain">
+                  {t('editor.composites.modal.main_label')}
+                </span>
+              ) : (
+                <IconButton
+                  aria-label={t('editor.composites.modal.delete')}
+                  onClick={() => setPendingDelete(entry)}
+                >
+                  <DeleteOutlineIcon />
+                </IconButton>
+              )}
+            </Box>
+          ))}
+          {nonMainComposites.length === 0 && (
+            <Typography
+              className="ManageCompositesEmpty"
+              variant="body2"
+            >
+              {t('editor.composites.modal.empty')}
+            </Typography>
+          )}
+        </Box>
+      )}
+    </Modal>
+  );
+}

--- a/packages/creator-hub/renderer/src/components/Modals/ManageComposites/component.tsx
+++ b/packages/creator-hub/renderer/src/components/Modals/ManageComposites/component.tsx
@@ -1,10 +1,19 @@
-import { useCallback, useState } from 'react';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import { Box, IconButton, Typography } from 'decentraland-ui2';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import {
+  Box,
+  FormGroup,
+  IconButton,
+  Menu,
+  MenuItem,
+  OutlinedInput,
+  Typography,
+} from 'decentraland-ui2';
 
 import { t } from '/@/modules/store/translation/utils';
 import type { CompositeEntry } from '/shared/types/composites';
 
+import { Button } from '/@/components/Button';
 import { ConfirmationPanel } from '/@/components/ConfirmationPanel';
 import { Modal, onBackNoop } from '..';
 
@@ -13,12 +22,50 @@ import './styles.css';
 type Props = {
   open: boolean;
   composites: CompositeEntry[];
+  existingCustomFolderNames: string[];
   onClose: () => void;
   onDelete: (entry: CompositeEntry) => Promise<void> | void;
+  onDuplicate: (entry: CompositeEntry, newName: string) => Promise<void> | void;
 };
 
-export function ManageCompositesModal({ open, composites, onClose, onDelete }: Props) {
-  const [pendingDelete, setPendingDelete] = useState<CompositeEntry | null>(null);
+type DeletePending = { type: 'delete'; entry: CompositeEntry };
+type DuplicatePending = {
+  type: 'duplicate';
+  entry: CompositeEntry;
+  name: string;
+  error: string | null;
+  submitting: boolean;
+};
+type Pending = DeletePending | DuplicatePending | null;
+
+function sanitize(rawName: string): string {
+  return rawName
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+export function ManageCompositesModal({
+  open,
+  composites,
+  existingCustomFolderNames,
+  onClose,
+  onDelete,
+  onDuplicate,
+}: Props) {
+  const [pending, setPending] = useState<Pending>(null);
+  const [menuFor, setMenuFor] = useState<{ entry: CompositeEntry; anchorEl: HTMLElement } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!open) {
+      setPending(null);
+      setMenuFor(null);
+    }
+  }, [open]);
 
   const handleClose = useCallback(
     (_event: unknown, reason?: 'backdropClick' | 'escapeKeyDown') => {
@@ -28,16 +75,206 @@ export function ManageCompositesModal({ open, composites, onClose, onDelete }: P
     [onClose],
   );
 
+  const closePrompt = useCallback(() => setPending(null), []);
+
+  const openMenu = useCallback((entry: CompositeEntry, target: HTMLElement) => {
+    setMenuFor({ entry, anchorEl: target });
+  }, []);
+  const closeMenu = useCallback(() => setMenuFor(null), []);
+
+  const startDelete = useCallback((entry: CompositeEntry) => {
+    setPending({ type: 'delete', entry });
+  }, []);
+
+  const startDuplicate = useCallback((entry: CompositeEntry) => {
+    setPending({
+      type: 'duplicate',
+      entry,
+      name: `${entry.displayName}_copy`,
+      error: null,
+      submitting: false,
+    });
+  }, []);
+
   const handleConfirmDelete = useCallback(async () => {
-    if (!pendingDelete) return;
-    const entry = pendingDelete;
-    setPendingDelete(null);
+    if (!pending || pending.type !== 'delete') return;
+    const entry = pending.entry;
+    setPending(null);
     await onDelete(entry);
-  }, [pendingDelete, onDelete]);
+  }, [pending, onDelete]);
 
-  const handleCancelDelete = useCallback(() => setPendingDelete(null), []);
+  const getEntrySourceFolder = (entry: CompositeEntry) => {
+    const prefix = 'assets/custom/';
+    if (!entry.relativePath.startsWith(prefix)) return '';
+    const rest = entry.relativePath.slice(prefix.length);
+    const slash = rest.indexOf('/');
+    return slash >= 0 ? rest.slice(0, slash) : rest;
+  };
 
-  const nonMainComposites = composites.filter(c => !c.isMain);
+  const validatePromptName = useCallback(
+    (value: string, sourceFolder: string): string | null => {
+      const trimmed = value.trim();
+      if (!trimmed) return t('editor.composites.create_modal.errors.empty');
+      const folder = sanitize(trimmed);
+      if (!folder) return t('editor.composites.create_modal.errors.invalid');
+      if (folder === sourceFolder) return t('editor.composites.create_modal.errors.exists');
+      if (existingCustomFolderNames.includes(folder)) {
+        return t('editor.composites.create_modal.errors.exists');
+      }
+      return null;
+    },
+    [existingCustomFolderNames],
+  );
+
+  const updatePromptName = useCallback(
+    (value: string) => {
+      setPending(prev => {
+        if (!prev || prev.type === 'delete') return prev;
+        const sourceFolder = getEntrySourceFolder(prev.entry);
+        return {
+          ...prev,
+          name: value,
+          error: validatePromptName(value, sourceFolder),
+        };
+      });
+    },
+    [validatePromptName],
+  );
+
+  const submitPrompt = useCallback(async () => {
+    if (!pending || pending.type === 'delete') return;
+    const sourceFolder = getEntrySourceFolder(pending.entry);
+    const error = validatePromptName(pending.name, sourceFolder);
+    if (error) {
+      setPending({ ...pending, error });
+      return;
+    }
+    setPending({ ...pending, submitting: true, error: null });
+    try {
+      await onDuplicate(pending.entry, pending.name.trim());
+      setPending(null);
+    } catch (err: any) {
+      setPending(prev =>
+        prev && prev.type !== 'delete'
+          ? {
+              ...prev,
+              submitting: false,
+              error: err?.message ?? t('editor.composites.create_modal.errors.invalid'),
+            }
+          : prev,
+      );
+    }
+  }, [pending, validatePromptName, onDuplicate]);
+
+  const nonMainComposites = useMemo(() => composites.filter(c => !c.isMain), [composites]);
+
+  const renderList = () => (
+    <Box className="ManageCompositesList">
+      {composites.map(entry => (
+        <Box
+          key={entry.relativePath}
+          className="ManageCompositesRow"
+        >
+          <Box className="ManageCompositesRowInfo">
+            <span className="ManageCompositesRowName">{entry.displayName}</span>
+            <span className="ManageCompositesRowPath">{entry.relativePath}</span>
+          </Box>
+          {entry.isMain ? (
+            <span className="ManageCompositesRowMain">
+              {t('editor.composites.modal.main_label')}
+            </span>
+          ) : (
+            <IconButton
+              aria-label={t('editor.composites.modal.actions_aria')}
+              onClick={event => openMenu(entry, event.currentTarget)}
+            >
+              <MoreVertIcon />
+            </IconButton>
+          )}
+        </Box>
+      ))}
+      {nonMainComposites.length === 0 && (
+        <Typography
+          className="ManageCompositesEmpty"
+          variant="body2"
+        >
+          {t('editor.composites.modal.empty')}
+        </Typography>
+      )}
+    </Box>
+  );
+
+  const renderPrompt = (state: DuplicatePending) => (
+    <Box className="ManageCompositesPrompt">
+      <Typography
+        variant="h6"
+        className="ManageCompositesPromptTitle"
+      >
+        {t('editor.composites.modal.duplicate_title', { name: state.entry.displayName })}
+      </Typography>
+      <FormGroup className="ManageCompositesPromptForm">
+        <Typography variant="body1">{t('editor.composites.create_modal.label')}</Typography>
+        <OutlinedInput
+          autoFocus
+          color="secondary"
+          placeholder={t('editor.composites.create_modal.placeholder')}
+          value={state.name}
+          onChange={e => updatePromptName(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              void submitPrompt();
+            }
+          }}
+        />
+        <Typography
+          variant="caption"
+          className="ManageCompositesPromptDescription"
+        >
+          {t('editor.composites.modal.duplicate_description')}
+        </Typography>
+        {state.error && (
+          <Typography
+            variant="body2"
+            className="ManageCompositesPromptError"
+          >
+            {state.error}
+          </Typography>
+        )}
+      </FormGroup>
+      <Box className="ManageCompositesPromptActions">
+        <Button
+          color="secondary"
+          onClick={closePrompt}
+          disabled={state.submitting}
+        >
+          {t('modal.cancel')}
+        </Button>
+        <Button
+          onClick={submitPrompt}
+          disabled={state.submitting || !!state.error || !state.name.trim()}
+        >
+          {t('editor.composites.modal.duplicate_submit')}
+        </Button>
+      </Box>
+    </Box>
+  );
+
+  const body =
+    pending && pending.type === 'delete' ? (
+      <ConfirmationPanel
+        title={t('editor.composites.modal.confirm_title', { name: pending.entry.displayName })}
+        warning={t('editor.composites.modal.confirm_warning')}
+        cancelLabel={t('modal.cancel')}
+        confirmLabel={t('editor.composites.modal.delete')}
+        onCancel={closePrompt}
+        onConfirm={handleConfirmDelete}
+      />
+    ) : pending ? (
+      renderPrompt(pending)
+    ) : (
+      renderList()
+    );
 
   return (
     <Modal
@@ -48,50 +285,29 @@ export function ManageCompositesModal({ open, composites, onClose, onDelete }: P
       onBack={onBackNoop}
       onClose={handleClose}
     >
-      {pendingDelete ? (
-        <ConfirmationPanel
-          title={t('editor.composites.modal.confirm_title', { name: pendingDelete.displayName })}
-          warning={t('editor.composites.modal.confirm_warning')}
-          cancelLabel={t('modal.cancel')}
-          confirmLabel={t('editor.composites.modal.delete')}
-          onCancel={handleCancelDelete}
-          onConfirm={handleConfirmDelete}
-        />
-      ) : (
-        <Box className="ManageCompositesList">
-          {composites.map(entry => (
-            <Box
-              key={entry.relativePath}
-              className="ManageCompositesRow"
-            >
-              <Box className="ManageCompositesRowInfo">
-                <span className="ManageCompositesRowName">{entry.displayName}</span>
-                <span className="ManageCompositesRowPath">{entry.relativePath}</span>
-              </Box>
-              {entry.isMain ? (
-                <span className="ManageCompositesRowMain">
-                  {t('editor.composites.modal.main_label')}
-                </span>
-              ) : (
-                <IconButton
-                  aria-label={t('editor.composites.modal.delete')}
-                  onClick={() => setPendingDelete(entry)}
-                >
-                  <DeleteOutlineIcon />
-                </IconButton>
-              )}
-            </Box>
-          ))}
-          {nonMainComposites.length === 0 && (
-            <Typography
-              className="ManageCompositesEmpty"
-              variant="body2"
-            >
-              {t('editor.composites.modal.empty')}
-            </Typography>
-          )}
-        </Box>
-      )}
+      {body}
+      <Menu
+        anchorEl={menuFor?.anchorEl ?? null}
+        open={!!menuFor}
+        onClose={closeMenu}
+      >
+        <MenuItem
+          onClick={() => {
+            if (menuFor) startDuplicate(menuFor.entry);
+            closeMenu();
+          }}
+        >
+          {t('editor.composites.modal.duplicate')}
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            if (menuFor) startDelete(menuFor.entry);
+            closeMenu();
+          }}
+        >
+          {t('editor.composites.modal.delete')}
+        </MenuItem>
+      </Menu>
     </Modal>
   );
 }

--- a/packages/creator-hub/renderer/src/components/Modals/ManageComposites/index.ts
+++ b/packages/creator-hub/renderer/src/components/Modals/ManageComposites/index.ts
@@ -1,0 +1,1 @@
+export { ManageCompositesModal } from './component';

--- a/packages/creator-hub/renderer/src/components/Modals/ManageComposites/styles.css
+++ b/packages/creator-hub/renderer/src/components/Modals/ManageComposites/styles.css
@@ -60,3 +60,34 @@
   font-style: italic;
   margin-right: 12px;
 }
+
+.ManageCompositesPrompt {
+  padding: 8px 0 4px;
+}
+
+.ManageCompositesPromptTitle {
+  font-size: 15px;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+
+.ManageCompositesPromptForm .MuiInputBase-root {
+  margin-top: 8px;
+}
+
+.ManageCompositesPromptDescription {
+  margin-top: 8px;
+  color: var(--clear-divider);
+}
+
+.ManageCompositesPromptError {
+  color: var(--error);
+  margin-top: 8px;
+}
+
+.ManageCompositesPromptActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}

--- a/packages/creator-hub/renderer/src/components/Modals/ManageComposites/styles.css
+++ b/packages/creator-hub/renderer/src/components/Modals/ManageComposites/styles.css
@@ -1,0 +1,62 @@
+.ManageCompositesModal .MuiPaper-root {
+  min-width: 480px;
+  max-width: 640px;
+}
+
+.ManageCompositesList {
+  display: flex;
+  flex-direction: column;
+  padding: 8px 0 16px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.ManageCompositesEmpty {
+  padding: 20px;
+  font-size: 13px;
+  color: var(--clear-divider);
+  text-align: center;
+}
+
+.ManageCompositesRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 4px;
+  border-bottom: 1px solid var(--dark-gray);
+}
+
+.ManageCompositesRow:last-child {
+  border-bottom: none;
+}
+
+.ManageCompositesRowInfo {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  flex: 1;
+  margin-right: 12px;
+}
+
+.ManageCompositesRowName {
+  font-size: 14px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ManageCompositesRowPath {
+  font-size: 12px;
+  color: var(--clear-divider);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ManageCompositesRowMain {
+  font-size: 12px;
+  color: var(--clear-divider);
+  font-style: italic;
+  margin-right: 12px;
+}

--- a/packages/creator-hub/renderer/src/hooks/useEditor.ts
+++ b/packages/creator-hub/renderer/src/hooks/useEditor.ts
@@ -88,8 +88,10 @@ export const useEditor = () => {
 
   // TODO: find a proper name for this function
   const refreshProject = useCallback(
-    async (rpcInfo: RPCInfo) => {
-      const _ = await saveAndGetThumbnail(rpcInfo);
+    async (rpcInfo: RPCInfo, options?: { skipThumbnail?: boolean }) => {
+      if (!options?.skipThumbnail) {
+        await saveAndGetThumbnail(rpcInfo);
+      }
       dispatch(
         workspaceActions.getProject({
           path: rpcInfo.project.path,
@@ -97,7 +99,7 @@ export const useEditor = () => {
         }),
       );
     },
-    [workspaceActions.getProject, project],
+    [workspaceActions.getProject, project, saveAndGetThumbnail],
   );
 
   const getMobileQR = useCallback(

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
@@ -43,13 +43,31 @@
     "composites": {
       "main_scene": "Main scene",
       "manage": "Manage composites…",
+      "create": "Create new composite…",
       "modal": {
         "title": "Manage composites",
         "empty": "This project has no additional composites. Drag a smart item into a custom folder to create one.",
-        "main_label": "Main scene (cannot be deleted)",
+        "main_label": "Main scene (cannot be modified)",
+        "actions_aria": "More actions",
         "delete": "Delete",
+        "duplicate": "Duplicate…",
         "confirm_title": "Delete composite \"{name}\"?",
-        "confirm_warning": "The composite file will be removed from disk. Asset files inside its folder are kept."
+        "confirm_warning": "The composite file will be removed from disk. Asset files inside its folder are kept.",
+        "duplicate_title": "Duplicate composite \"{name}\"",
+        "duplicate_description": "A copy of the composite folder will be created under assets/custom.",
+        "duplicate_submit": "Duplicate"
+      },
+      "create_modal": {
+        "title": "Create new composite",
+        "label": "Name",
+        "placeholder": "e.g. my_widget",
+        "description": "A folder will be created under assets/custom with this name. The composite file and any assets you add will live inside it.",
+        "submit": "Create",
+        "errors": {
+          "empty": "Please enter a name",
+          "invalid": "Use letters, numbers, hyphens or underscores only",
+          "exists": "A composite with this name already exists"
+        }
       }
     },
     "header": {

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
@@ -40,6 +40,18 @@
     "loading": {
       "title": "Loading..."
     },
+    "composites": {
+      "main_scene": "Main scene",
+      "manage": "Manage composites…",
+      "modal": {
+        "title": "Manage composites",
+        "empty": "This project has no additional composites. Drag a smart item into a custom folder to create one.",
+        "main_label": "Main scene (cannot be deleted)",
+        "delete": "Delete",
+        "confirm_title": "Delete composite \"{name}\"?",
+        "confirm_warning": "The composite file will be removed from disk. Asset files inside its folder are kept."
+      }
+    },
     "header": {
       "actions": {
         "code": "Code",

--- a/packages/creator-hub/shared/types/composites.ts
+++ b/packages/creator-hub/shared/types/composites.ts
@@ -1,0 +1,5 @@
+export type CompositeEntry = {
+  relativePath: string;
+  displayName: string;
+  isMain: boolean;
+};

--- a/packages/inspector/src/components/EntityInspector/EntityHeader/EntityHeader.tsx
+++ b/packages/inspector/src/components/EntityInspector/EntityHeader/EntityHeader.tsx
@@ -8,6 +8,7 @@ import { type Entity } from '@dcl/ecs';
 import { type WithSdkProps, withSdk } from '../../../hoc/withSdk';
 import { useChange } from '../../../hooks/sdk/useChange';
 import { isRoot, useEntityComponent } from '../../../hooks/sdk/useEntityComponent';
+import { isAltCompositeMode } from '../../../lib/data-layer/host/fs-utils';
 import { CAMERA, PLAYER, ROOT } from '../../../lib/sdk/tree';
 import { type SdkContextEvents, type SdkContextValue } from '../../../lib/sdk/context';
 import { getAssetByModel } from '../../../lib/logic/catalog';
@@ -18,7 +19,7 @@ import { selectCustomAssets } from '../../../redux/app';
 import { Edit as EditInput } from '../../Tree/Edit';
 import { Block } from '../../Block';
 import CustomAssetIcon from '../../Icons/CustomAsset';
-import { Dropdown, Divider } from '../../ui';
+import { Dropdown } from '../../ui';
 
 import MoreOptionsMenu from '../MoreOptionsMenu';
 import { TagsInspector } from '../TagsInspector';
@@ -340,9 +341,14 @@ export default React.memo(
 
     const handleRenameEntity = useCallback(
       async (value: string) => {
-        if (isRoot(entity)) return;
+        const altRootRenameable = entity === ROOT && isAltCompositeMode();
+        if (isRoot(entity) && !altRootRenameable) return;
         const { Name } = sdk.components;
-        sdk.operations.updateValue(Name, entity, { value });
+        if (entity === ROOT && !Name.has(entity)) {
+          sdk.operations.addComponent(entity, Name.componentId, { value });
+        } else {
+          sdk.operations.updateValue(Name, entity, { value });
+        }
         await sdk.operations.dispatch();
         quitEditMode();
       },
@@ -373,34 +379,49 @@ export default React.memo(
             ) : null}
           </div>
           <div className="RightContent">
-            {componentOptions.some(option => !option.header) && !isRoot(entity) ? (
-              <Dropdown
-                className="AddComponent"
-                options={componentOptions}
-                trigger={
-                  <div className="AddComponentTrigger">
-                    <AddIcon />
-                    <ChevronDownIcon />
-                  </div>
-                }
-              />
-            ) : null}
-            {!isRoot(entity) ? (
-              <MoreOptionsMenu
-                options={[
-                  {
-                    label: 'Rename Entity',
-                    leftIcon: <RenameIcon />,
-                    onClick: () => enterEditMode(),
-                  },
-                  {
-                    label: 'Delete Entity',
-                    leftIcon: <TrashIcon />,
-                    onClick: () => void handleRemoveEntity(),
-                  },
-                ]}
-              />
-            ) : null}
+            {(() => {
+              const altRoot = entity === ROOT && isAltCompositeMode();
+              const showAddComponent =
+                componentOptions.some(option => !option.header) && (!isRoot(entity) || altRoot);
+              const showMoreOptions = !isRoot(entity) || altRoot;
+              const moreOptions = altRoot
+                ? [
+                    {
+                      label: 'Rename Entity',
+                      leftIcon: <RenameIcon />,
+                      onClick: () => enterEditMode(),
+                    },
+                  ]
+                : [
+                    {
+                      label: 'Rename Entity',
+                      leftIcon: <RenameIcon />,
+                      onClick: () => enterEditMode(),
+                    },
+                    {
+                      label: 'Delete Entity',
+                      leftIcon: <TrashIcon />,
+                      onClick: () => void handleRemoveEntity(),
+                    },
+                  ];
+              return (
+                <>
+                  {showAddComponent ? (
+                    <Dropdown
+                      className="AddComponent"
+                      options={componentOptions}
+                      trigger={
+                        <div className="AddComponentTrigger">
+                          <AddIcon />
+                          <ChevronDownIcon />
+                        </div>
+                      }
+                    />
+                  ) : null}
+                  {showMoreOptions ? <MoreOptionsMenu options={moreOptions} /> : null}
+                </>
+              );
+            })()}
           </div>
         </div>
         {!isRoot(entity) && (

--- a/packages/inspector/src/components/EntityInspector/EntityInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/EntityInspector.tsx
@@ -9,6 +9,7 @@ import { useEntitiesWith } from '../../hooks/sdk/useEntitiesWith';
 import { useAppSelector } from '../../redux/hooks';
 import { getHiddenComponents } from '../../redux/ui';
 import { EDITOR_ENTITIES, PLAYER } from '../../lib/sdk/tree';
+import { isAltCompositeMode } from '../../lib/data-layer/host/fs-utils';
 
 import { Divider } from '../ui';
 
@@ -153,7 +154,9 @@ const SingleEntityInspector = withSdk<{ entity: Entity | null }>(({ sdk, entity 
         name: sdk.components.MeshRenderer.componentName,
         component: MeshRendererInspector,
       },
-      { name: sdk.components.Scene.componentName, component: SceneInspector },
+      ...(isAltCompositeMode()
+        ? []
+        : [{ name: sdk.components.Scene.componentName, component: SceneInspector }]),
       {
         name: sdk.components.TextShape.componentName,
         component: TextShapeInspector,

--- a/packages/inspector/src/components/EntityInspector/ScriptInspector/utils.ts
+++ b/packages/inspector/src/components/EntityInspector/ScriptInspector/utils.ts
@@ -1,4 +1,9 @@
-import { DIRECTORY, withAssetDir } from '../../../lib/data-layer/host/fs-utils';
+import {
+  DIRECTORY,
+  getCompositeBaseFolder,
+  isAltCompositeMode,
+  withAssetDir,
+} from '../../../lib/data-layer/host/fs-utils';
 import type { DataLayerRpcClient } from '../../../lib/data-layer/types';
 import type { AssetCatalogResponse } from '../../../tooling-entrypoint';
 import { determineAssetType } from '../../ImportAsset/utils';
@@ -39,7 +44,12 @@ export const isScriptNode = (node: TreeNode): node is AssetNodeItem =>
   isAssetNode(node) && isScriptFile(node.name);
 
 export function buildScriptPath(name: string): string {
-  const scriptsDir = withAssetDir(`${DIRECTORY.SCENE}/${determineAssetType('ts')}`);
+  // When editing an alt composite, scripts created from its entities live next to the
+  // composite file (e.g. assets/custom/my_widget/Scripts/NewScript.tsx) so the folder
+  // stays self-contained and portable.
+  const scriptsDir = isAltCompositeMode()
+    ? `${getCompositeBaseFolder()}/${determineAssetType('ts')}`
+    : withAssetDir(`${DIRECTORY.SCENE}/${determineAssetType('ts')}`);
   if (name.startsWith(scriptsDir)) return name; // if it's already a built path, return the name parameter
   const scriptName = isScriptFile(name) ? name : `${name}.tsx`;
   const scriptPath = `${scriptsDir}/${scriptName}`;

--- a/packages/inspector/src/components/Hierarchy/Hierarchy.tsx
+++ b/packages/inspector/src/components/Hierarchy/Hierarchy.tsx
@@ -9,6 +9,7 @@ import { withSdk } from '../../hoc/withSdk';
 import './Hierarchy.css';
 import { useAppSelector } from '../../redux/hooks';
 import { selectCustomAssets } from '../../redux/app';
+import { isAltCompositeMode } from '../../lib/data-layer/host/fs-utils';
 import { ContextMenu } from './ContextMenu';
 import PlayerTree from './PlayerTree';
 
@@ -66,6 +67,7 @@ const HierarchyIcon = withSdk<{ value: Entity }>(({ sdk, value }) => {
 const EntityTree = Tree<Entity>();
 
 const Hierarchy = withSdk(({ sdk }) => {
+  const altComposite = isAltCompositeMode();
   const spawnPointManager = sdk.sceneContext.spawnPoints;
   const {
     addChild,
@@ -195,11 +197,15 @@ const Hierarchy = withSdk(({ sdk }) => {
       className="Hierarchy"
       onClick={handleBackgroundDeselect}
     >
-      <PlayerTree onSelect={(entity, multiple) => void select(entity, !!multiple)} />
-      <EntityTree
-        value={CAMERA}
-        {...props}
-      />
+      {!altComposite && (
+        <>
+          <PlayerTree onSelect={(entity, multiple) => void select(entity, !!multiple)} />
+          <EntityTree
+            value={CAMERA}
+            {...props}
+          />
+        </>
+      )}
       <EntityTree
         value={ROOT}
         {...props}

--- a/packages/inspector/src/components/Renderer/Metrics/Metrics.tsx
+++ b/packages/inspector/src/components/Renderer/Metrics/Metrics.tsx
@@ -12,6 +12,7 @@ import { withSdk } from '../../../hoc/withSdk';
 import { useChange } from '../../../hooks/sdk/useChange';
 import { useOutsideClick } from '../../../hooks/useOutsideClick';
 import { getLayoutManager } from '../../../lib/babylon/decentraland/layout-manager';
+import { isAltCompositeMode } from '../../../lib/data-layer/host/fs-utils';
 import type { Layout } from '../../../lib/utils/layout';
 import { GROUND_MESH_PREFIX, PARCEL_SIZE } from '../../../lib/utils/scene';
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
@@ -168,6 +169,15 @@ const Metrics = withSdk<WithSdkProps>(({ sdk }) => {
   }, [sdk, setSceneLayout]);
 
   const handleSceneChange = useCallback(() => {
+    // Alt composites (smart items, custom assets) have no scene parcels; out-of-bounds
+    // is meaningless and the layout manager has nothing to measure against.
+    if (isAltCompositeMode()) {
+      if (entitiesOutOfBoundaries.length > 0) {
+        dispatch(setEntitiesOutOfBoundaries([]));
+      }
+      return;
+    }
+
     const nodes = getNodes();
     const { isEntityOutsideLayout } = getLayoutManager(sdk.scene);
 
@@ -184,7 +194,7 @@ const Metrics = withSdk<WithSdkProps>(({ sdk }) => {
     });
 
     dispatch(setEntitiesOutOfBoundaries(entitiesOutOfBoundariesArray));
-  }, [sdk, dispatch, getNodes, setEntitiesOutOfBoundaries]);
+  }, [sdk, dispatch, getNodes, setEntitiesOutOfBoundaries, entitiesOutOfBoundaries]);
 
   useEffect(() => {
     const handleOutsideMaterialChange = (material: Material) => {

--- a/packages/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/inspector/src/components/Renderer/Renderer.tsx
@@ -105,8 +105,36 @@ const Renderer: React.FC = () => {
       if (layout) {
         layout.setEnabled(!groundGridDisabled && !altComposite);
       }
+      const spawnPoints = sdk.scene.getNodeByName('spawn_points');
+      if (spawnPoints) {
+        spawnPoints.setEnabled(!altComposite);
+      }
+      const backgroundPlane = sdk.scene.getMeshByName('BackgroundPlane');
+      if (backgroundPlane) {
+        backgroundPlane.setEnabled(!altComposite);
+      }
     }
   }, [sdk, groundGridDisabled, altComposite]);
+
+  // In alt-composite mode, frame the camera on the loaded item once its GLBs finish loading.
+  useEffect(() => {
+    if (!sdk || !altComposite) return;
+    let done = false;
+    const center = () => {
+      if (done) return;
+      const rootNode = sdk.sceneContext.rootNode;
+      const { min } = rootNode.getHierarchyBoundingVectors();
+      // Babylon returns MAX_VALUE for empty hierarchies — wait for at least one mesh.
+      if (min.x === Number.MAX_VALUE) return;
+      done = true;
+      sdk.editorCamera.centerViewOnEntity(rootNode);
+      sdk.scene.onDataLoadedObservable.remove(observer);
+    };
+    const observer = sdk.scene.onDataLoadedObservable.add(center);
+    return () => {
+      sdk.scene.onDataLoadedObservable.remove(observer);
+    };
+  }, [sdk, altComposite]);
 
   const deleteSelectedEntities = useCallback(() => {
     if (!sdk) return;

--- a/packages/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/inspector/src/components/Renderer/Renderer.tsx
@@ -5,7 +5,12 @@ import cx from 'classnames';
 import { Vector3 } from '@babylonjs/core';
 import type { Entity } from '@dcl/ecs';
 
-import { DIRECTORY, withAssetDir } from '../../lib/data-layer/host/fs-utils';
+import {
+  DIRECTORY,
+  getCompositeBaseFolder,
+  isAltCompositeMode,
+  withAssetDir,
+} from '../../lib/data-layer/host/fs-utils';
 import { getRelativeResourcePath, getResourcesBasePath } from '../../lib/utils/path-utils';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { getDataLayerInterface, getAssetCatalog, saveThumbnail } from '../../redux/data-layer';
@@ -92,14 +97,16 @@ const Renderer: React.FC = () => {
     }
   }, [sdk, gizmosDisabled]);
 
+  const altComposite = isAltCompositeMode();
+
   useEffect(() => {
     if (sdk) {
       const layout = sdk.scene.getNodeByName('layout');
       if (layout) {
-        layout.setEnabled(!groundGridDisabled);
+        layout.setEnabled(!groundGridDisabled && !altComposite);
       }
     }
-  }, [sdk, groundGridDisabled]);
+  }, [sdk, groundGridDisabled, altComposite]);
 
   const deleteSelectedEntities = useCallback(() => {
     if (!sdk) return;
@@ -277,6 +284,7 @@ const Renderer: React.FC = () => {
     const assetPackageName = asset.name.trim().replaceAll(' ', '_').toLowerCase();
     const position = await getDropPosition();
     const content: Map<string, Uint8Array> = new Map();
+    const compositeBaseFolder = altComposite ? getCompositeBaseFolder() : null;
 
     const dataLayer = getDataLayerInterface();
     if (!dataLayer) return;
@@ -314,7 +322,9 @@ const Renderer: React.FC = () => {
       asset: { type: 'gltf', src: '', id: asset.id },
       composite: asset.composite,
     };
-    const basePath = withAssetDir(`${destFolder}/${assetPackageName}`);
+    const basePath = compositeBaseFolder
+      ? `${compositeBaseFolder}/${assetPackageName}`
+      : withAssetDir(`${destFolder}/${assetPackageName}`);
 
     await dataLayer.importAsset({ content, basePath, assetPackageName: '' });
     dispatch(getAssetCatalog()); // Refresh catalog after import
@@ -349,6 +359,7 @@ const Renderer: React.FC = () => {
     const position = await getDropPosition();
     const fileContent: Record<string, Uint8Array> = {};
     const destFolder = 'asset-packs';
+    const compositeBaseFolder = altComposite ? getCompositeBaseFolder() : null;
     const assetPackageName = asset.name.trim().replaceAll(' ', '_').toLowerCase();
     const path = Object.keys(asset.contents).find($ => isAsset($));
     let thumbnail: Uint8Array | undefined;
@@ -380,7 +391,7 @@ const Renderer: React.FC = () => {
       if (dataLayer) {
         await dataLayer.importAsset({
           content,
-          basePath: withAssetDir(destFolder),
+          basePath: compositeBaseFolder ?? withAssetDir(destFolder),
           assetPackageName,
         });
         dispatch(getAssetCatalog()); // Refresh catalog after import
@@ -406,7 +417,9 @@ const Renderer: React.FC = () => {
       asset: { type: path ? 'gltf' : 'unknown', src: path ?? '', id: asset.id },
       composite: asset.composite,
     };
-    const basePath = withAssetDir(`${destFolder}/${assetPackageName}`);
+    const basePath = compositeBaseFolder
+      ? `${compositeBaseFolder}/${assetPackageName}`
+      : withAssetDir(`${destFolder}/${assetPackageName}`);
     if (isGround(asset) && !placeSingleTile) {
       await setGround(model, basePath);
     } else {

--- a/packages/inspector/src/hooks/sdk/useEntityComponent.ts
+++ b/packages/inspector/src/hooks/sdk/useEntityComponent.ts
@@ -6,6 +6,7 @@ import { CrdtMessageType } from '@dcl/ecs';
 import type { SdkContextValue } from '../../lib/sdk/context';
 import { CoreComponents, EditorComponentNames } from '../../lib/sdk/components';
 import { getConfig } from '../../lib/logic/config';
+import { isAltCompositeMode } from '../../lib/data-layer/host/fs-utils';
 import { CAMERA, EDITOR_ENTITIES, PLAYER, ROOT } from '../../lib/sdk/tree';
 import { useSdk } from './useSdk';
 import { useChange } from './useChange';
@@ -164,7 +165,10 @@ export const useEntityComponent = () => {
           })
           .sort((a, b) => a.name.localeCompare(b.name));
 
-        if (isRoot(entity)) {
+        // In alt composite mode the ROOT entity is the smart item's root — treat it
+        // like any other entity so users can attach Actions, Triggers, etc. to it.
+        const altRootUnlocked = isAltCompositeMode() && entity === ROOT;
+        if (isRoot(entity) && !altRootUnlocked) {
           available = available.filter(
             component =>
               Array.isArray(ROOT_COMPONENTS[entity]) &&

--- a/packages/inspector/src/hooks/sdk/useTree.ts
+++ b/packages/inspector/src/hooks/sdk/useTree.ts
@@ -13,6 +13,7 @@ import {
 import { debounce } from '../../lib/utils/debounce';
 import { getRoot } from '../../lib/sdk/nodes';
 import type { DropType } from '../../components/Tree/utils';
+import { isAltCompositeMode } from '../../lib/data-layer/host/fs-utils';
 import { useChange } from './useChange';
 import { useSdk } from './useSdk';
 
@@ -57,7 +58,12 @@ export const useTree = () => {
 
   const getLabel = useCallback(
     (entity: Entity) => {
-      if (entity === ROOT) return 'Scene';
+      if (entity === ROOT) {
+        if (!sdk) return 'Scene';
+        if (!isAltCompositeMode()) return 'Scene';
+        const { Name } = sdk.components;
+        return Name.has(entity) ? Name.get(entity).value : 'Scene';
+      }
       if (entity === PLAYER) return 'Player';
       if (entity === CAMERA) return 'Camera';
       if (!sdk) return entity.toString();

--- a/packages/inspector/src/hooks/sdk/useTree.ts
+++ b/packages/inspector/src/hooks/sdk/useTree.ts
@@ -137,9 +137,15 @@ export const useTree = () => {
 
   const rename = useCallback(
     async (entity: Entity, value: string) => {
-      if (entity === ROOT || !sdk) return;
+      if (!sdk) return;
+      // ROOT is renameable when editing an alt composite (the entity is the smart item's root).
+      if (entity === ROOT && !isAltCompositeMode()) return;
       const { Name } = sdk.components;
-      sdk.operations.updateValue(Name, entity, { value });
+      if (entity === ROOT && !Name.has(entity)) {
+        sdk.operations.addComponent(entity, Name.componentId, { value });
+      } else {
+        sdk.operations.updateValue(Name, entity, { value });
+      }
       await sdk.operations.dispatch();
       handleUpdate();
     },
@@ -207,7 +213,14 @@ export const useTree = () => {
     [],
   );
   const isNotRoot = useCallback((entity: Entity) => !isRoot(entity), []);
-  const canRename = isNotRoot;
+  const canRename = useCallback(
+    (entity: Entity) => {
+      // ROOT is renameable while editing an alt composite (it's the smart item's root entity).
+      if (entity === ROOT) return isAltCompositeMode();
+      return isNotRoot(entity);
+    },
+    [isNotRoot],
+  );
   const canRemove = isNotRoot;
   const canDuplicate = isNotRoot;
   const canDrag = isNotRoot;

--- a/packages/inspector/src/lib/babylon/decentraland/layout-manager.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/layout-manager.ts
@@ -14,6 +14,7 @@ import { memoize } from '../../logic/once';
 import type { Layout } from '../../utils/layout';
 import { inBounds } from '../../utils/layout';
 import { PARCEL_SIZE, GROUND_MESH_PREFIX } from '../../utils/scene';
+import { isAltCompositeMode } from '../../data-layer/host/fs-utils';
 import { createAxisIndicator } from './axis-indicator';
 
 function center(scene: Scene, layout: Layout) {
@@ -131,6 +132,10 @@ export const getLayoutManager = memoize((scene: Scene) => {
   }
 
   function isEntityOutsideLayout(mesh: AbstractMesh) {
+    // Alt composites (smart items, custom assets) aren't constrained by scene parcels;
+    // every entity would otherwise read as outside the (hidden) layout.
+    if (isAltCompositeMode()) return false;
+
     const layoutBoundingBox = getLayoutBoundingBox();
     const meshBoundingBox = mesh.getBoundingInfo().boundingBox;
 

--- a/packages/inspector/src/lib/data-layer/host/composite-provider.ts
+++ b/packages/inspector/src/lib/data-layer/host/composite-provider.ts
@@ -1,7 +1,11 @@
 import type { Scene } from '@dcl/schemas';
 import type { CompositeDefinition, Entity, IEngine } from '@dcl/ecs';
 import { Composite, CrdtMessageType, EntityMappingMode } from '@dcl/ecs';
-import { initComponents, migrateAll as migrateAllAssetPacksComponents } from '@dcl/asset-packs';
+import {
+  COMPONENTS_WITH_ID,
+  initComponents,
+  migrateAll as migrateAllAssetPacksComponents,
+} from '@dcl/asset-packs';
 import type { EditorComponents } from '../../sdk/components';
 import { EditorComponentNames } from '../../sdk/components';
 import { migrateAll as migrateAllInspectorComponents } from '../../sdk/components/versioning/registry';
@@ -99,8 +103,24 @@ export class CompositeProvider implements StateProvider {
   private async loadComposite(): Promise<void> {
     if (!this.compositeManager) throw new Error('Composite manager not initialized');
 
-    const loadedCompositeResource = this.compositeManager.getCompositeOrNull(this.compositePath);
-    if (!loadedCompositeResource) throw new Error('Invalid composite');
+    let loadedCompositeResource = this.compositeManager.getCompositeOrNull(this.compositePath);
+    if (!loadedCompositeResource) {
+      // Alt composite files (e.g. composite.json under assets/custom or assets/asset-packs)
+      // are not picked up by the default `.composite`-only scan. Read and parse them directly,
+      // resolving smart-item placeholders ({self}, {self:Component}, {N:Component}) so the
+      // engine receives only numeric ids.
+      try {
+        const buffer = await this.fs.readFile(this.compositePath);
+        const json = JSON.parse(new TextDecoder().decode(buffer));
+        const resolved = resolveCompositePlaceholders(json);
+        loadedCompositeResource = {
+          src: this.compositePath,
+          composite: Composite.fromJson(resolved),
+        };
+      } catch (err) {
+        throw new Error(`Invalid composite at ${this.compositePath}: ${(err as Error).message}`);
+      }
+    }
 
     console.log('Loading composite into engine...');
 
@@ -270,4 +290,81 @@ export class CompositeProvider implements StateProvider {
     this.composite = null;
     this.compositeManager = null;
   }
+}
+
+const SELF_REF = /^\{self:(.+)\}$/;
+const CROSS_REF = /^\{(\d+):(.+)\}$/;
+const COUNTER_COMPONENT = 'asset-packs::Counter';
+
+function resolveCompositePlaceholders(json: any): any {
+  if (!json || !Array.isArray(json.components)) return json;
+  const clone = JSON.parse(JSON.stringify(json));
+  const idMap = new Map<string, number>();
+
+  // Initialize id counter from existing Counter.value on the root entity (0), if present.
+  // We mirror getNextId's contract (Counter.getOrCreateMutable(RootEntity); ++counter.value)
+  // but locally so we don't mutate the engine before Composite.instance runs.
+  let counter = 0;
+  const counterComponent = clone.components.find((c: any) => c.name === COUNTER_COMPONENT);
+  const rootCounterValue = Number(counterComponent?.data?.['0']?.json?.value);
+  if (Number.isFinite(rootCounterValue)) counter = rootCounterValue;
+
+  for (const component of clone.components) {
+    if (!COMPONENTS_WITH_ID.includes(component.name) || !component.data) continue;
+    for (const [entityId, dataEntry] of Object.entries<any>(component.data)) {
+      const value = dataEntry?.json;
+      if (value && value.id === '{self}') {
+        const newId = ++counter;
+        idMap.set(`${component.name}:${entityId}`, newId);
+        value.id = newId;
+      }
+    }
+  }
+
+  // Persist the final counter back on entity 0 so the engine's Counter.value
+  // continues allocating from the right spot after Composite.instance loads.
+  if (counterComponent) {
+    counterComponent.data = counterComponent.data ?? {};
+    const rootEntry = counterComponent.data['0'] ?? { json: { id: 0, value: 0 } };
+    rootEntry.json = rootEntry.json ?? {};
+    rootEntry.json.value = counter;
+    if (rootEntry.json.id === undefined) rootEntry.json.id = 0;
+    counterComponent.data['0'] = rootEntry;
+  }
+
+  const resolve = (val: any, entityId: string): any => {
+    if (val === null || val === undefined) return val;
+    if (typeof val === 'string') {
+      if (val === '{self}') return Number(entityId);
+      const self = val.match(SELF_REF);
+      if (self) {
+        const mapped = idMap.get(`${self[1]}:${entityId}`);
+        return mapped ?? val;
+      }
+      const cross = val.match(CROSS_REF);
+      if (cross) {
+        const mapped = idMap.get(`${cross[2]}:${cross[1]}`);
+        return mapped ?? val;
+      }
+      return val;
+    }
+    if (Array.isArray(val)) return val.map(v => resolve(v, entityId));
+    if (typeof val === 'object') {
+      const out: any = {};
+      for (const [k, v] of Object.entries(val)) out[k] = resolve(v, entityId);
+      return out;
+    }
+    return val;
+  };
+
+  for (const component of clone.components) {
+    if (!component.data) continue;
+    for (const [entityId, dataEntry] of Object.entries<any>(component.data)) {
+      if (dataEntry?.json) {
+        dataEntry.json = resolve(dataEntry.json, entityId);
+      }
+    }
+  }
+
+  return clone;
 }

--- a/packages/inspector/src/lib/data-layer/host/composite-provider.ts
+++ b/packages/inspector/src/lib/data-layer/host/composite-provider.ts
@@ -14,7 +14,7 @@ import { getMinimalComposite } from '../client/feeded-local-fs';
 import type { InspectorPreferences } from '../../logic/preferences/types';
 import { buildNodesHierarchyIfNotExists } from './utils/migrations/build-nodes-hierarchy';
 import { removeLegacyEntityNodeComponents } from './utils/migrations/legacy-entity-node';
-import { DIRECTORY, withAssetDir } from './fs-utils';
+import { DIRECTORY, getCompositeBaseFolder, withAssetDir } from './fs-utils';
 import { dumpEngineToComposite, generateEntityNamesType } from './utils/engine-to-composite';
 import type { CompositeManager } from './utils/fs-composite-provider';
 import { createFsCompositeProvider } from './utils/fs-composite-provider';
@@ -112,7 +112,8 @@ export class CompositeProvider implements StateProvider {
       try {
         const buffer = await this.fs.readFile(this.compositePath);
         const json = JSON.parse(new TextDecoder().decode(buffer));
-        const resolved = resolveCompositePlaceholders(json);
+        const base = getCompositeBaseFolder(this.compositePath);
+        const resolved = resolveCompositePlaceholders(json, this.engine, base);
         loadedCompositeResource = {
           src: this.compositePath,
           composite: Composite.fromJson(resolved),
@@ -295,8 +296,9 @@ export class CompositeProvider implements StateProvider {
 const SELF_REF = /^\{self:(.+)\}$/;
 const CROSS_REF = /^\{(\d+):(.+)\}$/;
 const COUNTER_COMPONENT = 'asset-packs::Counter';
+const SYNC_COMPONENTS_COMPONENT = 'core-schema::Sync-Components';
 
-function resolveCompositePlaceholders(json: any): any {
+function resolveCompositePlaceholders(json: any, engine: IEngine, assetBasePath: string): any {
   if (!json || !Array.isArray(json.components)) return json;
   const clone = JSON.parse(JSON.stringify(json));
   const idMap = new Map<string, number>();
@@ -332,6 +334,35 @@ function resolveCompositePlaceholders(json: any): any {
     counterComponent.data['0'] = rootEntry;
   }
 
+  // Resolve SyncComponents.componentIds entries that are stored as component
+  // name strings (template form) into their numeric component ids. Mirrors
+  // what parseSyncComponents does at add-asset time.
+  const syncComponent = clone.components.find((c: any) => c.name === SYNC_COMPONENTS_COMPONENT);
+  if (syncComponent?.data) {
+    for (const dataEntry of Object.values<any>(syncComponent.data)) {
+      const value = dataEntry?.json;
+      const ids = value?.componentIds ?? value?.value;
+      if (!Array.isArray(ids)) continue;
+      const resolved: number[] = [];
+      for (const id of ids) {
+        if (typeof id === 'number') {
+          resolved.push(id);
+          continue;
+        }
+        if (typeof id === 'string') {
+          try {
+            const component = engine.getComponent(id);
+            resolved.push(component.componentId);
+          } catch {
+            // component not registered in this engine — drop it, same as parseSyncComponents.
+          }
+        }
+      }
+      value.componentIds = resolved;
+      if ('value' in value) delete value.value;
+    }
+  }
+
   const resolve = (val: any, entityId: string): any => {
     if (val === null || val === undefined) return val;
     if (typeof val === 'string') {
@@ -345,6 +376,9 @@ function resolveCompositePlaceholders(json: any): any {
       if (cross) {
         const mapped = idMap.get(`${cross[2]}:${cross[1]}`);
         return mapped ?? val;
+      }
+      if (val.includes('{assetPath}')) {
+        return val.split('{assetPath}').join(assetBasePath);
       }
       return val;
     }

--- a/packages/inspector/src/lib/data-layer/host/fs-utils.ts
+++ b/packages/inspector/src/lib/data-layer/host/fs-utils.ts
@@ -80,8 +80,33 @@ export function isFileInAssetDir(filePath: string = '') {
   return filePath.startsWith(DIRECTORY.ASSETS);
 }
 
+export const MAIN_COMPOSITE_PATH = withAssetDir(`${DIRECTORY.SCENE}/main.composite`);
+
+function readCompositePathFromUrl(): string | null {
+  try {
+    const search = globalThis?.location?.search;
+    if (!search) return null;
+    return new URLSearchParams(search).get('compositePath');
+  } catch {
+    return null;
+  }
+}
+
 export function getCurrentCompositePath() {
-  return withAssetDir(`${DIRECTORY.SCENE}/main.composite`);
+  const override = readCompositePathFromUrl();
+  if (override && override !== MAIN_COMPOSITE_PATH) {
+    return override;
+  }
+  return MAIN_COMPOSITE_PATH;
+}
+
+export function isAltCompositeMode() {
+  return getCurrentCompositePath() !== MAIN_COMPOSITE_PATH;
+}
+
+export function getCompositeBaseFolder(compositePath: string = getCurrentCompositePath()) {
+  const idx = compositePath.lastIndexOf('/');
+  return idx >= 0 ? compositePath.slice(0, idx) : '';
 }
 
 export function transformBinaryToBase64Resource(content: Uint8Array): string {

--- a/packages/inspector/src/lib/logic/config.ts
+++ b/packages/inspector/src/lib/logic/config.ts
@@ -11,6 +11,7 @@ export type InspectorConfig = {
   segmentKey: string | null;
   projectId: string | null;
   catalystBaseUrl: string | null;
+  compositePath: string | null;
 };
 
 export type GlobalWithConfig = typeof globalThis & {
@@ -42,5 +43,6 @@ export function getConfig(): InspectorConfig {
     segmentKey: params.get('segmentKey') || config?.segmentKey || null,
     projectId: params.get('projectId') || config?.projectId || null,
     catalystBaseUrl: params.get('catalystBaseUrl') || config?.catalystBaseUrl || CATALYST_BASE_URL,
+    compositePath: params.get('compositePath') || config?.compositePath || null,
   };
 }


### PR DESCRIPTION
## Summary

Adds a dropdown next to the scene name that lets you pick a composite file other than `main.composite`. The selected composite is what the inspector edits.

<img width="1399" height="999" alt="Screenshot 2026-05-21 at 3 17 16 PM" src="https://github.com/user-attachments/assets/6cc276bb-31b0-4261-9dbe-62fc3d2d8e1c" />

These alternative composites are meant to describe items that can be added dynamically to a scene at runtime via [js-sdk-toolchain#1333](https://github.com/decentraland/js-sdk-toolchain/pull/1333). Changing a composite doesn't retroactively update instances already placed in `main.composite`, but it affects any new ones spawned dynamically once the scene starts.

## What the dropdown does

- Lists every composite file under `assets/` (main scene + alt composites discovered by recursive scan, with corrupted `composite.json` files filtered out).
- **Create New Composite…** prompts for a name and scaffolds `assets/custom/<slug>/composite.json` with a single `core-schema::Name` component on the root entity.
- **Manage Composites…** opens a modal where each alt composite has a kebab menu with **Duplicate…** (copies the whole folder and strips any `data.json` so the duplicate gets its own identity) and **Delete** (removes just the composite file; assets in the same folder are kept).

## What's different when editing an alternative composite

Scene-level concepts don't apply when you're authoring a single item, so the UI hides or repurposes them:

- The parcel grid is hidden, and Babylon's `BackgroundPlane` ground is disabled so the item isn't half-buried at y=0.
- Spawn-point visuals (`spawn_points` node) are disabled.
- The Player and Camera entities, the spawn-point tree, and `SceneInspector` are not rendered.
- Out-of-bounds detection is short-circuited (`isEntityOutsideLayout` returns false), so no entities get the yellow "outside layout" material or warning icons.
- Thumbnail screenshots are skipped on Back / Publish / Deploy — those buttons still publish the whole project, they just don't snapshot the alt-composite view.
- The camera frames the loaded item via `editorCamera.centerViewOnEntity(sceneContext.rootNode)` on the first `onDataLoadedObservable` fire.
- The root entity:
  - Shows its `Name` component value as the label (falls back to "Scene" if absent).
  - Can be renamed via right-click → Rename or the entity header's More Options menu.
  - Accepts any component from the AddComponent dropdown (the `ROOT_COMPOSITE` filter is bypassed for ROOT in alt mode).
  - Has no Transform by default — it's just an empty entity the user can build out.

## Asset placement

When dropping assets while editing an alt composite, files go into the composite's folder rather than the project-wide `assets/asset-packs` / `assets/custom`:

- Catalog assets land at `<compositeBaseFolder>/<assetPackageName>/`.
- Custom-item drops land at `<compositeBaseFolder>/<assetPackageName>/`.
- New scripts created via the Script component land at `<compositeBaseFolder>/Scripts/`.

## Loading alt composites into the engine

Alt-composite files (`composite.json` under `assets/custom/...` or `assets/asset-packs/...`) aren't picked up by the existing `.composite`-only scan, so `composite-provider.ts` falls back to reading them directly and resolving smart-item placeholders before handing them to `Composite.fromJson`:

- `{self}` → numeric component id allocated from a counter seeded from the existing `Counter.value` on entity 0 (and the final value is written back into the composite JSON before instancing, so we don't mutate the engine before `Composite.instance` runs).
- `{self:ComponentName}` / `{N:ComponentName}` → resolved against the same id map.
- `core-schema::Sync-Components.componentIds` entries that are stored as component name strings → resolved to numeric component ids via `engine.getComponent(name).componentId` (mirroring `parseSyncComponents` from add-asset). Unregistered components are dropped rather than crashing the stream.
- `{assetPath}` → replaced with the composite's parent folder in every string in the composite, including JSON-encoded action payloads like `'{"src":"{assetPath}/fireworkexplode.mp3"}'`.

## Test plan

- [ ] Open an existing project — dropdown shows "Main scene"; everything else behaves like main.
- [ ] Click **Create New Composite…**, enter a name, confirm — new folder appears under `assets/custom/<slug>/`, the inspector reloads into the new composite, and the root entity is labeled with the name you typed.
- [ ] In the new alt composite: drop a smart item (e.g. confetti), drop a custom item, create a script — all files land under `assets/custom/<slug>/`.
- [ ] Verify the alt-composite UI: no grid, no ground, no out-of-bounds warnings, no Player/Camera entries, no spawn points, no scene metadata inspector, camera frames the item.
- [ ] Right-click the root entity → **Rename** works; the entity header shows the **+** AddComponent dropdown for the root.
- [ ] Open an asset-packs composite (e.g. `assets/asset-packs/confetti/composite.json`) — placeholders resolve, GLBs load, no `BigInt` errors.
- [ ] Open **Manage Composites…** → kebab menu shows **Duplicate…** and **Delete**. Duplicate creates a new folder; the resulting composite shows up in the dropdown. Delete removes the composite file and keeps sibling assets.
- [ ] Switch back to **Main scene** — grid returns, spawn points render, out-of-bounds works again, all main-scene behavior unchanged.
- [ ] Run **Preview** / **Publish** — no behavior change; thumbnails skipped only when alt composite is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)