### PR TITLE
fix: inspector startup errors and flaky E2E in CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,14 @@ branches that pin `@dcl/*` packages to SDK-toolchain tarball URLs (syncpack
 reports `UnsupportedMismatch`). When this happens, run `npm run lint:fix`
 directly to skip syncpack and still get ESLint autofixes.
 
+**Note:** npm won't repair a missing transitive lockfile node. When `npm ls` /
+a build's `ELSPROBLEMS` reports a transitive dep `missing` (e.g. `buffer-crc32`
+under the `@dcl/sdk-commands` tarball subtree), a plain `npm install` will NOT
+add it — npm trusts the existing lockfile and reports "up to date". Add the
+`node_modules/<dep>` package node to `package-lock.json` directly (version +
+registry `resolved`/`integrity`), then `npm install`/`npm ci` to reify it. Since
+the parent packages declare the dep, the node then sticks.
+
 ### Protocol Buffers
 
 Proto files live at `packages/inspector/src/lib/data-layer/proto/`. After modifying `.proto` files:

--- a/docs/testing-standards.md
+++ b/docs/testing-standards.md
@@ -64,3 +64,15 @@ machine and self-document what the test is gating on.
 Examples in `packages/inspector/test/e2e/pageObjects/Hierarchy.ts`:
 `waitForLabel`, the post-`duplicate` count-change wait, the post-`remove`
 detach wait.
+
+### Run each E2E spec file in its own forked process
+
+`vitest.e2e.config.js` uses `pool: 'forks'` with `singleFork: false` **and**
+`fileParallelism: false`: each spec file runs in a fresh forked process, one at
+a time. Do not set `singleFork: true` — sharing one long-lived worker across all
+files accumulates Chromium/Babylon native memory until the CI runner kills the
+process. The signature is `Error: Worker exited unexpectedly` at a *moving*
+spec-file boundary (every test that ran passed; no V8 heap-OOM message) — it
+reads like flakiness but is memory exhaustion, so raising `--max-old-space-size`
+won't help. A fresh process per file reclaims memory; sequential execution keeps
+only one headless Chromium alive at a time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8636,6 +8636,16 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "dev": true,

--- a/packages/inspector/build.js
+++ b/packages/inspector/build.js
@@ -43,10 +43,11 @@ async function main() {
 
   if (WATCH_MODE) {
     await context.watch();
-    let { host, port } = await context.serve({
+    let { hosts, port } = await context.serve({
+      host: 'localhost',
       servedir: 'public',
     });
-    console.log(`> Serving on http://${host}:${port}`);
+    console.log(`> Serving on http://${hosts[0] ?? 'localhost'}:${port}`);
   } else {
     console.time('> Building browser bundle');
     await context.rebuild();
@@ -122,8 +123,13 @@ function runTypeChecker() {
 }
 
 function getNotBundledModules() {
-  // || true is added because `npm ls` fails installing a package from S3
-  const child = child_process.execSync('npm ls --all --json || true', {});
+  // || true is added because `npm ls` fails installing a package from S3.
+  // stderr is muted so harmless transitive-dependency warnings don't pollute
+  // the dev server output; stdout stays piped for JSON.parse below.
+  const child = child_process.execSync('npm ls --all --json || true', {
+    stdio: ['ignore', 'pipe', 'ignore'],
+    maxBuffer: 64 * 1024 * 1024,
+  });
   const ret = JSON.parse(child.toString());
 
   const externalModules = new Set();

--- a/packages/inspector/test/e2e/setup.ts
+++ b/packages/inspector/test/e2e/setup.ts
@@ -92,5 +92,14 @@ beforeAll(async () => {
 }, 120000);
 
 afterAll(async () => {
-  await browser?.close();
+  try {
+    await page?.close();
+  } catch {
+    // ignore teardown errors so they don't cascade into the next spec file
+  }
+  try {
+    await browser?.close();
+  } catch {
+    // ignore teardown errors so they don't cascade into the next spec file
+  }
 });

--- a/packages/inspector/vitest.e2e.config.js
+++ b/packages/inspector/vitest.e2e.config.js
@@ -16,9 +16,16 @@ export default defineConfig({
     pool: 'forks', // use forks instead of threads for better isolation
     poolOptions: {
       forks: {
-        singleFork: true,
+        // Each spec file runs in its own fresh forked process. A single shared
+        // worker (singleFork: true) accumulated Chromium/Babylon native memory
+        // across files until the OS killed it mid-run in CI ("Worker exited
+        // unexpectedly"); a fresh process per file reclaims that memory.
+        singleFork: false,
       },
     },
+    // Run spec files one at a time so only one headless Chromium is alive at
+    // once (avoids N concurrent browsers, which would be worse than the bug).
+    fileParallelism: false,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Context and Problem Statement

Two independent problems, diagnosed from source and real CI logs:

1. **Inspector `npm run start` printed errors and a broken URL.** It logged `npm error code ELSPROBLEMS` / `missing: buffer-crc32` and `> Serving on http://undefined:8000`.
   - The `undefined` host: installed esbuild is **0.28.0**, whose `context.serve()` returns `{ port, hosts }` — the code destructured the old, removed `host` field.
   - The `buffer-crc32` noise: `buffer-crc32` is declared by `archiver`/`compress-commons` but had **no package record** in `package-lock.json`, so npm never installed it and `npm ls` (run by `build.js`) flagged it missing. `execSync` also forwards the child's stderr by default, leaking the warning into the dev-server output.

2. **The inspector E2E job failed in CI "for a different reason each time," not a timeout.** From CI logs the failure was `Error: Worker exited unexpectedly` at a *moving* spec-file boundary — every test that ran passed. The suite ran all spec files in one forked worker (`singleFork: true`), accumulating Chromium/Babylon native memory until the runner killed the process (no V8 heap-OOM message → native/RSS pressure, so `--max-old-space-size` wouldn't help).

## Solution

Key changes:
- **`build.js`**: use esbuild 0.28's `hosts[0]` (pass `host: 'localhost'`) so the served URL is clickable; mute the `npm ls` diagnostic stderr.
- **`package-lock.json`**: add the missing `buffer-crc32@0.2.13` transitive node so it installs and `npm ls` resolves clean (no `package.json` change).
- **`vitest.e2e.config.js`**: `singleFork: false` + `fileParallelism: false` — each spec file runs in its own fresh forked process, sequentially, reclaiming native memory between files while keeping only one headless Chromium alive at a time.
- **`test/e2e/setup.ts`**: hardened `afterAll` teardown so a close error can't cascade into the next file.
- Documented both root causes in `docs/testing-standards.md` and `CLAUDE.md`.

## Testing

- [x] Inspector `npm run start` is clean: no `ELSPROBLEMS`/`buffer-crc32`, serves a clickable URL (no `undefined`)
- [x] `npm ls buffer-crc32` resolves cleanly
- [x] Inspector E2E suite passes locally with the new config (`CI=1`): 4 files, 22 tests, no `Worker exited unexpectedly`
- [x] Inspector unit tests: 587 passed
- [x] Lint + format clean on changed files; typecheck passes (pre-commit hook)
- [ ] CI `tests / E2E (macos-latest)` job green (re-run once or twice to confirm stability, since the crash was nondeterministic)

## Impact

Developer-facing only: a clean inspector dev-server startup and a reliable E2E job in CI. No runtime/user-facing behavior changes. `buffer-crc32` was only reachable via `@dcl/sdk-commands`' `pack-smart-wearable` zip path (never the inspector), so installing it completes that toolchain without affecting anything else.

## Screenshots

N/A (tooling/CI fix, no UI changes).