### PR TITLE
Bevy gizmo tweaks

### DIFF
--- a/packages/inspector/agents/bevy/src/gizmo.tsx
+++ b/packages/inspector/agents/bevy/src/gizmo.tsx
@@ -92,10 +92,9 @@ const isPlaneKey = (a: Axis | 'xyz' | PlaneKey): a is PlaneKey =>
 
 /** Whether the gizmo handles follow the entity's rotation instead of the world
  * axes: scale always does (per-axis scaling is only meaningful on local axes);
- * translate does when the "align to world" checkbox is off. Rotate rings stay
- * world-aligned. */
+ * translate and rotate do when the "align to world" checkbox is off. */
 function isGizmoLocallyAligned(): boolean {
-  return gizmoMode === 'scale' || (gizmoMode === 'translate' && !alignToWorld);
+  return gizmoMode === 'scale' || !alignToWorld;
 }
 
 /** The world-space direction of a gizmo axis handle (rotated into the entity's
@@ -138,6 +137,16 @@ let selectedPos: Vector3 | null = null;
 let selectedRot: Quaternion = Quaternion.Identity();
 // The toolbar's "align to world" checkbox (inspector-supplied via set-selection).
 let alignToWorld = true;
+// The editor's snap increments (position: world units, rotation: radians,
+// scale: factor) when snapping is on, else null. Inspector-supplied via
+// set-selection. Drags quantize their feedback + committed deltas to these; the
+// inspector re-snaps the merged Transform authoritatively on commit.
+let snap: { position: number; rotation: number; scale: number } | null = null;
+
+/** Quantize `value` to multiples of `step` (no-op for step ≤ 0). */
+function snapStep(value: number, step: number): number {
+  return step > 0 ? Math.round(value / step) * step : value;
+}
 // Which gizmo the inspector wants shown (translate/rotate/scale/free).
 let gizmoMode: GizmoMode = 'translate';
 // Scene-local → engine-world offset (base parcel × 16m). The inspector renders
