### PR TITLE
chore: Sign In E2E tests

### DIFF
--- a/packages/creator-hub/e2e/e2e.spec.ts
+++ b/packages/creator-hub/e2e/e2e.spec.ts
@@ -1,42 +1,13 @@
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
 import type { ElectronApplication, JSHandle } from 'playwright';
-import { _electron as electron } from 'playwright';
 import { afterAll, beforeAll, expect, test } from 'vitest';
 import type { BrowserWindow } from 'electron';
-
-const electronPath = require('electron') as string;
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const creatorHubDir = join(__dirname, '..');
+import { launchApp } from './helpers/app';
 
 let electronApp: ElectronApplication;
-
-/**
- * Cold-launching Electron is the slowest, most run-to-run-variable step on a
- * contended CI runner. Retry a couple of times so a single spawn/CDP-connect
- * hiccup doesn't fail the whole suite. `timeout` is Playwright's own launch
- * timeout (default 30s); the beforeAll hook gets a larger budget on top.
- */
-async function launchApp(attempts = 3): Promise<ElectronApplication> {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    try {
-      return await electron.launch({
-        executablePath: electronPath,
-        args: ['.'],
-        cwd: creatorHubDir,
-        timeout: 60_000,
-      });
-    } catch (error) {
-      lastError = error;
-      console.warn(`[e2e] Electron launch attempt ${attempt}/${attempts} failed:`, error);
-    }
-  }
-  throw lastError;
-}
+let cleanup: () => void;
 
 beforeAll(async () => {
-  electronApp = await launchApp();
+  ({ electronApp, cleanup } = await launchApp());
 }, 120_000);
 
 afterAll(async () => {
@@ -44,6 +15,8 @@ afterAll(async () => {
     await electronApp?.close();
   } catch {
     // ignore teardown errors so they don't cascade into the next spec file
+  } finally {
+    cleanup?.();
   }
 });
 

--- a/packages/creator-hub/e2e/helpers/app.ts
+++ b/packages/creator-hub/e2e/helpers/app.ts
@@ -1,0 +1,63 @@
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import type { ElectronApplication } from 'playwright';
+import { _electron as electron } from 'playwright';
+
+const electronPath = require('electron') as string;
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the creator-hub package root (where the built app lives). */
+export const creatorHubDir = join(__dirname, '..', '..');
+
+/**
+ * A launched app together with the throwaway user-data directory it was given.
+ * Callers must `cleanup()` in their teardown to remove the temp directory.
+ */
+export type LaunchedApp = {
+  electronApp: ElectronApplication;
+  /** Removes the throwaway user-data directory. Safe to call more than once. */
+  cleanup: () => void;
+};
+
+/**
+ * Cold-launching Electron is the slowest, most run-to-run-variable step on a
+ * contended CI runner. Retry a couple of times so a single spawn/CDP-connect
+ * hiccup doesn't fail the whole suite. `timeout` is Playwright's own launch
+ * timeout (default 30s); the beforeAll hook gets a larger budget on top.
+ *
+ * Each launch gets a fresh, throwaway `--user-data-dir` so tests never depend on
+ * (or pollute) the developer's real profile — otherwise a persisted sign-in
+ * identity leaks in and the app starts already logged in, breaking any test that
+ * assumes a logged-out starting state.
+ */
+export async function launchApp(attempts = 3): Promise<LaunchedApp> {
+  const userDataDir = mkdtempSync(join(tmpdir(), 'creator-hub-e2e-'));
+  const cleanup = () => {
+    try {
+      rmSync(userDataDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors — the OS reclaims the temp dir eventually
+    }
+  };
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const electronApp = await electron.launch({
+        executablePath: electronPath,
+        args: ['.', `--user-data-dir=${userDataDir}`],
+        cwd: creatorHubDir,
+        timeout: 60_000,
+      });
+      return { electronApp, cleanup };
+    } catch (error) {
+      lastError = error;
+      console.warn(`[e2e] Electron launch attempt ${attempt}/${attempts} failed:`, error);
+    }
+  }
+
+  cleanup();
+  throw lastError;
+}