@@ -244,6 +253,7 @@ export function setSelectedEntity(
   mode: GizmoMode = 'translate',
   rotation: { x: number; y: number; z: number; w: number } | null = null,
   worldAligned: boolean = true,
+  snapValues: { position: number; rotation: number; scale: number } | null = null,
 ): void {
   selected = entity !== null && entity !== 0 ? (entity as Entity) : null;
   selectedPos =
@@ -255,6 +265,7 @@ export function setSelectedEntity(
       ? Quaternion.create(rotation.x, rotation.y, rotation.z, rotation.w)
       : Quaternion.Identity();
   alignToWorld = worldAligned;
+  snap = snapValues;
   gizmoMode = mode;
   // Show handles for translate / rotate / scale; `free` shows none.
   const supported = mode === 'translate' || mode === 'rotate' || mode === 'scale';
@@ -707,7 +718,8 @@ function pickScaleHandleAnalytic(ray: { origin: Vector3; dir: Vector3 }): Axis |
 
 /** Analytic rotate grab: which ring the pointer ray meets (hit on the axis plane
  * within a tolerance band around the ring radius), or null. The ring for `axis`
- * lies in the plane through the center with normal = axis. */
+ * lies in the plane through the center with normal = the handle axis (world, or
+ * the entity's rotated axis when locally aligned). */
 function pickRotateAxisAnalytic(ray: { origin: Vector3; dir: Vector3 }): Axis | null {
   if (selectedPos === null) return null;
   const scale = cameraDistanceScale(selectedPos);
@@ -716,7 +728,7 @@ function pickRotateAxisAnalytic(ray: { origin: Vector3; dir: Vector3 }): Axis | 
   let best: Axis | null = null;
   let bestErr = Infinity;
   for (const axis of AXES) {
-    const n = axisVec(axis);
+    const n = gizmoAxisDir(axis);
     const hit = rayPlaneIntersect(ray.origin, ray.dir, selectedPos, n);
     if (hit === null) continue;
     const r = Vector3.distance(hit, selectedPos);
@@ -729,12 +741,13 @@ function pickRotateAxisAnalytic(ray: { origin: Vector3; dir: Vector3 }): Axis | 
   return best;
 }
 
-/** The angle (radians) of `hit` around `center` in the plane ⊥ `axis`, measured
- * in a stable basis so successive frames compare consistently. */
-function angleOnRing(hit: Vector3, center: Vector3, axis: Axis): number {
-  const n = axisVec(axis);
-  // Two orthonormal in-plane basis vectors (u, v) with u×v = n.
-  const ref = axis === 'y' ? Vector3.Forward() : Vector3.Up();
+/** The angle (radians) of `hit` around `center` in the plane ⊥ `n` (the ring's
+ * world normal), measured in a stable basis so successive frames compare
+ * consistently. */
+function angleOnRing(hit: Vector3, center: Vector3, n: Vector3): number {
+  // Two orthonormal in-plane basis vectors (u, v) with u×v = n; the reference
+  // just needs to not be parallel to n.
+  const ref = Math.abs(n.y) > 0.99 ? Vector3.Forward() : Vector3.Up();
   const u = Vector3.normalize(Vector3.cross(ref, n));
   const v = Vector3.cross(n, u);
   const d = Vector3.subtract(hit, center);
@@ -926,15 +939,16 @@ function beginDrag(axis: Axis | 'xyz' | PlaneKey): void {
   }
 
   if (gizmoMode === 'rotate') {
-    // Rotate: drag in the ring's plane (normal = the axis). Record the start
-    // angle around the ring; the drag tracks the swept angle.
-    const planeNormal = axisVec(axis);
+    // Rotate: drag in the ring's plane (normal = the handle axis — world, or the
+    // entity's rotated axis when locally aligned). Record the start angle around
+    // the ring; the drag tracks the swept angle about that world-space normal.
+    const planeNormal = gizmoAxisDir(axis);
     const startHit = rayPlaneIntersect(ray.origin, ray.dir, center, planeNormal);
     if (startHit === null) return;
     drag = {
       mode: 'rotate',
       axis,
-      axisDir: axisVec(axis),
+      axisDir: planeNormal,
       center,
       planeNormal,
       startHit,
@@ -981,21 +995,24 @@ function updateDrag(): void {
   if (hit === null) return;
 
   if (drag.mode === 'rotate' && isAxis(drag.axis)) {
-    // Swept angle since drag start, unwrapped across the ±π seam so a drag past
-    // half a turn keeps accumulating instead of flipping sign.
-    const startAngle = angleOnRing(drag.startHit, drag.center, drag.axis);
-    const nowAngle = angleOnRing(hit, drag.center, drag.axis);
+    // Swept angle since drag start about the ring's world normal, unwrapped
+    // across the ±π seam so a drag past half a turn keeps accumulating instead
+    // of flipping sign. `drag.angle` keeps the RAW angle (so unwrapping stays
+    // continuous); snapping applies to what's shown and committed.
+    const startAngle = angleOnRing(drag.startHit, drag.center, drag.axisDir);
+    const nowAngle = angleOnRing(hit, drag.center, drag.axisDir);
     let delta = nowAngle - startAngle;
     const prev = drag.angle ?? 0;
     while (delta - prev > Math.PI) delta -= Math.PI * 2;
     while (delta - prev < -Math.PI) delta += Math.PI * 2;
     drag.angle = delta;
-    // Spin the whole gizmo visual about the axis for feedback.
+    // Spin the whole gizmo visual about the ring normal for feedback, on top of
+    // its base orientation (the entity's rotation when locally aligned).
     if (gizmoRoot !== null) {
-      Transform.getMutable(gizmoRoot).rotation = Quaternion.fromAngleAxis(
-        (delta * 180) / Math.PI,
-        axisVec(drag.axis),
-      );
+      const shown = snap !== null ? snapStep(delta, snap.rotation) : delta;
+      const spin = Quaternion.fromAngleAxis((shown * 180) / Math.PI, drag.axisDir);
+      const base = isGizmoLocallyAligned() ? selectedRot : Quaternion.Identity();
+      Transform.getMutable(gizmoRoot).rotation = Quaternion.multiply(spin, base);
     }
     return;
   }
@@ -1010,7 +1027,8 @@ function updateDrag(): void {
         ? 1 +
           Vector3.dot(Vector3.subtract(hit, drag.startHit), drag.axisDir) / (drag.startAlong ?? 1)
         : Vector3.dot(Vector3.subtract(hit, drag.center), drag.axisDir) / (drag.startAlong ?? 1);
-    const factor = Math.min(Math.max(raw, 0.01), 100);
+    const snapped = snap !== null ? snapStep(raw, snap.scale) : raw;
+    const factor = Math.min(Math.max(snapped, 0.01), 100);
     drag.factor = factor;
     // Feedback: stretch the handle(s) along their axis (each container is
     // axis-oriented with +Y along the axis, so scale Y). Per-axis stretches only
@@ -1028,10 +1046,25 @@ function updateDrag(): void {
 
   const worldDelta = Vector3.subtract(hit, drag.startHit);
   // Plane handle: take the whole in-plane delta (both hits lie on the drag
-  // plane). Axis arm: project the delta onto the arm's direction.
-  const newPos = isPlaneKey(drag.axis)
-    ? Vector3.add(drag.center, worldDelta)
-    : Vector3.add(drag.center, Vector3.scale(drag.axisDir, Vector3.dot(worldDelta, drag.axisDir)));
+  // plane), snapping each in-plane component. Axis arm: project the delta onto
+  // the arm's direction, snapping the along-axis distance.
+  let newPos: Vector3;
+  if (isPlaneKey(drag.axis)) {
+    let delta = worldDelta;
+    if (snap !== null) {
+      const [a0, a1] = PLANE_AXES[drag.axis];
+      const du = gizmoAxisDir(a0);
+      const dv = gizmoAxisDir(a1);
+      const u = snapStep(Vector3.dot(worldDelta, du), snap.position);
+      const v = snapStep(Vector3.dot(worldDelta, dv), snap.position);
+      delta = Vector3.add(Vector3.scale(du, u), Vector3.scale(dv, v));
+    }
+    newPos = Vector3.add(drag.center, delta);
+  } else {
+    const rawAlong = Vector3.dot(worldDelta, drag.axisDir);
+    const along = snap !== null ? snapStep(rawAlong, snap.position) : rawAlong;
+    newPos = Vector3.add(drag.center, Vector3.scale(drag.axisDir, along));
+  }
   dragPos = newPos;
 
   // Move only the gizmo visual during the drag (feedback); the entity itself is
@@ -1047,15 +1080,23 @@ function endDrag(): void {
   if (d === null || selected === null) return;
 
   if (d.mode === 'rotate' && isAxis(d.axis)) {
-    const angle = d.angle ?? 0;
-    // Reset the gizmo visual (the entity's real rotation updates via the commit,
-    // flows back over the CRDT, and the inspector re-anchors the gizmo).
-    if (gizmoRoot !== null) Transform.getMutable(gizmoRoot).rotation = Quaternion.Identity();
+    const raw = d.angle ?? 0;
+    const angle = snap !== null ? snapStep(raw, snap.rotation) : raw;
+    // Reset the gizmo visual to its base orientation (the entity's real rotation
+    // updates via the commit, flows back over the CRDT, and the inspector
+    // re-anchors + re-aligns the gizmo).
+    if (gizmoRoot !== null) {
+      Transform.getMutable(gizmoRoot).rotation = isGizmoLocallyAligned()
+        ? { ...selectedRot }
+        : Quaternion.Identity();
+    }
     if (Math.abs(angle) < 1e-4) return; // no-op drag → nothing to commit
-    // Commit a DELTA rotation about the axis; the inspector composes it onto the
-    // entity's current rotation (the agent can't read that base). Rotation is
-    // orientation-only, so — unlike position — no scene-offset conversion.
-    const delta = Quaternion.fromAngleAxis((angle * 180) / Math.PI, axisVec(d.axis));
+    // Commit a WORLD-frame DELTA rotation about the ring's world normal (the
+    // entity's rotated axis when locally aligned); the inspector composes it
+    // onto the entity's current rotation as delta ⊗ current (the agent can't
+    // read that base). Rotation is orientation-only, so — unlike position — no
+    // scene-offset conversion.
+    const delta = Quaternion.fromAngleAxis((angle * 180) / Math.PI, d.axisDir);
     bus.postToPage({
       kind: 'gizmoCommit',
       transforms: [

--- a/packages/inspector/agents/bevy/src/gizmo.tsx
+++ b/packages/inspector/agents/bevy/src/gizmo.tsx
@@ -268,18 +268,26 @@ export function setSelectedEntity(
   snap = snapValues;
   gizmoMode = mode;
   // Show handles for translate / rotate / scale; `free` shows none.
-  const supported = mode === 'translate' || mode === 'rotate' || mode === 'scale';
-  if (selected === null || selectedPos === null || !supported) {
+  if (selected === null || selectedPos === null || !isSupportedMode(mode)) {
     hideGizmo();
   } else {
     setModeVisibility();
   }
 }
 
+/** Modes that draw handles (`free` draws none — the gizmo stays hidden). */
+function isSupportedMode(mode: GizmoMode): boolean {
+  return mode === 'translate' || mode === 'rotate' || mode === 'scale';
+}
+
 export function setupGizmo(): void {
   picker = engine.addEntity();
   Transform.create(picker);
   buildGizmo();
+  // Initialize per-mode handle visibility: buildGizmo creates EVERY handle group
+  // visible (scale One), so without this the first anchored frame would show all
+  // three gizmos overlapping until a mode change toggles the groups.
+  setModeVisibility();
   setupGizmoCamera();
   hideGizmo();
   engine.addSystem(gizmoSystem);
@@ -793,8 +801,10 @@ function gizmoSystemInner(): void {
   }
 
   // Position + scale the gizmo on the selected entity each frame (the inspector
-  // supplied selectedPos; during a drag we update it locally below).
-  if (selected !== null && selectedPos !== null && drag === null) {
+  // supplied selectedPos; during a drag we update it locally below). Only for
+  // modes that draw handles: re-anchoring in `free` mode would undo hideGizmo's
+  // park and show whatever groups happen to be visible.
+  if (selected !== null && selectedPos !== null && drag === null && isSupportedMode(gizmoMode)) {
     const t = Transform.getMutable(gizmoRoot);
     t.position = { ...selectedPos };
     // Orient the handles to the entity's rotation when locally aligned (scale

--- a/packages/inspector/agents/bevy/src/gizmo.tsx
+++ b/packages/inspector/agents/bevy/src/gizmo.tsx
@@ -37,10 +37,10 @@ import { bus } from './bus';
  * write — matching the IRenderer reverse-channel contract (renderer previews,
  * inspector commits).
  *
- * The selected entity's world position is SUPPLIED BY THE INSPECTOR over the bus
- * (set-selection), because a super-user agent can't read another scene's
- * Transform from its own engine. Scope: translate only, no rotate/scale, no
- * TextureCamera composite (handles render in the world, not on-top).
+ * The selected entity's world position + rotation are SUPPLIED BY THE INSPECTOR
+ * over the bus (set-selection), because a super-user agent can't read another
+ * scene's Transform from its own engine. Translate, rotate and scale gizmos are
+ * supported; handles composite on top of the viewport via a TextureCamera.
  */
 
 type Axis = 'x' | 'y' | 'z';
@@ -67,6 +67,13 @@ const AXIS_COLOR: Record<Axis, Color4> = {
 const axisVec = (a: Axis): Vector3 =>
   a === 'x' ? Vector3.Right() : a === 'y' ? Vector3.Up() : Vector3.Forward();
 
+/** The world-space direction of a gizmo axis handle. Scale handles follow the
+ * entity's rotation (see the selectedRot note); translate/rotate handles are
+ * world axes. */
+function gizmoAxisDir(a: Axis): Vector3 {
+  return gizmoMode === 'scale' ? Vector3.rotate(axisVec(a), selectedRot) : axisVec(a);
+}
+
 let gizmoRoot: Entity | null = null;
 // Translate arm containers + rotate ring containers, per axis. Shown/hidden by
 // mode (setModeVisibility): translate shows the arms, rotate shows the rings.
@@ -84,12 +91,21 @@ const RING_SEG_R = 0.03;
 // Scale handle geometry: a short axis shaft capped with a cube (vs translate's
 // arrow), grabbed like the translate arm; drag distance → per-axis multiplier.
 const SCALE_BOX = 0.18;
+// The white cube at the scale gizmo's center: dragging it scales all three axes
+// proportionally (matching the Babylon ScaleGizmo's uniform-scale center cube).
+const SCALE_CENTER_BOX = 0.25;
+let scaleCenterGroup: Entity | null = null;
 let selected: Entity | null = null;
 // The selected entity's world position, supplied by the inspector (the agent
 // can't read the inspected scene's Transform). The gizmo's anchor.
 let selectedPos: Vector3 | null = null;
-// Which gizmo the inspector wants shown (translate/rotate/scale/free). Only
-// `translate` draws handles today; rotate/scale are later slices.
+// The selected entity's world rotation (inspector-supplied, like selectedPos).
+// The SCALE gizmo aligns its handles to this — always, independent of any
+// align-to-world setting, because per-axis scaling only makes sense on the
+// entity's LOCAL axes (the committed multiplier applies to local scale).
+// Translate/rotate handles stay world-aligned.
+let selectedRot: Quaternion = Quaternion.Identity();
+// Which gizmo the inspector wants shown (translate/rotate/scale/free).
 let gizmoMode: GizmoMode = 'translate';
 // Scene-local → engine-world offset (base parcel × 16m). The inspector renders
 // every scene at the ORIGIN (SceneContext.rootNode at 0,0,0), so the positions
@@ -101,14 +117,21 @@ let rayTs = 0;
 
 interface DragState {
   mode: 'translate' | 'rotate' | 'scale';
-  axis: Axis;
+  // 'xyz' = the scale gizmo's center cube (uniform scale on all three axes).
+  axis: Axis | 'xyz';
+  // World-space direction the drag projects onto, captured at grab time:
+  // the world axis (translate), the entity-local axis (scale), or the camera's
+  // up-right diagonal (uniform scale). Frozen for the whole drag so a mid-drag
+  // selection repost can't change the math under the pointer.
+  axisDir: Vector3;
   center: Vector3; // entity world position at drag start
   planeNormal: Vector3;
   startHit: Vector3;
   // Rotate only: the signed angle (radians) swept so far, about `axis`.
   angle?: number;
-  // Scale only: the along-axis offset of the start hit from center, and the
-  // current scale factor for the axis (committed on release).
+  // Scale only: the along-axis offset of the start hit from center (per-axis) or
+  // the normalizing arm length (uniform), and the current scale factor
+  // (committed on release).
   startAlong?: number;
   factor?: number;
 }
@@ -178,17 +201,23 @@ export function getGroundPointAtPointer(): { x: number; y: number; z: number } |
 }
 
 /** Attach the gizmo to an entity at a scene-local position (or hide when null).
- * The scene offset is added so it lands in the engine's world space. */
+ * The scene offset is added so it lands in the engine's world space. The world
+ * rotation orients the scale gizmo's handles (rotation is offset-free). */
 export function setSelectedEntity(
   entity: number | null,
   position: { x: number; y: number; z: number } | null,
   mode: GizmoMode = 'translate',
+  rotation: { x: number; y: number; z: number; w: number } | null = null,
 ): void {
   selected = entity !== null && entity !== 0 ? (entity as Entity) : null;
   selectedPos =
     selected !== null && position
       ? Vector3.add(Vector3.create(position.x, position.y, position.z), sceneOffset)
       : null;
+  selectedRot =
+    selected !== null && rotation
+      ? Quaternion.create(rotation.x, rotation.y, rotation.z, rotation.w)
+      : Quaternion.Identity();
   gizmoMode = mode;
   // Show handles for translate / rotate / scale; `free` shows none.
   const supported = mode === 'translate' || mode === 'rotate' || mode === 'scale';
@@ -296,6 +325,30 @@ function buildGizmo(): void {
     buildRotateRing(root, axis);
     buildScaleHandle(root, axis);
   }
+  buildScaleCenter(root);
+}
+
+/**
+ * The scale gizmo's white center cube: dragging it scales all three axes
+ * proportionally. Grab is analytic (ray-vs-center distance in
+ * pickScaleHandleAnalytic), so no collider. Shown only in scale mode.
+ */
+function buildScaleCenter(root: Entity): void {
+  const group = engine.addEntity();
+  Transform.create(group, { parent: root });
+  scaleCenterGroup = group;
+
+  const cube = engine.addEntity();
+  Transform.create(cube, {
+    scale: Vector3.create(SCALE_CENTER_BOX, SCALE_CENTER_BOX, SCALE_CENTER_BOX),
+    parent: group,
+  });
+  MeshRenderer.setBox(cube);
+  Material.setPbrMaterial(cube, {
+    albedoColor: Color4.White(),
+    emissiveColor: Color3.White(),
+    emissiveIntensity: 0.4,
+  });
 }
 
 /**
@@ -396,6 +449,9 @@ function setModeVisibility(): void {
         Transform.getMutable(group).scale = gizmoMode === mode ? shown : hidden;
     }
   }
+  if (scaleCenterGroup !== null) {
+    Transform.getMutable(scaleCenterGroup).scale = gizmoMode === 'scale' ? shown : hidden;
+  }
 }
 
 function hideGizmo(): void {
@@ -474,7 +530,8 @@ function raySegmentDistance(
 
 /** Analytic grab: which axis arm the pointer ray is closest to (within a
  * screen-scaled tolerance), or null. Anchored at the gizmo center (selectedPos),
- * arms extend `SHAFT_LEN * scale` along each world axis. */
+ * arms extend `SHAFT_LEN * scale` along each handle axis (world for translate,
+ * entity-local for scale — gizmoAxisDir). */
 function pickAxisAnalytic(ray: { origin: Vector3; dir: Vector3 }): Axis | null {
   if (selectedPos === null) return null;
   const scale = cameraDistanceScale(selectedPos);
@@ -485,7 +542,7 @@ function pickAxisAnalytic(ray: { origin: Vector3; dir: Vector3 }): Axis | null {
   let best: Axis | null = null;
   let bestDist = Infinity;
   for (const axis of AXES) {
-    const end = Vector3.add(selectedPos, Vector3.scale(axisVec(axis), armLen));
+    const end = Vector3.add(selectedPos, Vector3.scale(gizmoAxisDir(axis), armLen));
     const { dist } = raySegmentDistance(ray.origin, ray.dir, selectedPos, end);
     if (dist <= tol && dist < bestDist) {
       bestDist = dist;
@@ -493,6 +550,27 @@ function pickAxisAnalytic(ray: { origin: Vector3; dir: Vector3 }): Axis | null {
     }
   }
   return best;
+}
+
+/** Closest distance between a ray (origin, unit dir, t≥0) and a point. */
+function rayPointDistance(origin: Vector3, dir: Vector3, p: Vector3): number {
+  const toP = Vector3.subtract(p, origin);
+  const t = Vector3.dot(toP, dir);
+  if (t < 0) return Vector3.length(toP); // point is behind the ray
+  return Vector3.distance(Vector3.add(origin, Vector3.scale(dir, t)), p);
+}
+
+/** Analytic scale grab: the center cube ('xyz', uniform scale) or an axis arm.
+ * The center is tested FIRST — every arm starts at the center, so near the
+ * middle all three arms are within the arm tolerance and would shadow it. */
+function pickScaleHandleAnalytic(ray: { origin: Vector3; dir: Vector3 }): Axis | 'xyz' | null {
+  if (selectedPos === null) return null;
+  const scale = cameraDistanceScale(selectedPos);
+  // Forgiving, screen-constant grab radius around the center cube (~1.4× its
+  // half-diagonal), same hand-aimed-click reasoning as the arm tolerance.
+  const centerTol = SCALE_CENTER_BOX * 1.4 * scale;
+  if (rayPointDistance(ray.origin, ray.dir, selectedPos) <= centerTol) return 'xyz';
+  return pickAxisAnalytic(ray);
 }
 
 /** Analytic rotate grab: which ring the pointer ray meets (hit on the axis plane
@@ -574,7 +652,9 @@ function gizmoSystemInner(): void {
   if (selected !== null && selectedPos !== null && drag === null) {
     const t = Transform.getMutable(gizmoRoot);
     t.position = { ...selectedPos };
-    t.rotation = Quaternion.Identity();
+    // Scale mode: orient the handles to the entity's rotation (always — see the
+    // selectedRot note). Translate/rotate stay world-aligned.
+    t.rotation = gizmoMode === 'scale' ? { ...selectedRot } : Quaternion.Identity();
     const s = cameraDistanceScale(selectedPos);
     t.scale = Vector3.create(s, s, s);
   }
@@ -596,7 +676,9 @@ function gizmoSystemInner(): void {
           ? null
           : gizmoMode === 'rotate'
             ? pickRotateAxisAnalytic(ray)
-            : pickAxisAnalytic(ray);
+            : gizmoMode === 'scale'
+              ? pickScaleHandleAnalytic(ray)
+              : pickAxisAnalytic(ray);
       if (grabbedAxis !== null) {
         beginDrag(grabbedAxis);
       } else {
@@ -664,11 +746,40 @@ function isGizmoHandle(id: number): boolean {
   return false;
 }
 
-function beginDrag(axis: Axis): void {
+function beginDrag(axis: Axis | 'xyz'): void {
   if (selected === null || selectedPos === null) return;
   const center = { ...selectedPos };
   const ray = pointerRay();
   if (ray === null) return;
+  const camT = Transform.getOrNull(engine.CameraEntity);
+  const camForward =
+    camT === null ? Vector3.Forward() : Vector3.rotate(Vector3.Forward(), camT.rotation);
+
+  if (axis === 'xyz') {
+    // Uniform scale (the center cube): drag in the camera-facing plane through
+    // the center; motion along the camera's up-right diagonal drives the factor
+    // (right/up grows, left/down shrinks — matching the Babylon center cube).
+    const camRight =
+      camT === null ? Vector3.Right() : Vector3.rotate(Vector3.Right(), camT.rotation);
+    const camUp = camT === null ? Vector3.Up() : Vector3.rotate(Vector3.Up(), camT.rotation);
+    const refDir = Vector3.normalize(Vector3.add(camRight, camUp));
+    const planeNormal = camForward;
+    const startHit = rayPlaneIntersect(ray.origin, ray.dir, center, planeNormal);
+    if (startHit === null) return;
+    drag = {
+      mode: 'scale',
+      axis,
+      axisDir: refDir,
+      center,
+      planeNormal,
+      startHit,
+      // Normalize the drag by the arm length so the feel is camera-distance
+      // invariant: dragging one arm-length up-right doubles the scale.
+      startAlong: SHAFT_LEN * cameraDistanceScale(center),
+      factor: 1,
+    };
+    return;
+  }
 
   if (gizmoMode === 'rotate') {
     // Rotate: drag in the ring's plane (normal = the axis). Record the start
@@ -676,17 +787,23 @@ function beginDrag(axis: Axis): void {
     const planeNormal = axisVec(axis);
     const startHit = rayPlaneIntersect(ray.origin, ray.dir, center, planeNormal);
     if (startHit === null) return;
-    drag = { mode: 'rotate', axis, center, planeNormal, startHit, angle: 0 };
+    drag = {
+      mode: 'rotate',
+      axis,
+      axisDir: axisVec(axis),
+      center,
+      planeNormal,
+      startHit,
+      angle: 0,
+    };
     return;
   }
 
   // Translate + scale: drag in a plane containing the axis and most facing the
   // camera, projecting the pointer onto the axis. They differ only in what the
   // along-axis motion means (position offset vs scale factor).
-  const camT = Transform.getOrNull(engine.CameraEntity);
-  const camForward =
-    camT === null ? Vector3.Forward() : Vector3.rotate(Vector3.Forward(), camT.rotation);
-  const planeNormal = axisDragPlaneNormal(axisVec(axis), camForward);
+  const axisDir = gizmoAxisDir(axis);
+  const planeNormal = axisDragPlaneNormal(axisDir, camForward);
   const startHit = rayPlaneIntersect(ray.origin, ray.dir, center, planeNormal);
   if (startHit === null) return;
 
@@ -694,10 +811,11 @@ function beginDrag(axis: Axis): void {
     // Distance from center to the grab point along the axis = the "current arm
     // length"; the factor is (current distance / start distance), so dragging
     // outward grows and inward shrinks. Clamp start away from 0 to avoid blow-up.
-    const startAlong = Vector3.dot(Vector3.subtract(startHit, center), axisVec(axis));
+    const startAlong = Vector3.dot(Vector3.subtract(startHit, center), axisDir);
     drag = {
       mode: 'scale',
       axis,
+      axisDir,
       center,
       planeNormal,
       startHit,
@@ -707,7 +825,7 @@ function beginDrag(axis: Axis): void {
     return;
   }
 
-  drag = { mode: 'translate', axis, center, planeNormal, startHit };
+  drag = { mode: 'translate', axis, axisDir, center, planeNormal, startHit };
   dragPos = center;
 }
 
@@ -718,7 +836,7 @@ function updateDrag(): void {
   const hit = rayPlaneIntersect(ray.origin, ray.dir, drag.center, drag.planeNormal);
   if (hit === null) return;
 
-  if (drag.mode === 'rotate') {
+  if (drag.mode === 'rotate' && drag.axis !== 'xyz') {
     // Swept angle since drag start, unwrapped across the ±π seam so a drag past
     // half a turn keeps accumulating instead of flipping sign.
     const startAngle = angleOnRing(drag.startHit, drag.center, drag.axis);
@@ -739,21 +857,33 @@ function updateDrag(): void {
   }
 
   if (drag.mode === 'scale') {
-    // Factor = current along-axis distance / start distance. Dragging the handle
-    // outward grows, inward shrinks; clamp to keep the factor positive + sane.
-    const nowAlong = Vector3.dot(Vector3.subtract(hit, drag.center), axisVec(drag.axis));
-    const raw = nowAlong / (drag.startAlong ?? 1);
+    // Per-axis: factor = current along-axis distance / start distance (dragging
+    // the handle outward grows, inward shrinks). Uniform ('xyz'): factor = 1 +
+    // motion along the camera's up-right diagonal / arm length. Clamp to keep
+    // the factor positive + sane.
+    const raw =
+      drag.axis === 'xyz'
+        ? 1 +
+          Vector3.dot(Vector3.subtract(hit, drag.startHit), drag.axisDir) / (drag.startAlong ?? 1)
+        : Vector3.dot(Vector3.subtract(hit, drag.center), drag.axisDir) / (drag.startAlong ?? 1);
     const factor = Math.min(Math.max(raw, 0.01), 100);
     drag.factor = factor;
-    // Feedback: stretch the gizmo along the axis (the container is axis-oriented
-    // with +Y along the axis, so scale Y). Only the active axis' handle stretches.
-    const group = scaleGroupOf[drag.axis];
-    if (group !== undefined) Transform.getMutable(group).scale = Vector3.create(1, factor, 1);
+    // Feedback: stretch the handle(s) along their axis (each container is
+    // axis-oriented with +Y along the axis, so scale Y). Per-axis stretches only
+    // the active arm; uniform stretches all three plus the center cube.
+    const feedbackAxes: Axis[] = drag.axis === 'xyz' ? AXES : [drag.axis];
+    for (const axis of feedbackAxes) {
+      const group = scaleGroupOf[axis];
+      if (group !== undefined) Transform.getMutable(group).scale = Vector3.create(1, factor, 1);
+    }
+    if (drag.axis === 'xyz' && scaleCenterGroup !== null) {
+      Transform.getMutable(scaleCenterGroup).scale = Vector3.create(factor, factor, factor);
+    }
     return;
   }
 
   const worldDelta = Vector3.subtract(hit, drag.startHit);
-  const dir = axisVec(drag.axis);
+  const dir = drag.axisDir;
   const along = Vector3.dot(worldDelta, dir);
   const newPos = Vector3.add(drag.center, Vector3.scale(dir, along));
   dragPos = newPos;
@@ -770,7 +900,7 @@ function endDrag(): void {
   dragPos = null;
   if (d === null || selected === null) return;
 
-  if (d.mode === 'rotate') {
+  if (d.mode === 'rotate' && d.axis !== 'xyz') {
     const angle = d.angle ?? 0;
     // Reset the gizmo visual (the entity's real rotation updates via the commit,
     // flows back over the CRDT, and the inspector re-anchors the gizmo).
@@ -795,18 +925,23 @@ function endDrag(): void {
 
   if (d.mode === 'scale') {
     const factor = d.factor ?? 1;
-    // Reset the stretched handle visual (the entity's real scale updates via the
-    // commit → CRDT, and the inspector re-anchors the gizmo).
-    const group = scaleGroupOf[d.axis];
-    if (group !== undefined) Transform.getMutable(group).scale = Vector3.One();
+    // Reset the stretched handle visuals (the entity's real scale updates via
+    // the commit → CRDT, and the inspector re-anchors the gizmo).
+    for (const axis of AXES) {
+      const group = scaleGroupOf[axis];
+      if (group !== undefined) Transform.getMutable(group).scale = Vector3.One();
+    }
+    if (scaleCenterGroup !== null) Transform.getMutable(scaleCenterGroup).scale = Vector3.One();
     if (Math.abs(factor - 1) < 1e-3) return; // no-op drag
-    // Commit a per-axis scale MULTIPLIER (1 on the untouched axes); the inspector
-    // multiplies it onto the entity's current scale. Scale is dimensionless, so
-    // no scene-offset conversion.
+    // Commit a per-axis scale MULTIPLIER (1 on the untouched axes; the center
+    // cube multiplies all three — uniform); the inspector multiplies it onto
+    // the entity's current scale. Scale is dimensionless, so no scene-offset
+    // conversion — and it applies to LOCAL scale, which is why the handles are
+    // aligned to the entity's local axes.
     const mul = {
-      x: d.axis === 'x' ? factor : 1,
-      y: d.axis === 'y' ? factor : 1,
-      z: d.axis === 'z' ? factor : 1,
+      x: d.axis === 'x' || d.axis === 'xyz' ? factor : 1,
+      y: d.axis === 'y' || d.axis === 'xyz' ? factor : 1,
+      z: d.axis === 'z' || d.axis === 'xyz' ? factor : 1,
     };
     bus.postToPage({
       kind: 'gizmoCommit',

--- a/packages/inspector/agents/bevy/src/gizmo.tsx
+++ b/packages/inspector/agents/bevy/src/gizmo.tsx
@@ -50,6 +50,10 @@ const AXES: Axis[] = ['x', 'y', 'z'];
 const SHAFT_LEN = 1.2;
 const SHAFT_R = 0.03;
 const HANDLE_R = 0.12;
+// Translate arrow-head cone at the tip of each arm (a cylinder with zero top
+// radius — the SDK has no dedicated cone mesh).
+const CONE_LEN = 0.3;
+const CONE_R = 0.09;
 const SCALE_FACTOR = 0.12; // fraction of camera distance
 const MIN_SCALE = 0.2;
 const MAX_SCALE = 50;
@@ -67,11 +71,37 @@ const AXIS_COLOR: Record<Axis, Color4> = {
 const axisVec = (a: Axis): Vector3 =>
   a === 'x' ? Vector3.Right() : a === 'y' ? Vector3.Up() : Vector3.Forward();
 
-/** The world-space direction of a gizmo axis handle. Scale handles follow the
- * entity's rotation (see the selectedRot note); translate/rotate handles are
- * world axes. */
+// Translate plane handles: small quads offset from the center in each pair of
+// axes, for dragging freely within that plane (Babylon/Blender-style). Colored
+// by the plane's NORMAL axis, like Blender's patches.
+type PlaneKey = 'xy' | 'xz' | 'yz';
+const PLANE_KEYS: PlaneKey[] = ['xy', 'xz', 'yz'];
+const PLANE_AXES: Record<PlaneKey, [Axis, Axis]> = {
+  xy: ['x', 'y'],
+  xz: ['x', 'z'],
+  yz: ['y', 'z'],
+};
+const PLANE_NORMAL_AXIS: Record<PlaneKey, Axis> = { xy: 'z', xz: 'y', yz: 'x' };
+const PLANE_SIZE = 0.35; // quad side length at scale 1
+const PLANE_OFFSET = 0.5; // quad center's offset from the gizmo center, per axis
+const planeGroupOf: Partial<Record<PlaneKey, Entity>> = {};
+
+const isAxis = (a: Axis | 'xyz' | PlaneKey): a is Axis => a === 'x' || a === 'y' || a === 'z';
+const isPlaneKey = (a: Axis | 'xyz' | PlaneKey): a is PlaneKey =>
+  a === 'xy' || a === 'xz' || a === 'yz';
+
+/** Whether the gizmo handles follow the entity's rotation instead of the world
+ * axes: scale always does (per-axis scaling is only meaningful on local axes);
+ * translate does when the "align to world" checkbox is off. Rotate rings stay
+ * world-aligned. */
+function isGizmoLocallyAligned(): boolean {
+  return gizmoMode === 'scale' || (gizmoMode === 'translate' && !alignToWorld);
+}
+
+/** The world-space direction of a gizmo axis handle (rotated into the entity's
+ * frame when the gizmo is locally aligned — see isGizmoLocallyAligned). */
 function gizmoAxisDir(a: Axis): Vector3 {
-  return gizmoMode === 'scale' ? Vector3.rotate(axisVec(a), selectedRot) : axisVec(a);
+  return isGizmoLocallyAligned() ? Vector3.rotate(axisVec(a), selectedRot) : axisVec(a);
 }
 
 let gizmoRoot: Entity | null = null;
@@ -102,9 +132,12 @@ let selectedPos: Vector3 | null = null;
 // The selected entity's world rotation (inspector-supplied, like selectedPos).
 // The SCALE gizmo aligns its handles to this — always, independent of any
 // align-to-world setting, because per-axis scaling only makes sense on the
-// entity's LOCAL axes (the committed multiplier applies to local scale).
-// Translate/rotate handles stay world-aligned.
+// entity's LOCAL axes (the committed multiplier applies to local scale). The
+// TRANSLATE gizmo aligns to it when `alignToWorld` is false; rotate rings stay
+// world-aligned.
 let selectedRot: Quaternion = Quaternion.Identity();
+// The toolbar's "align to world" checkbox (inspector-supplied via set-selection).
+let alignToWorld = true;
 // Which gizmo the inspector wants shown (translate/rotate/scale/free).
 let gizmoMode: GizmoMode = 'translate';
 // Scene-local → engine-world offset (base parcel × 16m). The inspector renders
@@ -117,11 +150,13 @@ let rayTs = 0;
 
 interface DragState {
   mode: 'translate' | 'rotate' | 'scale';
-  // 'xyz' = the scale gizmo's center cube (uniform scale on all three axes).
-  axis: Axis | 'xyz';
-  // World-space direction the drag projects onto, captured at grab time:
-  // the world axis (translate), the entity-local axis (scale), or the camera's
-  // up-right diagonal (uniform scale). Frozen for the whole drag so a mid-drag
+  // 'xyz' = the scale gizmo's center cube (uniform scale on all three axes);
+  // a PlaneKey = a translate plane handle (free drag within that plane).
+  axis: Axis | 'xyz' | PlaneKey;
+  // World-space direction the drag projects onto, captured at grab time: the
+  // handle's axis (world or entity-local per alignment), the camera's up-right
+  // diagonal (uniform scale), or the plane normal (plane drags — unused, the
+  // in-plane delta is taken whole). Frozen for the whole drag so a mid-drag
   // selection repost can't change the math under the pointer.
   axisDir: Vector3;
   center: Vector3; // entity world position at drag start
@@ -208,6 +243,7 @@ export function setSelectedEntity(
   position: { x: number; y: number; z: number } | null,
   mode: GizmoMode = 'translate',
   rotation: { x: number; y: number; z: number; w: number } | null = null,
+  worldAligned: boolean = true,
 ): void {
   selected = entity !== null && entity !== 0 ? (entity as Entity) : null;
   selectedPos =
@@ -218,6 +254,7 @@ export function setSelectedEntity(
     selected !== null && rotation
       ? Quaternion.create(rotation.x, rotation.y, rotation.z, rotation.w)
       : Quaternion.Identity();
+  alignToWorld = worldAligned;
   gizmoMode = mode;
   // Show handles for translate / rotate / scale; `free` shows none.
   const supported = mode === 'translate' || mode === 'rotate' || mode === 'scale';
@@ -312,6 +349,20 @@ function buildGizmo(): void {
       emissiveIntensity: 0.4,
     });
 
+    // Arrow head: a cone (zero-top-radius cylinder) pointing outward at the tip.
+    const cone = engine.addEntity();
+    Transform.create(cone, {
+      position: Vector3.create(0, SHAFT_LEN + CONE_LEN / 2, 0),
+      scale: Vector3.create(1, CONE_LEN, 1),
+      parent: container,
+    });
+    MeshRenderer.setCylinder(cone, CONE_R, 0);
+    Material.setPbrMaterial(cone, {
+      albedoColor: AXIS_COLOR[axis],
+      emissiveColor: Color3.create(AXIS_COLOR[axis].r, AXIS_COLOR[axis].g, AXIS_COLOR[axis].b),
+      emissiveIntensity: 0.4,
+    });
+
     // A fat collider along the axis so the handle is easy to grab.
     const handle = engine.addEntity();
     Transform.create(handle, {
@@ -325,7 +376,49 @@ function buildGizmo(): void {
     buildRotateRing(root, axis);
     buildScaleHandle(root, axis);
   }
+  buildTranslatePlanes(root);
   buildScaleCenter(root);
+}
+
+/**
+ * The translate gizmo's plane handles: one small quad per axis pair, offset from
+ * the center along both of its axes, for dragging freely within that plane.
+ * Colored by the plane's normal axis (Blender-style). Grab is analytic
+ * (pickTranslateHandleAnalytic), so no colliders. Shown only in translate mode.
+ */
+function buildTranslatePlanes(root: Entity): void {
+  // The SDK plane primitive is a unit quad in local XY (normal = Z); rotate it
+  // into the xz / yz planes, and center it PLANE_OFFSET out along both axes.
+  const orient: Record<PlaneKey, Quaternion> = {
+    xy: Quaternion.Identity(),
+    xz: Quaternion.fromEulerDegrees(90, 0, 0), // local +Y → +Z
+    yz: Quaternion.fromEulerDegrees(0, 90, 0), // normal → ±X
+  };
+  const center: Record<PlaneKey, Vector3> = {
+    xy: Vector3.create(PLANE_OFFSET, PLANE_OFFSET, 0),
+    xz: Vector3.create(PLANE_OFFSET, 0, PLANE_OFFSET),
+    yz: Vector3.create(0, PLANE_OFFSET, PLANE_OFFSET),
+  };
+  for (const key of PLANE_KEYS) {
+    const group = engine.addEntity();
+    Transform.create(group, { parent: root });
+    planeGroupOf[key] = group;
+
+    const quad = engine.addEntity();
+    Transform.create(quad, {
+      position: center[key],
+      rotation: orient[key],
+      scale: Vector3.create(PLANE_SIZE, PLANE_SIZE, 1),
+      parent: group,
+    });
+    MeshRenderer.setPlane(quad);
+    const n = PLANE_NORMAL_AXIS[key];
+    Material.setPbrMaterial(quad, {
+      albedoColor: AXIS_COLOR[n],
+      emissiveColor: Color3.create(AXIS_COLOR[n].r, AXIS_COLOR[n].g, AXIS_COLOR[n].b),
+      emissiveIntensity: 0.4,
+    });
+  }
 }
 
 /**
@@ -452,6 +545,11 @@ function setModeVisibility(): void {
   if (scaleCenterGroup !== null) {
     Transform.getMutable(scaleCenterGroup).scale = gizmoMode === 'scale' ? shown : hidden;
   }
+  for (const key of PLANE_KEYS) {
+    const group = planeGroupOf[key];
+    if (group !== undefined)
+      Transform.getMutable(group).scale = gizmoMode === 'translate' ? shown : hidden;
+  }
 }
 
 function hideGizmo(): void {
@@ -560,6 +658,40 @@ function rayPointDistance(origin: Vector3, dir: Vector3, p: Vector3): number {
   return Vector3.distance(Vector3.add(origin, Vector3.scale(dir, t)), p);
 }
 
+/** Analytic translate grab: a plane handle (free drag within that plane) or an
+ * axis arm. The planes are tested FIRST — each quad sits between two arms,
+ * inside the arms' fat grab tolerance, so arm-first would shadow them. When the
+ * ray crosses more than one quad region, the nearest hit wins. */
+function pickTranslateHandleAnalytic(ray: {
+  origin: Vector3;
+  dir: Vector3;
+}): Axis | PlaneKey | null {
+  if (selectedPos === null) return null;
+  const scale = cameraDistanceScale(selectedPos);
+  // Forgiving band around each quad (same hand-aimed-click reasoning as arms).
+  const margin = PLANE_SIZE * 0.35 * scale;
+  const lo = (PLANE_OFFSET - PLANE_SIZE / 2) * scale - margin;
+  const hi = (PLANE_OFFSET + PLANE_SIZE / 2) * scale + margin;
+  let best: PlaneKey | null = null;
+  let bestT = Infinity;
+  for (const key of PLANE_KEYS) {
+    const n = gizmoAxisDir(PLANE_NORMAL_AXIS[key]);
+    const hit = rayPlaneIntersect(ray.origin, ray.dir, selectedPos, n);
+    if (hit === null) continue;
+    const d = Vector3.subtract(hit, selectedPos);
+    const [a0, a1] = PLANE_AXES[key];
+    const u = Vector3.dot(d, gizmoAxisDir(a0));
+    const v = Vector3.dot(d, gizmoAxisDir(a1));
+    if (u < lo || u > hi || v < lo || v > hi) continue;
+    const t = Vector3.distance(ray.origin, hit);
+    if (t < bestT) {
+      bestT = t;
+      best = key;
+    }
+  }
+  return best ?? pickAxisAnalytic(ray);
+}
+
 /** Analytic scale grab: the center cube ('xyz', uniform scale) or an axis arm.
  * The center is tested FIRST — every arm starts at the center, so near the
  * middle all three arms are within the arm tolerance and would shadow it. */
@@ -652,9 +784,9 @@ function gizmoSystemInner(): void {
   if (selected !== null && selectedPos !== null && drag === null) {
     const t = Transform.getMutable(gizmoRoot);
     t.position = { ...selectedPos };
-    // Scale mode: orient the handles to the entity's rotation (always — see the
-    // selectedRot note). Translate/rotate stay world-aligned.
-    t.rotation = gizmoMode === 'scale' ? { ...selectedRot } : Quaternion.Identity();
+    // Orient the handles to the entity's rotation when locally aligned (scale
+    // always; translate when align-to-world is off — see the selectedRot note).
+    t.rotation = isGizmoLocallyAligned() ? { ...selectedRot } : Quaternion.Identity();
     const s = cameraDistanceScale(selectedPos);
     t.scale = Vector3.create(s, s, s);
   }
@@ -678,7 +810,7 @@ function gizmoSystemInner(): void {
             ? pickRotateAxisAnalytic(ray)
             : gizmoMode === 'scale'
               ? pickScaleHandleAnalytic(ray)
-              : pickAxisAnalytic(ray);
+              : pickTranslateHandleAnalytic(ray);
       if (grabbedAxis !== null) {
         beginDrag(grabbedAxis);
       } else {
@@ -746,7 +878,7 @@ function isGizmoHandle(id: number): boolean {
   return false;
 }
 
-function beginDrag(axis: Axis | 'xyz'): void {
+function beginDrag(axis: Axis | 'xyz' | PlaneKey): void {
   if (selected === null || selectedPos === null) return;
   const center = { ...selectedPos };
   const ray = pointerRay();
@@ -754,6 +886,18 @@ function beginDrag(axis: Axis | 'xyz'): void {
   const camT = Transform.getOrNull(engine.CameraEntity);
   const camForward =
     camT === null ? Vector3.Forward() : Vector3.rotate(Vector3.Forward(), camT.rotation);
+
+  if (isPlaneKey(axis)) {
+    // Plane drag (translate): move freely within the handle's plane. Start and
+    // live hits both lie on the plane, so the start→now delta is already
+    // in-plane — no per-axis projection.
+    const planeNormal = gizmoAxisDir(PLANE_NORMAL_AXIS[axis]);
+    const startHit = rayPlaneIntersect(ray.origin, ray.dir, center, planeNormal);
+    if (startHit === null) return;
+    drag = { mode: 'translate', axis, axisDir: planeNormal, center, planeNormal, startHit };
+    dragPos = center;
+    return;
+  }
 
   if (axis === 'xyz') {
     // Uniform scale (the center cube): drag in the camera-facing plane through
@@ -836,7 +980,7 @@ function updateDrag(): void {
   const hit = rayPlaneIntersect(ray.origin, ray.dir, drag.center, drag.planeNormal);
   if (hit === null) return;
 
-  if (drag.mode === 'rotate' && drag.axis !== 'xyz') {
+  if (drag.mode === 'rotate' && isAxis(drag.axis)) {
     // Swept angle since drag start, unwrapped across the ±π seam so a drag past
     // half a turn keeps accumulating instead of flipping sign.
     const startAngle = angleOnRing(drag.startHit, drag.center, drag.axis);
@@ -871,7 +1015,7 @@ function updateDrag(): void {
     // Feedback: stretch the handle(s) along their axis (each container is
     // axis-oriented with +Y along the axis, so scale Y). Per-axis stretches only
     // the active arm; uniform stretches all three plus the center cube.
-    const feedbackAxes: Axis[] = drag.axis === 'xyz' ? AXES : [drag.axis];
+    const feedbackAxes: Axis[] = drag.axis === 'xyz' ? AXES : isAxis(drag.axis) ? [drag.axis] : [];
     for (const axis of feedbackAxes) {
       const group = scaleGroupOf[axis];
       if (group !== undefined) Transform.getMutable(group).scale = Vector3.create(1, factor, 1);
@@ -883,9 +1027,11 @@ function updateDrag(): void {
   }
 
   const worldDelta = Vector3.subtract(hit, drag.startHit);
-  const dir = drag.axisDir;
-  const along = Vector3.dot(worldDelta, dir);
-  const newPos = Vector3.add(drag.center, Vector3.scale(dir, along));
+  // Plane handle: take the whole in-plane delta (both hits lie on the drag
+  // plane). Axis arm: project the delta onto the arm's direction.
+  const newPos = isPlaneKey(drag.axis)
+    ? Vector3.add(drag.center, worldDelta)
+    : Vector3.add(drag.center, Vector3.scale(drag.axisDir, Vector3.dot(worldDelta, drag.axisDir)));
   dragPos = newPos;
 
   // Move only the gizmo visual during the drag (feedback); the entity itself is
@@ -900,7 +1046,7 @@ function endDrag(): void {
   dragPos = null;
   if (d === null || selected === null) return;
 
-  if (d.mode === 'rotate' && d.axis !== 'xyz') {
+  if (d.mode === 'rotate' && isAxis(d.axis)) {
     const angle = d.angle ?? 0;
     // Reset the gizmo visual (the entity's real rotation updates via the commit,
     // flows back over the CRDT, and the inspector re-anchors the gizmo).

--- a/packages/inspector/agents/bevy/src/index.ts
+++ b/packages/inspector/agents/bevy/src/index.ts
@@ -35,7 +35,14 @@ export function main(): void {
     // Track the current selection + its world position so the gizmo attaches to
     // it (the agent can't read the inspected scene's Transform).
     if (msg.kind === 'set-selection') {
-      setSelectedEntity(msg.entity, msg.position, msg.mode, msg.rotation, msg.alignToWorld);
+      setSelectedEntity(
+        msg.entity,
+        msg.position,
+        msg.mode,
+        msg.rotation,
+        msg.alignToWorld,
+        msg.snap,
+      );
       return;
     }
     // Drag-drop placement: raycast the ground under the pointer and reply with

--- a/packages/inspector/agents/bevy/src/index.ts
+++ b/packages/inspector/agents/bevy/src/index.ts
@@ -35,7 +35,7 @@ export function main(): void {
     // Track the current selection + its world position so the gizmo attaches to
     // it (the agent can't read the inspected scene's Transform).
     if (msg.kind === 'set-selection') {
-      setSelectedEntity(msg.entity, msg.position, msg.mode, msg.rotation);
+      setSelectedEntity(msg.entity, msg.position, msg.mode, msg.rotation, msg.alignToWorld);
       return;
     }
     // Drag-drop placement: raycast the ground under the pointer and reply with

--- a/packages/inspector/agents/bevy/src/index.ts
+++ b/packages/inspector/agents/bevy/src/index.ts
@@ -35,7 +35,7 @@ export function main(): void {
     // Track the current selection + its world position so the gizmo attaches to
     // it (the agent can't read the inspected scene's Transform).
     if (msg.kind === 'set-selection') {
-      setSelectedEntity(msg.entity, msg.position, msg.mode);
+      setSelectedEntity(msg.entity, msg.position, msg.mode, msg.rotation);
       return;
     }
     // Drag-drop placement: raycast the ground under the pointer and reply with

--- a/packages/inspector/agents/protocol/src/index.ts
+++ b/packages/inspector/agents/protocol/src/index.ts
@@ -88,6 +88,11 @@ export type PageToScene =
       kind: 'set-selection';
       entity: number | null;
       position: BusVec3 | null;
+      // The entity's world rotation, so the scale gizmo can align its handles to
+      // the entity's local axes (scale is only meaningful on local axes — the
+      // scale gizmo is ALWAYS locally aligned, independent of the align-to-world
+      // setting, matching the Babylon ScaleGizmo). Null when nothing is selected.
+      rotation: BusQuat | null;
       // Which gizmo to show for the selection (translate/rotate/scale), or `free`
       // when none is active. Drives which handles the agent draws + how a drag
       // commits. The inspector owns the mode (its Gizmos toolbar writes it to the

--- a/packages/inspector/agents/protocol/src/index.ts
+++ b/packages/inspector/agents/protocol/src/index.ts
@@ -88,11 +88,15 @@ export type PageToScene =
       kind: 'set-selection';
       entity: number | null;
       position: BusVec3 | null;
-      // The entity's world rotation, so the scale gizmo can align its handles to
-      // the entity's local axes (scale is only meaningful on local axes — the
-      // scale gizmo is ALWAYS locally aligned, independent of the align-to-world
-      // setting, matching the Babylon ScaleGizmo). Null when nothing is selected.
+      // The entity's world rotation, so gizmos can align their handles to the
+      // entity's local axes (the scale gizmo always does — scale is only
+      // meaningful on local axes, matching the Babylon ScaleGizmo; the translate
+      // gizmo does when `alignToWorld` is false). Null when nothing is selected.
       rotation: BusQuat | null;
+      // The toolbar's "align to world" checkbox: true = translate handles on the
+      // WORLD axes, false = on the entity's local axes. Scale ignores it (always
+      // local); rotate is world-aligned for now.
+      alignToWorld: boolean;
       // Which gizmo to show for the selection (translate/rotate/scale), or `free`
       // when none is active. Drives which handles the agent draws + how a drag
       // commits. The inspector owns the mode (its Gizmos toolbar writes it to the

--- a/packages/inspector/agents/protocol/src/index.ts
+++ b/packages/inspector/agents/protocol/src/index.ts
@@ -57,7 +57,10 @@ export type AgentToPage =
   // the rest. The agent can't read the entity's base transform (separate engine),
   // so rotation/scale are DELTAS the inspector composes onto the current value:
   //  - position: ABSOLUTE world point (the agent is given the anchor up front).
-  //  - rotation: a DELTA quaternion → newRotation = current ⊗ delta.
+  //  - rotation: a WORLD-frame DELTA quaternion about the dragged ring's world
+  //    normal → newRotation = delta ⊗ current. (A locally-aligned ring's normal
+  //    is the entity's rotated axis, which makes the same composition apply the
+  //    delta about the entity's local axis.)
   //  - scale:    a per-axis MULTIPLIER → newScale = current * factor.
   | {
       kind: 'gizmoCommit';
@@ -93,10 +96,15 @@ export type PageToScene =
       // meaningful on local axes, matching the Babylon ScaleGizmo; the translate
       // gizmo does when `alignToWorld` is false). Null when nothing is selected.
       rotation: BusQuat | null;
-      // The toolbar's "align to world" checkbox: true = translate handles on the
-      // WORLD axes, false = on the entity's local axes. Scale ignores it (always
-      // local); rotate is world-aligned for now.
+      // The toolbar's "align to world" checkbox: true = translate/rotate handles
+      // on the WORLD axes, false = on the entity's local axes. Scale ignores it
+      // (always local).
       alignToWorld: boolean;
+      // The editor's snap increments (position: world units, rotation: RADIANS,
+      // scale: factor) when snapping is enabled, or null when it's off. The
+      // agent quantizes drag feedback + committed deltas to these; the inspector
+      // additionally snaps the merged Transform authoritatively on commit.
+      snap: { position: number; rotation: number; scale: number } | null;
       // Which gizmo to show for the selection (translate/rotate/scale), or `free`
       // when none is active. Drives which handles the agent draws + how a drag
       // commits. The inspector owns the mode (its Gizmos toolbar writes it to the

--- a/packages/inspector/src/lib/babylon/decentraland/snap-manager.ts
+++ b/packages/inspector/src/lib/babylon/decentraland/snap-manager.ts
@@ -124,6 +124,31 @@ export function snapScale(scale: Vector3) {
   return snapManager.isEnabled() ? snapVector(scale, snapManager.getScaleSnap()) : scale;
 }
 
+/**
+ * Renderer-agnostic scale snap: plain `{x, y, z}` data, for callers across the
+ * renderer boundary (e.g. the reverse-channel gizmo merge). Mirrors
+ * {@link snapScale}.
+ */
+export function snapScaleValue(scale: { x: number; y: number; z: number }) {
+  if (!snapManager.isEnabled()) return scale;
+  const snap = snapManager.getScaleSnap();
+  return { x: snapValue(scale.x, snap), y: snapValue(scale.y, snap), z: snapValue(scale.z, snap) };
+}
+
+/**
+ * Renderer-agnostic rotation snap: plain `{x, y, z, w}` quaternion data, for
+ * callers across the renderer boundary (e.g. the reverse-channel gizmo merge).
+ * Snaps the euler decomposition to the rotation step, like {@link snapRotation}.
+ */
+export function snapRotationValue(rotation: { x: number; y: number; z: number; w: number }) {
+  if (!snapManager.isEnabled()) return rotation;
+  const snapped = snapQuaternion(
+    new Quaternion(rotation.x, rotation.y, rotation.z, rotation.w),
+    snapManager.getRotationSnap(),
+  );
+  return { x: snapped.x, y: snapped.y, z: snapped.z, w: snapped.w };
+}
+
 export function snapRotation(rotation: Quaternion) {
   return snapManager.isEnabled()
     ? snapQuaternion(rotation, snapManager.getRotationSnap())

--- a/packages/inspector/src/lib/renderer/bevy/BevyRenderer.spec.ts
+++ b/packages/inspector/src/lib/renderer/bevy/BevyRenderer.spec.ts
@@ -109,6 +109,46 @@ describe('BevyRenderer editor camera', () => {
   });
 });
 
+describe('BevyRenderer gizmo world alignment', () => {
+  let renderer: BevyRenderer;
+
+  beforeEach(() => {
+    renderer = new BevyRenderer();
+  });
+
+  afterEach(() => {
+    renderer.dispose();
+  });
+
+  it('should default to world-aligned with the toggle enabled', () => {
+    expect(renderer.gizmos.isWorldAligned()).toBe(true);
+    expect(renderer.gizmos.isWorldAlignmentDisabled()).toBe(false);
+  });
+
+  it('should update the alignment and notify subscribers on change', () => {
+    let changes = 0;
+    renderer.gizmos.onChange(() => changes++);
+    renderer.gizmos.setWorldAligned(false);
+    expect(renderer.gizmos.isWorldAligned()).toBe(false);
+    expect(changes).toBe(1);
+  });
+
+  it('should ignore a no-op set to the current alignment', () => {
+    let changes = 0;
+    renderer.gizmos.onChange(() => changes++);
+    renderer.gizmos.setWorldAligned(true); // already world-aligned
+    expect(changes).toBe(0);
+  });
+
+  it('should stop notifying after unsubscribe', () => {
+    let changes = 0;
+    const off = renderer.gizmos.onChange(() => changes++);
+    off();
+    renderer.gizmos.setWorldAligned(false);
+    expect(changes).toBe(0);
+  });
+});
+
 describe('BevyRenderer focusOnEntity', () => {
   let renderer: BevyRenderer;
 

--- a/packages/inspector/src/lib/renderer/bevy/BevyRenderer.ts
+++ b/packages/inspector/src/lib/renderer/bevy/BevyRenderer.ts
@@ -84,13 +84,19 @@ export class BevyRenderer implements IRenderer {
   // Posts a camera reset to the agent (default scene framing). Injected by
   // `register`; null in the conformance path (reset falls back to the in-memory pose).
   #postReset: ((position: Vector3) => void) | null = null;
+  // Gizmo world-alignment (the toolbar's "align to world" checkbox). The gizmo
+  // itself is drawn/dragged by the editor-agent scene; this renderer owns the
+  // SETTING so the toolbar can bind to it, and the selection bridge forwards it
+  // to the agent over the bus.
+  #gizmosWorldAligned = true;
+  #gizmoChangeHandlers = new Set<() => void>();
 
   constructor() {
     this.context = new BevySceneContext();
 
     this.camera = this.#createCamera();
     this.editorCamera = this.#createEditorCamera();
-    this.gizmos = this.#createGizmoStub();
+    this.gizmos = this.#createGizmos();
     this.metrics = this.#createMetrics();
     this.viewport = this.#createViewport();
     this.spawnPoints = this.#createSpawnPointStub();
@@ -174,17 +180,29 @@ export class BevyRenderer implements IRenderer {
     };
   }
 
-  // Editor manipulation not yet implemented for Bevy — honest stubs. These map
-  // to bevy-editor's scene-side gizmo/TextureCamera composite in the next slice.
-  #createGizmoStub(): RendererGizmos {
+  // Gizmo drawing + dragging live in the editor-agent scene (over the bus); the
+  // renderer owns the gizmo SETTINGS the toolbar binds to — world alignment. Mode
+  // is driven through the Selection component (not setMode) and enable/disable
+  // isn't wired, so those stay honest no-ops.
+  #createGizmos(): RendererGizmos {
     return {
       isEnabled: () => false,
       setEnabled: () => {},
       setMode: (_mode: GizmoType) => {},
-      isWorldAligned: () => true,
-      setWorldAligned: () => {},
-      isWorldAlignmentDisabled: () => true,
-      onChange: () => () => {},
+      isWorldAligned: () => this.#gizmosWorldAligned,
+      setWorldAligned: (aligned: boolean) => {
+        if (this.#gizmosWorldAligned === aligned) return;
+        this.#gizmosWorldAligned = aligned;
+        // Iterate a copy: a handler may unsubscribe mid-iteration.
+        for (const h of [...this.#gizmoChangeHandlers]) h();
+      },
+      isWorldAlignmentDisabled: () => false,
+      onChange: (cb: () => void) => {
+        this.#gizmoChangeHandlers.add(cb);
+        return () => {
+          this.#gizmoChangeHandlers.delete(cb);
+        };
+      },
     };
   }
 
@@ -282,6 +300,7 @@ export class BevyRenderer implements IRenderer {
   dispose(): void {
     this.#disposed = true;
     this.#engineWindow = null;
+    this.#gizmoChangeHandlers.clear();
     this.context.dispose();
     this.events.all.clear();
   }

--- a/packages/inspector/src/lib/renderer/bevy/BevySceneContext.ts
+++ b/packages/inspector/src/lib/renderer/bevy/BevySceneContext.ts
@@ -2,8 +2,8 @@ import type { ComponentDefinition, Entity, TransformType } from '@dcl/ecs';
 import { CrdtMessageType, Engine } from '@dcl/ecs';
 import type { IEngine } from '@dcl/ecs';
 import * as components from '@dcl/ecs/dist/components';
-import { Vector3 as DclVector3 } from '@dcl/ecs-math';
-import type { Vector3 } from '@dcl/ecs-math';
+import { Quaternion as DclQuaternion, Vector3 as DclVector3 } from '@dcl/ecs-math';
+import type { Quaternion, Vector3 } from '@dcl/ecs-math';
 
 import { createOperations } from '../../sdk/operations';
 import { createEditorComponents } from '../../sdk/components';
@@ -116,6 +116,36 @@ export class BevySceneContext {
       current = t.parent as Entity | undefined;
     }
     return DclVector3.create(x, y, z);
+  }
+
+  /**
+   * An entity's world rotation, composed down the Transform.parent chain
+   * (world = parent-world ⊗ local) — the rotation analogue of
+   * {@link BevySceneContext.#resolveWorldPosition}, with the same spike-level
+   * fidelity (parent scale is ignored). Null when the entity has no Transform.
+   * The selection bridge sends this to the agent so the scale gizmo can align
+   * its handles to the entity's rotation.
+   */
+  getEntityWorldRotation(entity: Entity): Quaternion | null {
+    // Collect local rotations from the entity up to the root…
+    const locals: Quaternion[] = [];
+    let current: Entity | undefined = entity;
+    // Bound the walk so a malformed cyclic parent chain can't spin forever.
+    let guard = 0;
+    while (current !== undefined && current !== ROOT && guard++ < 1024) {
+      const t = this.Transform.getOrNull(current) as TransformType | null;
+      if (!t) break;
+      locals.push(t.rotation);
+      current = t.parent as Entity | undefined;
+    }
+    if (locals.length === 0) return null;
+    // …then compose top-down: world = R(topmost ancestor) ⊗ … ⊗ R(entity).
+    let world = DclQuaternion.Identity();
+    for (let i = locals.length - 1; i >= 0; i--) {
+      const q = locals[i];
+      world = DclQuaternion.multiply(world, DclQuaternion.create(q.x, q.y, q.z, q.w));
+    }
+    return world;
   }
 
   /**

--- a/packages/inspector/src/lib/renderer/bevy/register.ts
+++ b/packages/inspector/src/lib/renderer/bevy/register.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '../../logic/config';
+import { snapManager } from '../../babylon/decentraland/snap-manager';
 import { connectReverseChannel } from '../reverse-channel';
 import { registerRenderer } from '../plugin';
 import { BevyRenderer } from './BevyRenderer';
@@ -82,10 +83,22 @@ export function registerBevyRenderer(): void {
 
       // Forward the inspector's selection to the agent so its gizmo attaches to
       // the selected entity (from a viewport pick OR a tree click). The gizmos
-      // handle carries the "align to world" setting along with it.
+      // handle carries the "align to world" setting; the snap handle carries the
+      // Snap panel's increments (null while snapping is off).
       const disconnectSelection = createSelectionBridge({
         context: bevy.context,
         gizmos: bevy.gizmos,
+        snap: {
+          getSnap: () =>
+            snapManager.isEnabled()
+              ? {
+                  position: snapManager.getPositionSnap(),
+                  rotation: snapManager.getRotationSnap(),
+                  scale: snapManager.getScaleSnap(),
+                }
+              : null,
+          onChange: cb => snapManager.onChange(cb),
+        },
       });
 
       // Drag-drop placement: the agent raycasts the ground under the pointer and

--- a/packages/inspector/src/lib/renderer/bevy/register.ts
+++ b/packages/inspector/src/lib/renderer/bevy/register.ts
@@ -81,8 +81,12 @@ export function registerBevyRenderer(): void {
       const disconnectPick = createPickBridge({ events: bevy.events });
 
       // Forward the inspector's selection to the agent so its gizmo attaches to
-      // the selected entity (from a viewport pick OR a tree click).
-      const disconnectSelection = createSelectionBridge({ context: bevy.context });
+      // the selected entity (from a viewport pick OR a tree click). The gizmos
+      // handle carries the "align to world" setting along with it.
+      const disconnectSelection = createSelectionBridge({
+        context: bevy.context,
+        gizmos: bevy.gizmos,
+      });
 
       // Drag-drop placement: the agent raycasts the ground under the pointer and
       // replies over the bus; wire it into the renderer's getPointerWorldPoint.

--- a/packages/inspector/src/lib/renderer/bevy/selection-bridge.spec.ts
+++ b/packages/inspector/src/lib/renderer/bevy/selection-bridge.spec.ts
@@ -30,11 +30,12 @@ describe('createSelectionBridge', () => {
 
   // GizmoType: FREE=0, POSITION=1, ROTATION=2, SCALE=3.
   describe('when an entity gains the Selection component', () => {
-    it('should post set-selection with that entity, its world position, and gizmo mode', async () => {
+    it('should post set-selection with that entity, its world position, rotation, and gizmo mode', async () => {
       const entity = ctx.engine.addEntity();
       ctx.Transform.create(entity, {
         ...IDENTITY,
         position: { x: 4, y: 1, z: 2 },
+        rotation: { x: 0.5, y: 0.5, z: 0.5, w: 0.5 },
         parent: ctx.engine.RootEntity,
       });
       ctx.editorComponents.Selection.create(entity, { gizmo: 1 }); // POSITION → translate
@@ -46,6 +47,7 @@ describe('createSelectionBridge', () => {
           kind: 'set-selection',
           entity: entity as number,
           position: { x: 4, y: 1, z: 2 },
+          rotation: { x: 0.5, y: 0.5, z: 0.5, w: 0.5 },
           mode: 'translate',
         },
       });
@@ -69,7 +71,40 @@ describe('createSelectionBridge', () => {
           kind: 'set-selection',
           entity: entity as number,
           position: null,
+          rotation: null,
           mode: 'rotate',
+        },
+      });
+    });
+  });
+
+  describe("when the selected entity's Transform changes", () => {
+    it('should re-post with the new position and rotation', async () => {
+      const entity = ctx.engine.addEntity();
+      ctx.Transform.create(entity, {
+        ...IDENTITY,
+        position: { x: 1, y: 0, z: 1 },
+        parent: ctx.engine.RootEntity,
+      });
+      ctx.editorComponents.Selection.create(entity, { gizmo: 3 }); // SCALE
+      await ctx.engine.update(1);
+      posted.length = 0;
+
+      // A rotation edit lands while selected (panel edit, undo, gizmo commit) —
+      // the scale gizmo must re-align, so the bridge re-posts the selection.
+      const mutable = ctx.Transform.getMutable(entity);
+      mutable.position = { x: 2, y: 0, z: 1 };
+      mutable.rotation = { x: 0, y: 0.5, z: 0, w: 0.5 };
+      await ctx.engine.update(1);
+
+      expect(posted).toContainEqual({
+        to: 'scene',
+        msg: {
+          kind: 'set-selection',
+          entity: entity as number,
+          position: { x: 2, y: 0, z: 1 },
+          rotation: { x: 0, y: 0.5, z: 0, w: 0.5 },
+          mode: 'scale',
         },
       });
     });
@@ -87,7 +122,7 @@ describe('createSelectionBridge', () => {
 
       expect(posted).toContainEqual({
         to: 'scene',
-        msg: { kind: 'set-selection', entity: null, position: null, mode: 'free' },
+        msg: { kind: 'set-selection', entity: null, position: null, rotation: null, mode: 'free' },
       });
     });
   });

--- a/packages/inspector/src/lib/renderer/bevy/selection-bridge.spec.ts
+++ b/packages/inspector/src/lib/renderer/bevy/selection-bridge.spec.ts
@@ -48,6 +48,7 @@ describe('createSelectionBridge', () => {
           entity: entity as number,
           position: { x: 4, y: 1, z: 2 },
           rotation: { x: 0.5, y: 0.5, z: 0.5, w: 0.5 },
+          alignToWorld: true,
           mode: 'translate',
         },
       });
@@ -72,6 +73,7 @@ describe('createSelectionBridge', () => {
           entity: entity as number,
           position: null,
           rotation: null,
+          alignToWorld: true,
           mode: 'rotate',
         },
       });
@@ -104,7 +106,51 @@ describe('createSelectionBridge', () => {
           entity: entity as number,
           position: { x: 2, y: 0, z: 1 },
           rotation: { x: 0, y: 0.5, z: 0, w: 0.5 },
+          alignToWorld: true,
           mode: 'scale',
+        },
+      });
+    });
+  });
+
+  describe('when the "align to world" setting toggles', () => {
+    it('should re-post the current selection with the new alignment', async () => {
+      // A dedicated bridge wired with a fake gizmos handle (the renderer's
+      // world-alignment state + change subscription).
+      disconnect();
+      posted.length = 0;
+      let worldAligned = true;
+      const gizmoHandlers = new Set<() => void>();
+      disconnect = createSelectionBridge({
+        context: ctx,
+        gizmos: {
+          isWorldAligned: () => worldAligned,
+          onChange: cb => {
+            gizmoHandlers.add(cb);
+            return () => gizmoHandlers.delete(cb);
+          },
+        },
+        channel: { postMessage: m => posted.push(m), close() {} },
+      });
+
+      const entity = ctx.engine.addEntity();
+      ctx.editorComponents.Selection.create(entity, { gizmo: 1 }); // translate
+      await ctx.engine.update(1);
+      posted.length = 0;
+
+      // The user unchecks "align to world" in the Gizmos toolbar.
+      worldAligned = false;
+      for (const h of [...gizmoHandlers]) h();
+
+      expect(posted).toContainEqual({
+        to: 'scene',
+        msg: {
+          kind: 'set-selection',
+          entity: entity as number,
+          position: null,
+          rotation: null,
+          alignToWorld: false,
+          mode: 'translate',
         },
       });
     });
@@ -122,7 +168,14 @@ describe('createSelectionBridge', () => {
 
       expect(posted).toContainEqual({
         to: 'scene',
-        msg: { kind: 'set-selection', entity: null, position: null, rotation: null, mode: 'free' },
+        msg: {
+          kind: 'set-selection',
+          entity: null,
+          position: null,
+          rotation: null,
+          alignToWorld: true,
+          mode: 'free',
+        },
       });
     });
   });

--- a/packages/inspector/src/lib/renderer/bevy/selection-bridge.spec.ts
+++ b/packages/inspector/src/lib/renderer/bevy/selection-bridge.spec.ts
@@ -49,6 +49,7 @@ describe('createSelectionBridge', () => {
           position: { x: 4, y: 1, z: 2 },
           rotation: { x: 0.5, y: 0.5, z: 0.5, w: 0.5 },
           alignToWorld: true,
+          snap: null,
           mode: 'translate',
         },
       });
@@ -74,6 +75,7 @@ describe('createSelectionBridge', () => {
           position: null,
           rotation: null,
           alignToWorld: true,
+          snap: null,
           mode: 'rotate',
         },
       });
@@ -107,6 +109,7 @@ describe('createSelectionBridge', () => {
           position: { x: 2, y: 0, z: 1 },
           rotation: { x: 0, y: 0.5, z: 0, w: 0.5 },
           alignToWorld: true,
+          snap: null,
           mode: 'scale',
         },
       });
@@ -150,7 +153,52 @@ describe('createSelectionBridge', () => {
           position: null,
           rotation: null,
           alignToWorld: false,
+          snap: null,
           mode: 'translate',
+        },
+      });
+    });
+  });
+
+  describe('when the snap settings change', () => {
+    it('should re-post the current selection with the new snap values', async () => {
+      // A dedicated bridge wired with a fake snap handle (the editor's snap
+      // settings + change subscription).
+      disconnect();
+      posted.length = 0;
+      let snap: { position: number; rotation: number; scale: number } | null = null;
+      const snapHandlers = new Set<() => void>();
+      disconnect = createSelectionBridge({
+        context: ctx,
+        snap: {
+          getSnap: () => snap,
+          onChange: cb => {
+            snapHandlers.add(cb);
+            return () => snapHandlers.delete(cb);
+          },
+        },
+        channel: { postMessage: m => posted.push(m), close() {} },
+      });
+
+      const entity = ctx.engine.addEntity();
+      ctx.editorComponents.Selection.create(entity, { gizmo: 2 }); // rotate
+      await ctx.engine.update(1);
+      posted.length = 0;
+
+      // The user enables snapping / edits the Snap panel values.
+      snap = { position: 0.25, rotation: Math.PI / 2, scale: 0.1 };
+      for (const h of [...snapHandlers]) h();
+
+      expect(posted).toContainEqual({
+        to: 'scene',
+        msg: {
+          kind: 'set-selection',
+          entity: entity as number,
+          position: null,
+          rotation: null,
+          alignToWorld: true,
+          snap: { position: 0.25, rotation: Math.PI / 2, scale: 0.1 },
+          mode: 'rotate',
         },
       });
     });
@@ -174,6 +222,7 @@ describe('createSelectionBridge', () => {
           position: null,
           rotation: null,
           alignToWorld: true,
+          snap: null,
           mode: 'free',
         },
       });

--- a/packages/inspector/src/lib/renderer/bevy/selection-bridge.ts
+++ b/packages/inspector/src/lib/renderer/bevy/selection-bridge.ts
@@ -39,10 +39,17 @@ interface Channel {
 
 export interface SelectionBridgeOptions {
   context: BevySceneContext;
-  /** The renderer's gizmo settings — world alignment for the translate gizmo
-   * (the toolbar's "align to world" checkbox). Optional so the bridge can run
-   * without a renderer (tests); then `alignToWorld` is always true. */
+  /** The renderer's gizmo settings — world alignment for the translate/rotate
+   * gizmos (the toolbar's "align to world" checkbox). Optional so the bridge can
+   * run without a renderer (tests); then `alignToWorld` is always true. */
   gizmos?: { isWorldAligned(): boolean; onChange(cb: () => void): () => void };
+  /** The editor's snap settings (the toolbar's Snap panel): the increments when
+   * snapping is enabled, or null when it's off. Optional (tests); absent =
+   * snapping off. */
+  snap?: {
+    getSnap(): { position: number; rotation: number; scale: number } | null;
+    onChange(cb: () => void): () => void;
+  };
   /** Test seam: the channel to post on. Defaults to a real BroadcastChannel. */
   channel?: Channel;
 }
@@ -79,12 +86,14 @@ export function createSelectionBridge(options: SelectionBridgeOptions): () => vo
     const wr = entity === null ? null : context.getEntityWorldRotation(entity);
     const rotation = wr === null ? null : { x: wr.x, y: wr.y, z: wr.z, w: wr.w };
     const alignToWorld = gizmos?.isWorldAligned() ?? true;
+    const snap = options.snap?.getSnap() ?? null;
     const msg: PageToScene = {
       kind: 'set-selection',
       entity: value,
       position,
       rotation,
       alignToWorld,
+      snap,
       mode,
     };
     const serialized = JSON.stringify(msg);
@@ -109,13 +118,16 @@ export function createSelectionBridge(options: SelectionBridgeOptions): () => vo
     }
   });
 
-  // Re-post when the "align to world" setting toggles, so the agent re-orients
-  // the translate gizmo on the current selection.
+  // Re-post when the "align to world" setting toggles (the agent re-orients the
+  // gizmo on the current selection) or the snap settings change (the agent
+  // re-quantizes its drags).
   const offGizmos = gizmos?.onChange(post);
+  const offSnap = options.snap?.onChange(post);
 
   return () => {
     off();
     offGizmos?.();
+    offSnap?.();
     channel.close();
   };
 }

--- a/packages/inspector/src/lib/renderer/bevy/selection-bridge.ts
+++ b/packages/inspector/src/lib/renderer/bevy/selection-bridge.ts
@@ -48,8 +48,9 @@ export function createSelectionBridge(options: SelectionBridgeOptions): () => vo
   const channel = options.channel ?? (new BroadcastChannel(EDITOR_BUS_CHANNEL) as Channel);
   const Selection = context.editorComponents.Selection;
 
-  let lastEntity: number | null | undefined;
-  let lastMode: GizmoMode | undefined;
+  // Dedupe by the full serialized message: a repost fires for entity, mode,
+  // position AND rotation changes (any of them moves/re-orients the gizmo).
+  let lastPosted: string | undefined;
 
   const post = () => {
     // Current selection = entities carrying the Selection component. Single-entity
@@ -64,25 +65,36 @@ export function createSelectionBridge(options: SelectionBridgeOptions): () => vo
     }
     const value = entity === null ? null : (entity as number);
     const mode = toGizmoMode(gizmo);
-    // Re-post when either the entity OR the mode changes (the user can switch
-    // gizmo mode on the same selection via the Gizmos toolbar).
-    if (value === lastEntity && mode === lastMode) return;
-    lastEntity = value;
-    lastMode = mode;
-    // Send the entity's world position too: the agent scene can't read the
-    // inspected scene's Transform from its own engine, so the inspector (which
-    // owns the CRDT) supplies where to place the gizmo.
+    // Send the entity's world position + rotation too: the agent scene can't
+    // read the inspected scene's Transform from its own engine, so the inspector
+    // (which owns the CRDT) supplies where to place the gizmo and how to orient
+    // it (the scale gizmo aligns its handles to the entity's rotation).
     const wp =
       entity === null ? null : (context.getEntityWorldPositions([entity]).get(entity) ?? null);
     const position = wp === null ? null : { x: wp.x, y: wp.y, z: wp.z };
-    const msg: PageToScene = { kind: 'set-selection', entity: value, position, mode };
+    const wr = entity === null ? null : context.getEntityWorldRotation(entity);
+    const rotation = wr === null ? null : { x: wr.x, y: wr.y, z: wr.z, w: wr.w };
+    const msg: PageToScene = { kind: 'set-selection', entity: value, position, rotation, mode };
+    const serialized = JSON.stringify(msg);
+    if (serialized === lastPosted) return;
+    lastPosted = serialized;
     const envelope: BusEnvelope = { to: 'scene', msg };
     channel.postMessage(envelope);
   };
 
-  // Post whenever a Selection component changes (added/removed OR gizmo mode edit).
+  // Post whenever a Selection component changes (added/removed OR gizmo mode
+  // edit), and on Transform changes so the gizmo tracks moves/rotations made
+  // while selected (a gizmo commit, a properties-panel edit, undo). Any
+  // entity's Transform can matter (a parent move shifts the selection's world
+  // pose); the value-dedupe in post() drops the no-op reposts.
   const off = context.onChange((_entity, _op, component) => {
-    if (component && component.componentId === Selection.componentId) post();
+    if (!component) return;
+    if (
+      component.componentId === Selection.componentId ||
+      component.componentId === context.Transform.componentId
+    ) {
+      post();
+    }
   });
 
   return () => {

--- a/packages/inspector/src/lib/renderer/bevy/selection-bridge.ts
+++ b/packages/inspector/src/lib/renderer/bevy/selection-bridge.ts
@@ -39,12 +39,16 @@ interface Channel {
 
 export interface SelectionBridgeOptions {
   context: BevySceneContext;
+  /** The renderer's gizmo settings — world alignment for the translate gizmo
+   * (the toolbar's "align to world" checkbox). Optional so the bridge can run
+   * without a renderer (tests); then `alignToWorld` is always true. */
+  gizmos?: { isWorldAligned(): boolean; onChange(cb: () => void): () => void };
   /** Test seam: the channel to post on. Defaults to a real BroadcastChannel. */
   channel?: Channel;
 }
 
 export function createSelectionBridge(options: SelectionBridgeOptions): () => void {
-  const { context } = options;
+  const { context, gizmos } = options;
   const channel = options.channel ?? (new BroadcastChannel(EDITOR_BUS_CHANNEL) as Channel);
   const Selection = context.editorComponents.Selection;
 
@@ -74,7 +78,15 @@ export function createSelectionBridge(options: SelectionBridgeOptions): () => vo
     const position = wp === null ? null : { x: wp.x, y: wp.y, z: wp.z };
     const wr = entity === null ? null : context.getEntityWorldRotation(entity);
     const rotation = wr === null ? null : { x: wr.x, y: wr.y, z: wr.z, w: wr.w };
-    const msg: PageToScene = { kind: 'set-selection', entity: value, position, rotation, mode };
+    const alignToWorld = gizmos?.isWorldAligned() ?? true;
+    const msg: PageToScene = {
+      kind: 'set-selection',
+      entity: value,
+      position,
+      rotation,
+      alignToWorld,
+      mode,
+    };
     const serialized = JSON.stringify(msg);
     if (serialized === lastPosted) return;
     lastPosted = serialized;
@@ -97,8 +109,13 @@ export function createSelectionBridge(options: SelectionBridgeOptions): () => vo
     }
   });
 
+  // Re-post when the "align to world" setting toggles, so the agent re-orients
+  // the translate gizmo on the current selection.
+  const offGizmos = gizmos?.onChange(post);
+
   return () => {
     off();
+    offGizmos?.();
     channel.close();
   };
 }

--- a/packages/inspector/src/lib/renderer/reverse-channel.spec.ts
+++ b/packages/inspector/src/lib/renderer/reverse-channel.spec.ts
@@ -196,6 +196,42 @@ describe('connectReverseChannel', () => {
       const written = (operations.updateValue as ReturnType<typeof vi.fn>).mock.calls[0][2];
       expect(written.scale).toEqual(Vector3.multiply(transformValue.scale, factor));
     });
+
+    it('should clamp a committed scale away from zero', () => {
+      transformValue = {
+        position: { x: 0, y: 0, z: 0 },
+        rotation: Quaternion.Identity(),
+        scale: { x: 1, y: 1, z: 1 },
+      };
+
+      events.emit('gizmoCommit', {
+        transforms: [{ entity: 7 as never, scale: { x: 0.001, y: 1, z: 1 } as never }],
+      });
+
+      const written = (operations.updateValue as ReturnType<typeof vi.fn>).mock.calls[0][2];
+      expect(written.scale.x).toBeCloseTo(0.01, 10);
+      expect(written.scale.y).toBeCloseTo(1, 10);
+      expect(written.scale.z).toBeCloseTo(1, 10);
+    });
+
+    it('should recover an entity whose scale is already zero', () => {
+      // 0 × factor = 0 forever — the base is clamped to the minimum first, so an
+      // outward drag stretches the entity back into shape.
+      transformValue = {
+        position: { x: 0, y: 0, z: 0 },
+        rotation: Quaternion.Identity(),
+        scale: { x: 0, y: 0, z: 0 },
+      };
+
+      events.emit('gizmoCommit', {
+        transforms: [{ entity: 7 as never, scale: { x: 50, y: 50, z: 50 } as never }],
+      });
+
+      const written = (operations.updateValue as ReturnType<typeof vi.fn>).mock.calls[0][2];
+      expect(written.scale.x).toBeCloseTo(0.5, 10);
+      expect(written.scale.y).toBeCloseTo(0.5, 10);
+      expect(written.scale.z).toBeCloseTo(0.5, 10);
+    });
   });
 
   describe('when snapping is enabled', () => {
@@ -254,6 +290,24 @@ describe('connectReverseChannel', () => {
       expect(written.scale.x).toBeCloseTo(1.1, 10);
       expect(written.scale.y).toBeCloseTo(1, 10);
       expect(written.scale.z).toBeCloseTo(1, 10);
+    });
+
+    it('should clamp a snapped-to-zero scale away from zero', () => {
+      // 1 × 0.01 = 0.01, which the 0.1 snap step rounds to 0 — the final clamp
+      // must keep it recoverable.
+      transformValue = {
+        position: { x: 0, y: 0, z: 0 },
+        rotation: Quaternion.Identity(),
+        scale: { x: 1, y: 1, z: 1 },
+      };
+
+      events.emit('gizmoCommit', {
+        transforms: [{ entity: 7 as never, scale: { x: 0.01, y: 1, z: 1 } as never }],
+      });
+
+      const written = (operations.updateValue as ReturnType<typeof vi.fn>).mock.calls[0][2];
+      expect(written.scale.x).toBeCloseTo(0.01, 10);
+      expect(written.scale.y).toBeCloseTo(1, 10);
     });
   });
 

--- a/packages/inspector/src/lib/renderer/reverse-channel.spec.ts
+++ b/packages/inspector/src/lib/renderer/reverse-channel.spec.ts
@@ -3,6 +3,7 @@ import type { Emitter } from 'mitt';
 import { Quaternion, Vector3 } from '@dcl/ecs-math';
 
 import type { SceneContext } from '../babylon/decentraland/SceneContext';
+import { snapManager } from '../babylon/decentraland/snap-manager';
 import { connectReverseChannel } from './reverse-channel';
 import type { RendererEvents } from './types';
 
@@ -34,6 +35,9 @@ describe('connectReverseChannel', () => {
       dispatch: vi.fn().mockResolvedValue(undefined),
     };
     transformValue = { position: { x: 0, y: 0, z: 0 } };
+    // The merge tests below assert pure composition; snapping (enabled by
+    // default) is exercised by its own describe.
+    snapManager.setEnabled(false);
 
     context = {
       rendererEvents: events,
@@ -129,14 +133,15 @@ describe('connectReverseChannel', () => {
     });
 
     it('should COMPOSE a rotation delta onto the current rotation', () => {
-      // Current: 90° about Y. Delta: 90° about Y. Expected: 180° about Y.
+      // Current: 90° about Y. World-frame delta: 90° about Y. Expected: 180°
+      // about Y (new = delta ⊗ current).
       transformValue = {
         position: { x: 0, y: 0, z: 0 },
         rotation: Quaternion.fromEulerDegrees(0, 90, 0),
         scale: { x: 1, y: 1, z: 1 },
       };
       const delta = Quaternion.fromEulerDegrees(0, 90, 0);
-      const expected = Quaternion.multiply(transformValue.rotation, delta);
+      const expected = Quaternion.multiply(delta, transformValue.rotation);
 
       events.emit('gizmoCommit', {
         transforms: [{ entity: 7 as never, rotation: delta as never }],
@@ -148,6 +153,32 @@ describe('connectReverseChannel', () => {
       }
       // Rotation-only commit leaves position/scale untouched.
       expect(written.position).toEqual({ x: 0, y: 0, z: 0 });
+    });
+
+    it('should apply the rotation delta in the WORLD frame (delta ⊗ current, not current ⊗ delta)', () => {
+      // Current: 90° about Y (local X points along world -Z). A world-aligned
+      // ring drag about world X must rotate about world X regardless of the
+      // entity's orientation — only delta ⊗ current does that; the two orders
+      // differ here (unlike the same-axis case above).
+      transformValue = {
+        position: { x: 0, y: 0, z: 0 },
+        rotation: Quaternion.fromEulerDegrees(0, 90, 0),
+        scale: { x: 1, y: 1, z: 1 },
+      };
+      const delta = Quaternion.fromEulerDegrees(90, 0, 0); // 90° about world X
+      const expected = Quaternion.multiply(delta, transformValue.rotation);
+      const wrongOrder = Quaternion.multiply(transformValue.rotation, delta);
+
+      events.emit('gizmoCommit', {
+        transforms: [{ entity: 7 as never, rotation: delta as never }],
+      });
+
+      const written = (operations.updateValue as ReturnType<typeof vi.fn>).mock.calls[0][2];
+      for (const k of ['x', 'y', 'z', 'w'] as const) {
+        expect(written.rotation[k]).toBeCloseTo(expected[k], 5);
+      }
+      // Sanity: the two orders genuinely differ for this case.
+      expect(Math.abs(Quaternion.dot(expected, wrongOrder))).toBeLessThan(0.999);
     });
 
     it('should MULTIPLY a scale factor onto the current scale', () => {
@@ -164,6 +195,65 @@ describe('connectReverseChannel', () => {
 
       const written = (operations.updateValue as ReturnType<typeof vi.fn>).mock.calls[0][2];
       expect(written.scale).toEqual(Vector3.multiply(transformValue.scale, factor));
+    });
+  });
+
+  describe('when snapping is enabled', () => {
+    beforeEach(() => {
+      snapManager.setEnabled(true);
+      snapManager.setPositionSnap(0.25);
+      snapManager.setRotationSnap(Math.PI / 2); // 90°
+      snapManager.setScaleSnap(0.1);
+    });
+
+    afterEach(() => {
+      snapManager.setEnabled(false);
+    });
+
+    it('should snap a committed position to the position step', () => {
+      events.emit('gizmoCommit', {
+        transforms: [{ entity: 42 as never, position: { x: 1.1, y: 2.04, z: 2.9 } as never }],
+      });
+
+      const written = (operations.updateValue as ReturnType<typeof vi.fn>).mock.calls[0][2];
+      expect(written.position).toEqual({ x: 1, y: 2, z: 3 });
+    });
+
+    it('should snap the composed rotation to the rotation step', () => {
+      // Identity ⊕ 80° about Y, snapped to 90° steps → 90° about Y.
+      transformValue = {
+        position: { x: 0, y: 0, z: 0 },
+        rotation: Quaternion.Identity(),
+        scale: { x: 1, y: 1, z: 1 },
+      };
+      const delta = Quaternion.fromEulerDegrees(0, 80, 0);
+      const expected = Quaternion.fromEulerDegrees(0, 90, 0);
+
+      events.emit('gizmoCommit', {
+        transforms: [{ entity: 7 as never, rotation: delta as never }],
+      });
+
+      const written = (operations.updateValue as ReturnType<typeof vi.fn>).mock.calls[0][2];
+      for (const k of ['x', 'y', 'z', 'w'] as const) {
+        expect(written.rotation[k]).toBeCloseTo(expected[k], 5);
+      }
+    });
+
+    it('should snap the multiplied scale to the scale step', () => {
+      transformValue = {
+        position: { x: 0, y: 0, z: 0 },
+        rotation: Quaternion.Identity(),
+        scale: { x: 1, y: 1, z: 1 },
+      };
+
+      events.emit('gizmoCommit', {
+        transforms: [{ entity: 7 as never, scale: { x: 1.07, y: 1, z: 1 } as never }],
+      });
+
+      const written = (operations.updateValue as ReturnType<typeof vi.fn>).mock.calls[0][2];
+      expect(written.scale.x).toBeCloseTo(1.1, 10);
+      expect(written.scale.y).toBeCloseTo(1, 10);
+      expect(written.scale.z).toBeCloseTo(1, 10);
     });
   });
 

--- a/packages/inspector/src/lib/renderer/reverse-channel.ts
+++ b/packages/inspector/src/lib/renderer/reverse-channel.ts
@@ -5,6 +5,11 @@ import { Quaternion, Vector3 } from '@dcl/ecs-math';
 import type { createOperations } from '../sdk/operations';
 import type { EditorComponents, SdkComponents } from '../sdk/components';
 import { getAncestors, isAncestor, mapNodes } from '../sdk/nodes';
+import {
+  snapPositionValue,
+  snapRotationValue,
+  snapScaleValue,
+} from '../babylon/decentraland/snap-manager';
 import type { PickTarget, RendererEvents } from './types';
 
 /**
@@ -88,16 +93,25 @@ export function connectReverseChannel(context: ReverseChannelTarget): () => void
       // A renderer that can't read the entity's base transform (e.g. the Bevy
       // agent, which lives in a separate engine) sends a gizmo drag as a DELTA:
       // - position is absolute (the renderer is given the world anchor up front);
-      // - rotation is a delta quaternion, composed onto the current rotation;
+      // - rotation is a WORLD-frame delta quaternion about the dragged ring's
+      //   world normal: new = delta ⊗ current. (For a locally-aligned ring the
+      //   normal is the entity's rotated axis, so the same composition applies
+      //   the delta about the entity's local axis.)
       // - scale is a per-axis multiplier, applied to the current scale.
       // Composing here (where we own the real Transform) keeps the untouched
       // fields exact and needs a single write per drag (the renderer commits once
-      // on release), so deltas don't accumulate.
-      const rotation = t.rotation ? Quaternion.multiply(current.rotation, t.rotation) : undefined;
-      const scale = t.scale ? Vector3.multiply(current.scale, t.scale) : undefined;
+      // on release), so deltas don't accumulate. The merged values are snapped
+      // AUTHORITATIVELY here when the editor's snap setting is enabled — the
+      // renderer only quantizes its drag feedback; the real Transform quantizes
+      // where it's written, so committed values land on the snap grid.
+      const position = t.position ? snapPositionValue(t.position) : undefined;
+      const rotation = t.rotation
+        ? snapRotationValue(Quaternion.multiply(t.rotation, current.rotation))
+        : undefined;
+      const scale = t.scale ? snapScaleValue(Vector3.multiply(current.scale, t.scale)) : undefined;
       operations.updateValue(context.Transform, t.entity, {
         ...current,
-        ...(t.position ? { position: t.position } : {}),
+        ...(position ? { position } : {}),
         ...(rotation ? { rotation } : {}),
         ...(scale ? { scale } : {}),
       });

--- a/packages/inspector/src/lib/renderer/reverse-channel.ts
+++ b/packages/inspector/src/lib/renderer/reverse-channel.ts
@@ -36,6 +36,26 @@ export interface ReverseChannelTarget {
  * operations — the inspector owning every scene edit. Any renderer reuses this
  * exact handler by emitting the same events against its own scene engine.
  */
+// A multiplicative scale gizmo can never recover a zero scale (0 × factor = 0),
+// and a drag can otherwise produce one (a tiny factor, or the snap step rounding
+// a small result to 0). Like Babylon's ScaleGizmo `minScaleValue`, keep both the
+// base and the merged result at least MIN_SCALE in magnitude, preserving sign
+// (0 counts as positive).
+const MIN_SCALE = 0.01;
+
+function clampScaleComponent(value: number): number {
+  if (Math.abs(value) >= MIN_SCALE) return value;
+  return value < 0 ? -MIN_SCALE : MIN_SCALE;
+}
+
+function clampScale(scale: { x: number; y: number; z: number }) {
+  return {
+    x: clampScaleComponent(scale.x),
+    y: clampScaleComponent(scale.y),
+    z: clampScaleComponent(scale.z),
+  };
+}
+
 export function connectReverseChannel(context: ReverseChannelTarget): () => void {
   const { engine, operations, editorComponents } = context;
 
@@ -108,7 +128,12 @@ export function connectReverseChannel(context: ReverseChannelTarget): () => void
       const rotation = t.rotation
         ? snapRotationValue(Quaternion.multiply(t.rotation, current.rotation))
         : undefined;
-      const scale = t.scale ? snapScaleValue(Vector3.multiply(current.scale, t.scale)) : undefined;
+      // Scale: clamp the base away from 0 first (so a zeroed entity is
+      // recoverable), multiply, snap, then clamp again (snapping can round a
+      // small result back to 0).
+      const scale = t.scale
+        ? clampScale(snapScaleValue(Vector3.multiply(clampScale(current.scale), t.scale)))
+        : undefined;
       operations.updateValue(context.Transform, t.entity, {
         ...current,
         ...(position ? { position } : {}),


### PR DESCRIPTION
# Bevy gizmos: arrows, plane handles, alignment, snapping + fixes

Brings the Bevy editor-agent gizmos (SDK-scene gizmos rendered by the super-user
agent) much closer to parity with the Babylon editor's gizmos, and fixes several
correctness bugs along the way.

## Features

### Scale gizmo
- **Uniform-scale center cube**: a white cube at the gizmo center; dragging it
  scales all three axes proportionally (motion along the camera's up-right
  diagonal, matching the Babylon center-cube feel). Commits a uniform `{f,f,f}`
  multiplier.
- **Always locally aligned**: the handles follow the entity's world rotation,
  independent of the "Align to world" setting — per-axis scaling is only
  meaningful on local axes (the committed multiplier applies to local scale).
  Matches the Babylon `ScaleGizmo`, which forces local alignment.

### Move gizmo
- **Arrow heads**: each axis arm ends in an outward-pointing cone (zero-top-
  radius cylinder; the SDK has no cone primitive).
- **Plane handles**: three small quads (XY / XZ / YZ) offset from the center,
  colored by their normal axis (Blender-style), for dragging freely within a
  plane. Picked analytically *before* the axis arms, which would otherwise
  shadow them.
- **Respects "Align to world"**: when unchecked, the root, analytic picking, and
  drag projection all use the entity's rotated local axes.

### Rotate gizmo
- **Respects "Align to world"**: rings, ring picking, and the drag plane follow
  the entity's rotation when unchecked; after a commit the gizmo re-aligns to
  the entity's new rotation.

### Snapping (all three gizmos)
- The Snap panel's increments now apply to Bevy gizmo drags, in two layers:
  - **Authoritative (inspector)**: the reverse-channel snaps the merged
    Transform on commit — position to the grid, scale to steps, rotation by
    snapping the final euler decomposition (rotation snap 90° → values land on
    exactly 0/90/180/270, matching Babylon editor semantics).
  - **Feedback (agent)**: snap increments travel over the bus in
    `set-selection`; drags quantize live (rings spin in angle steps, arms/planes
    move in grid steps, scale stretches in factor steps).

## Fixes
- **"Align to world" checkbox was locked under Bevy**: `BevyRenderer`'s gizmo
  surface was still an honest stub reporting `isWorldAlignmentDisabled() ===
  true` with a no-op setter, which `useGizmoAlignment` honors by refusing to
  flip the state. The stub is now real state with change notification, and the
  selection bridge forwards the value to the agent (re-posting on toggle).
- **World-aligned rotation rotated about the wrong axis on rotated entities**:
  the reverse-channel composed `new = current ⊗ delta`, which applies the delta
  in the entity's *local* frame. The agent now commits the delta about the
  ring's *world-space* normal and the reverse-channel composes
  `new = delta ⊗ current` (world-frame). Correct in both alignment modes — a
  locally-aligned ring's normal is the rotated local axis, so the same
  composition applies the delta in the entity's local frame. A test pins the
  order with a case where the two differ.
- **All three gizmos overlapping on first pick after scene load**: handle groups
  are built visible and visibility was only initialized on a translate/rotate/
  scale selection, while the per-frame anchor block re-showed the parked gizmo
  root for *any* selection — including free-mode ones. Visibility is now
  initialized at build time and the anchor block is gated on a mode that draws
  handles (also fixes the previous tool's gizmo lingering under the free tool).
- **Scale 0 was unrecoverable**: scale commits are multiplicative and the snap
  step could round a small result to exactly 0, after which `0 × f = 0`
  forever. The reverse-channel now mirrors Babylon's `minScaleValue`: each
  component is clamped to ≥ 0.01 magnitude (sign-preserving) *before* the
  multiply (so already-zeroed entities can be stretched back) and *after*
  snapping (so the snap step can't round back to 0).
- **Stale gizmo anchor**: the selection bridge now re-posts on Transform changes
  of the selected entity (deduped by value), so the gizmo tracks panel edits,
  undo, and gizmo commits — previously it only re-posted on selection/mode
  changes.

## Plumbing
- `@dcl/inspector-bevy-protocol`: `set-selection` gains `rotation` (entity world
  rotation), `alignToWorld`, and `snap` (increments or null when off);
  `gizmoCommit`'s rotation delta is now documented as world-frame.
- `BevySceneContext.getEntityWorldRotation()`: world rotation composed down the
  `Transform.parent` chain (same spike-level fidelity as world positions).
- `snap-manager`: new renderer-agnostic plain-data helpers `snapRotationValue`
  and `snapScaleValue` (the reverse-channel works with ecs-math values, not
  Babylon classes).
- Selection bridge accepts optional `gizmos` / `snap` handles (wired to the real
  renderer + snap manager in `register.ts`; absent in tests).

## Tests
- Reverse-channel: world-frame composition order (with a case where the orders
  differ), position/rotation/scale snapping, zero-scale clamp + recovery; the
  pure merge tests now explicitly disable snapping.
- Selection bridge: rotation/alignment/snap fields, re-post on Transform change,
  alignment toggle, snap change.
- BevyRenderer: gizmo alignment state, change notification, unsubscribe.
- All existing suites pass (`inspector` unit tests, agent scene build +
  typecheck, ESLint/Prettier).