--- a/packages/creator-hub/e2e/helpers/auth.ts
+++ b/packages/creator-hub/e2e/helpers/auth.ts
@@ -1,0 +1,108 @@
+import type { ElectronApplication, Page } from 'playwright';
+
+/**
+ * A valid 40-hex ethereum address used as the signed-in account in tests. The
+ * single-sign-on client validates the address against `/^0x[a-fA-F0-9]{40}$/`
+ * before persisting the identity, so this must be a well-formed address.
+ */
+export const MOCK_ADDRESS = '0x1234567890123456789012345678901234567890';
+
+/**
+ * A well-formed identity as returned by the auth server's
+ * `GET /identities/:id` endpoint. `fetchIdentity` reads `authChain[0].payload`
+ * as the signer address, and the SSO client only persists the identity when
+ * `expiration` is in the future — so both must be present and valid.
+ */
+export function buildMockIdentity(address: string = MOCK_ADDRESS) {
+  return {
+    expiration: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    ephemeralIdentity: { address },
+    authChain: [{ type: 'SIGNER', payload: address, signature: '' }],
+  };
+}
+
+export type AuthMockOptions = {
+  /** The requestId the stubbed `POST /requests` returns. */
+  requestId?: string;
+  /** The address the stubbed identity resolves to. */
+  address?: string;
+};
+
+type RecordedFetch = { url: string; method: string; body: string | null };
+
+/**
+ * Installs the sign-in mocks into the page: stubs the auth server (`window.fetch`
+ * for `/requests` and `/identities/:id`) and records browser-open calls
+ * (`window.open`) instead of opening anything. Recorded data is read back via
+ * {@link getOpenCalls} and {@link getFetchCalls}. Mocks only the external
+ * boundaries — all in-repo logic runs for real.
+ */
+export async function installAuthMocks(page: Page, options: AuthMockOptions = {}): Promise<void> {
+  const requestId = options.requestId ?? 'e2e-request-id';
+  const identity = buildMockIdentity(options.address ?? MOCK_ADDRESS);
+
+  await page.evaluate(
+    ({ requestId, identity }) => {
+      const w = window as any;
+      w.__e2eOpenCalls = [];
+      w.__e2eFetchCalls = [];
+
+      // Capture the auth dapp URL instead of opening a real browser window.
+      w.open = (url?: string) => {
+        w.__e2eOpenCalls.push(url ?? '');
+        return null;
+      };
+
+      // Stub only the auth-server endpoints; pass everything else through.
+      const realFetch = w.fetch.bind(w);
+      w.fetch = async (input: any, init?: any) => {
+        const url = typeof input === 'string' ? input : (input?.url ?? String(input));
+        const method = (init?.method ?? 'GET').toUpperCase();
+        const body = init?.body ?? null;
+
+        if (url.includes('/requests') && method === 'POST') {
+          w.__e2eFetchCalls.push({ url, method, body });
+          return new Response(JSON.stringify({ requestId }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        if (url.includes('/identities/')) {
+          w.__e2eFetchCalls.push({ url, method, body });
+          return new Response(JSON.stringify({ identity }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        return realFetch(input, init);
+      };
+    },
+    { requestId, identity },
+  );
+}
+
+/** Reads the recorded `window.open` URLs. */
+export function getOpenCalls(page: Page): Promise<string[]> {
+  return page.evaluate(() => (window as any).__e2eOpenCalls ?? []);
+}
+
+/** Reads the recorded auth-server fetch calls. */
+export function getFetchCalls(page: Page): Promise<RecordedFetch[]> {
+  return page.evaluate(() => (window as any).__e2eFetchCalls ?? []);
+}
+
+/**
+ * Fires a sign-in deeplink at the running app through the real macOS entry
+ * point (`open-url`), which the main process handles and forwards to the
+ * renderer over IPC — exercising the full deeplink path.
+ */
+export async function fireSignInDeeplink(
+  electronApp: ElectronApplication,
+  identityId: string,
+): Promise<void> {
+  await electronApp.evaluate(({ app }, url) => {
+    app.emit('open-url', { preventDefault() {} }, url);
+  }, `dcl-creator-hub://open?signin=${identityId}`);
+}

--- a/packages/creator-hub/e2e/pageObjects/Auth.ts
+++ b/packages/creator-hub/e2e/pageObjects/Auth.ts
@@ -1,0 +1,70 @@
+import type { Page } from 'playwright';
+
+/**
+ * Page object for the sign-in flow. The interactive elements the tests drive
+ * (header sign-in / avatar / sign-out) are keyed off `data-testid` set on the
+ * UserMenu component — a bare ".SignInButton" is ambiguous (the logged-out
+ * HomePage renders one inside its SignInCard too) and a structural selector
+ * would break on layout changes. The sign-in page carries its own `data-testid`
+ * too — its `.SignIn` class is purely presentational and could be renamed by a
+ * style refactor, so the test asserts against an explicit contract instead.
+ *
+ * `#UserMenu` stays id-based: that id is load-bearing (the avatar button's
+ * `aria-controls` / the menu's `aria-labelledby` reference it), so it is already
+ * a stable contract and a parallel test-id would be redundant. This matches the
+ * inspector e2e suite's hybrid convention.
+ *
+ * The renderer uses a MemoryRouter, so there is no URL to assert against — auth
+ * state is observed through the rendered DOM.
+ */
+class AuthPageObject {
+  private readonly signInButtonSelector = '[data-testid="user-menu-sign-in"]';
+  private readonly avatarButtonSelector = '[data-testid="user-menu-avatar-button"]';
+  private readonly signOutMenuItemSelector = '[data-testid="user-menu-sign-out"]';
+  private readonly userMenuSelector = '#UserMenu';
+  private readonly signInPageSelector = '[data-testid="sign-in-page"]';
+
+  /** Waits until the renderer has rendered the main content. */
+  async waitUntilReady(page: Page) {
+    await page.waitForSelector('#app main.Main', { state: 'visible' });
+  }
+
+  /** Waits for and clicks the header "Sign In" button. */
+  async clickSignIn(page: Page) {
+    await page.locator(this.signInButtonSelector).click();
+  }
+
+  /** True when the logged-out "Sign In" button is visible in the header. */
+  async isSignInButtonVisible(page: Page) {
+    return page.locator(this.signInButtonSelector).isVisible();
+  }
+
+  /** Waits for the sign-in (waiting-for-browser) page to be visible. */
+  async waitForSignInPage(page: Page) {
+    await page.waitForSelector(this.signInPageSelector, { state: 'visible' });
+  }
+
+  /** True when the sign-in page is currently visible. */
+  async isSignInPageVisible(page: Page) {
+    return page.locator(this.signInPageSelector).isVisible();
+  }
+
+  /** Waits for the signed-in state (avatar button in the header). */
+  async waitForSignedIn(page: Page) {
+    await page.waitForSelector(this.avatarButtonSelector, { state: 'visible' });
+  }
+
+  /** True when the signed-in avatar button is visible in the header. */
+  async isSignedIn(page: Page) {
+    return page.locator(this.avatarButtonSelector).isVisible();
+  }
+
+  /** Opens the user menu and clicks "Sign Out". */
+  async signOut(page: Page) {
+    await page.locator(this.avatarButtonSelector).click();
+    await page.waitForSelector(this.userMenuSelector, { state: 'visible' });
+    await page.locator(this.signOutMenuItemSelector).click();
+  }
+}
+
+export const Auth = new AuthPageObject();

--- a/packages/creator-hub/e2e/sign-in.spec.ts
+++ b/packages/creator-hub/e2e/sign-in.spec.ts
@@ -1,0 +1,97 @@
+import type { ElectronApplication, Page } from 'playwright';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { launchApp } from './helpers/app';
+import {
+  MOCK_ADDRESS,
+  fireSignInDeeplink,
+  getFetchCalls,
+  getOpenCalls,
+  installAuthMocks,
+} from './helpers/auth';
+import { Auth } from './pageObjects/Auth';
+
+const REQUEST_ID = 'e2e-request-id';
+const IDENTITY_ID = 'e2e-identity-id';
+
+let electronApp: ElectronApplication;
+let cleanup: () => void;
+let page: Page;
+
+/**
+ * Happy-path sign-in e2e. The auth server (HTTP) and the browser-open are the
+ * only external boundaries — both are mocked from the page via runtime
+ * injection. Everything else (AuthProvider orchestration, the preload IPC
+ * bridge, the main-process deeplink parsing/dispatch, identity persistence)
+ * runs for real against the built app.
+ *
+ * The tests form a dependent chain (open → request → deeplink → signed in) and
+ * share a single Electron instance, since cold-launching is the slow,
+ * flaky step.
+ */
+describe('sign in (happy path)', () => {
+  beforeAll(async () => {
+    ({ electronApp, cleanup } = await launchApp());
+    page = await electronApp.firstWindow();
+    await Auth.waitUntilReady(page);
+    await installAuthMocks(page, { requestId: REQUEST_ID, address: MOCK_ADDRESS });
+  }, 120_000);
+
+  afterAll(async () => {
+    try {
+      await electronApp?.close();
+    } catch {
+      // ignore teardown errors so they don't cascade into the next spec file
+    } finally {
+      cleanup?.();
+    }
+  });
+
+  test('shows the Sign In button when logged out', async () => {
+    expect(await Auth.isSignInButtonVisible(page), 'Sign In button not visible').toBe(true);
+    expect(await Auth.isSignedIn(page), 'Avatar button should not be visible yet').toBe(false);
+  });
+
+  test('opens the auth dapp with deeplink params on sign in', async () => {
+    await Auth.clickSignIn(page);
+    await Auth.waitForSignInPage(page);
+
+    const openCalls = await getOpenCalls(page);
+    expect(openCalls, 'window.open was not called').toHaveLength(1);
+    const url = openCalls[0];
+    expect(url).toContain(`/requests/${REQUEST_ID}`);
+    expect(url).toContain('targetConfigId=creator-hub');
+    expect(url).toContain('flow=deeplink');
+  });
+
+  test('creates the sign in request against the auth server', async () => {
+    const fetchCalls = await getFetchCalls(page);
+    const requestCall = fetchCalls.find(c => c.url.includes('/requests') && c.method === 'POST');
+    expect(requestCall, 'POST /requests was not made').toBeDefined();
+    expect(requestCall!.body, 'request body missing').toBeTruthy();
+    const parsed = JSON.parse(requestCall!.body as string);
+    expect(parsed.method).toBe('dcl_personal_sign');
+
+    // The requestId returned by the stub is the one used to open the dapp.
+    const openCalls = await getOpenCalls(page);
+    expect(openCalls[0]).toContain(`/requests/${REQUEST_ID}`);
+  });
+
+  test('completes sign in when the deeplink arrives', async () => {
+    await fireSignInDeeplink(electronApp, IDENTITY_ID);
+
+    await Auth.waitForSignedIn(page);
+    expect(await Auth.isSignedIn(page), 'Avatar button not visible after sign in').toBe(true);
+
+    // The sign-in page is left once sign in completes (navigate(-1)).
+    expect(await Auth.isSignInPageVisible(page), 'Sign In page should be gone').toBe(false);
+
+    // The identity fetch happened and the signer address was persisted.
+    const fetchCalls = await getFetchCalls(page);
+    expect(fetchCalls.some(c => c.url.includes(`/identities/${IDENTITY_ID}`))).toBe(true);
+
+    const storedAddress = await page.evaluate(() =>
+      window.localStorage.getItem('auth-server-provider-address'),
+    );
+    expect(storedAddress).toBe(MOCK_ADDRESS.toLowerCase());
+  });
+});

--- a/packages/creator-hub/renderer/src/components/Header/UserMenu/component.tsx
+++ b/packages/creator-hub/renderer/src/components/Header/UserMenu/component.tsx
@@ -23,6 +23,7 @@ export function UserMenu({ avatar, isSignedIn, onClickSignOut, onClickSignIn }: 
       <Button
         id="AvatarButton"
         className="AvatarButton"
+        data-testid="user-menu-avatar-button"
         aria-controls={open ? 'UserMenu' : undefined}
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
@@ -43,12 +44,18 @@ export function UserMenu({ avatar, isSignedIn, onClickSignOut, onClickSignIn }: 
           'aria-labelledby': 'AvatarButton',
         }}
       >
-        <MenuItem onClick={onClickSignOut}>{t('navbar.user_menu.sign_out')}</MenuItem>
+        <MenuItem
+          data-testid="user-menu-sign-out"
+          onClick={onClickSignOut}
+        >
+          {t('navbar.user_menu.sign_out')}
+        </MenuItem>
       </Menu>
     </>
   ) : (
     <Button
       className="SignInButton"
+      data-testid="user-menu-sign-in"
       onClick={onClickSignIn}
       variant="contained"
       disableRipple

--- a/packages/creator-hub/renderer/src/components/SignInPage/component.tsx
+++ b/packages/creator-hub/renderer/src/components/SignInPage/component.tsx
@@ -51,6 +51,7 @@ export function SignInPage() {
   return (
     <Grid
       className="SignIn"
+      data-testid="sign-in-page"
       container
       direction="row"
       alignItems="center"


### PR DESCRIPTION
# chore: Sign In E2E tests

## Context and Problem Statement

The sign-in flow (auth request → browser open → deeplink callback → identity persistence) had no end-to-end test coverage. Regressions in the AuthProvider orchestration, preload IPC bridge, main-process deeplink parsing, or identity persistence could ship undetected.

## Solution

Adds a full happy-path E2E test suite for the sign-in flow. Only the external boundaries (auth server HTTP calls and browser-open) are mocked via runtime injection — everything else (AuthProvider, IPC bridge, deeplink dispatch, localStorage persistence) runs against the real built app.

Key changes:
- **`helpers/app.ts`** — Extracts and improves the `launchApp` helper from `e2e.spec.ts`. Each launch now gets a fresh throwaway `--user-data-dir` so tests always start logged out and never pollute the developer's real profile.
- **`helpers/auth.ts`** — Auth mock utilities that stub `window.fetch` (for `POST /requests` and `GET /identities/:id`) and `window.open` (captures the auth dapp URL). Also provides `fireSignInDeeplink()` to emit a deeplink through the real `open-url` main-process handler.
- **`pageObjects/Auth.ts`** — Page object encapsulating sign-in UI interactions (sign-in button, avatar button, sign-out menu item, sign-in page), keyed off `data-testid` attributes for stability.
- **`sign-in.spec.ts`** — Four-test happy-path suite: verifies logged-out state → auth dapp opens with correct params → `POST /requests` fires with `dcl_personal_sign` → deeplink completes sign-in and persists the signer address.
- **`data-testid` attributes** — Added to `UserMenu` (`user-menu-sign-in`, `user-menu-avatar-button`, `user-menu-sign-out`) and `SignInPage` (`sign-in-page`) components for stable test selectors.

## Testing

- [x] Happy-path sign-in: logged-out → click Sign In → auth dapp URL opened → deeplink callback → signed-in state with correct address persisted
- [x] Existing `e2e.spec.ts` updated to use the shared `launchApp` helper with isolated user-data dir
- [x] Auth server mock stubs only `/requests` and `/identities/` — all other fetches pass through to real handlers

## Impact

No user-facing changes. Adds `data-testid` attributes to three components for test stability — these are invisible to end users.