### PR TITLE
fix(inspector): entity tree lock/hide toggles cannot be turned back off

### DIFF
--- a/packages/inspector/src/components/Tree/ActionArea/ActionArea.tsx
+++ b/packages/inspector/src/components/Tree/ActionArea/ActionArea.tsx
@@ -1,9 +1,11 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { IoEyeOutline as VisibleIcon, IoEyeOffOutline as InvisibleIcon } from 'react-icons/io5';
 import { MdOutlineLock as LockIcon, MdOutlineLockOpen as UnlockIcon } from 'react-icons/md';
-import { Entity } from '@dcl/ecs';
+import type { Entity } from '@dcl/ecs';
 
-import { WithSdkProps, withSdk } from '../../../hoc/withSdk';
+import type { WithSdkProps } from '../../../hoc/withSdk';
+import { withSdk } from '../../../hoc/withSdk';
+import { useHasComponent } from '../../../hooks/sdk/useHasComponent';
 import { CAMERA, PLAYER, ROOT } from '../../../lib/sdk/tree';
 import { InfoTooltip } from '../../ui';
 
@@ -20,13 +22,12 @@ const ActionArea: React.FC<WithSdkProps & Props> = ({ sdk, ...props }) => {
   } = sdk;
   const { entity } = props;
 
-  const isEntityLocked = useMemo(() => {
-    return Lock.getOrNull(entity) !== null;
-  }, [entity, sdk]);
-
-  const isEntityHidden = useMemo(() => {
-    return Hide.getOrNull(entity) !== null;
-  }, [entity, sdk]);
+  // Subscribe to the components so the icon + toggle closure recompute when the
+  // component is added/removed (a plain useMemo over getOrNull never re-fires —
+  // its deps [entity, sdk] don't change on a component write — so the button
+  // would freeze on its first state and look dead after one click).
+  const isEntityLocked = useHasComponent(entity, Lock);
+  const isEntityHidden = useHasComponent(entity, Hide);
 
   const lock = useCallback(
     (value: boolean) => {

--- a/packages/inspector/src/lib/sdk/operations/hide.spec.ts
+++ b/packages/inspector/src/lib/sdk/operations/hide.spec.ts
@@ -1,0 +1,76 @@
+import type { Entity, IEngine, TransformComponentExtended } from '@dcl/ecs';
+import { Engine } from '@dcl/ecs';
+
+import type { EditorComponents } from '../components';
+import { CoreComponents, createEditorComponents } from '../components';
+import { hide } from './hide';
+
+describe('hide', () => {
+  let engine: IEngine;
+  let Transform: TransformComponentExtended;
+  let Hide: EditorComponents['Hide'];
+  let parent: Entity;
+  let child: Entity;
+  let hideOperation: ReturnType<typeof hide>;
+
+  beforeEach(() => {
+    engine = Engine();
+    Transform = engine.getComponent(CoreComponents.TRANSFORM) as TransformComponentExtended;
+    Hide = createEditorComponents(engine).Hide;
+    parent = engine.addEntity();
+    child = engine.addEntity();
+    Transform.create(parent, {});
+    Transform.create(child, { parent });
+    hideOperation = hide(engine);
+  });
+
+  describe('when hiding a visible entity', () => {
+    beforeEach(() => {
+      hideOperation(parent, true);
+    });
+
+    it('should add the Hide component to the entity and all its children', () => {
+      expect(Hide.getOrNull(parent)).toStrictEqual({ value: true });
+      expect(Hide.getOrNull(child)).toStrictEqual({ value: true });
+    });
+
+    describe('and then un-hiding it', () => {
+      beforeEach(() => {
+        hideOperation(parent, false);
+      });
+
+      it('should remove the Hide component from the entity and all its children', () => {
+        expect(Hide.getOrNull(parent)).toBeNull();
+        expect(Hide.getOrNull(child)).toBeNull();
+      });
+    });
+
+    describe('and then hiding it again', () => {
+      it('should not throw and should keep the Hide component on the whole tree', () => {
+        expect(() => hideOperation(parent, true)).not.toThrow();
+        expect(Hide.getOrNull(parent)).toStrictEqual({ value: true });
+        expect(Hide.getOrNull(child)).toStrictEqual({ value: true });
+      });
+    });
+  });
+
+  describe('when hiding a parent whose child is already hidden', () => {
+    beforeEach(() => {
+      hideOperation(child, true);
+    });
+
+    it('should not throw and should hide the whole tree', () => {
+      expect(() => hideOperation(parent, true)).not.toThrow();
+      expect(Hide.getOrNull(parent)).toStrictEqual({ value: true });
+      expect(Hide.getOrNull(child)).toStrictEqual({ value: true });
+    });
+  });
+
+  describe('when un-hiding an entity that is not hidden', () => {
+    it('should not throw and should leave the tree without Hide components', () => {
+      expect(() => hideOperation(parent, false)).not.toThrow();
+      expect(Hide.getOrNull(parent)).toBeNull();
+      expect(Hide.getOrNull(child)).toBeNull();
+    });
+  });
+});

--- a/packages/inspector/src/lib/sdk/operations/hide.ts
+++ b/packages/inspector/src/lib/sdk/operations/hide.ts
@@ -16,7 +16,10 @@ export function hide(engine: IEngine) {
     const tree = Array.from(getComponentEntityTree(engine, entity, Transform));
     for (const node of tree) {
       if (value) {
-        addComponent(node, Hide.componentId, { value: true });
+        // Guard: a node in the tree may already carry Hide (e.g. a child hidden
+        // earlier, then the parent hidden) — addComponent uses component.create,
+        // which throws if it already exists ("already exists"). Skip those.
+        if (!Hide.has(node)) addComponent(node, Hide.componentId, { value: true });
       } else {
         removeComponent(node, Hide);
       }

--- a/packages/inspector/src/lib/sdk/operations/lock.spec.ts
+++ b/packages/inspector/src/lib/sdk/operations/lock.spec.ts
@@ -1,0 +1,54 @@
+import type { Entity, IEngine } from '@dcl/ecs';
+import { Engine } from '@dcl/ecs';
+
+import type { EditorComponents } from '../components';
+import { createEditorComponents } from '../components';
+import { lock } from './lock';
+
+describe('lock', () => {
+  let engine: IEngine;
+  let Lock: EditorComponents['Lock'];
+  let entity: Entity;
+  let lockOperation: ReturnType<typeof lock>;
+
+  beforeEach(() => {
+    engine = Engine();
+    Lock = createEditorComponents(engine).Lock;
+    entity = engine.addEntity();
+    lockOperation = lock(engine);
+  });
+
+  describe('when locking an unlocked entity', () => {
+    beforeEach(() => {
+      lockOperation(entity, true);
+    });
+
+    it('should add the Lock component to the entity', () => {
+      expect(Lock.getOrNull(entity)).toStrictEqual({ value: true });
+    });
+
+    describe('and then unlocking it', () => {
+      beforeEach(() => {
+        lockOperation(entity, false);
+      });
+
+      it('should remove the Lock component from the entity', () => {
+        expect(Lock.getOrNull(entity)).toBeNull();
+      });
+    });
+
+    describe('and then locking it again', () => {
+      it('should not throw and should keep the Lock component', () => {
+        expect(() => lockOperation(entity, true)).not.toThrow();
+        expect(Lock.getOrNull(entity)).toStrictEqual({ value: true });
+      });
+    });
+  });
+
+  describe('when unlocking an entity that is not locked', () => {
+    it('should not throw and should leave the entity without a Lock component', () => {
+      expect(() => lockOperation(entity, false)).not.toThrow();
+      expect(Lock.getOrNull(entity)).toBeNull();
+    });
+  });
+});

--- a/packages/inspector/src/lib/sdk/operations/lock.ts
+++ b/packages/inspector/src/lib/sdk/operations/lock.ts
@@ -12,7 +12,9 @@ export function lock(engine: IEngine) {
 
     // Apply the lock only to the selected entity, not to its children
     if (value) {
-      addComponent(entity, Lock.componentId, { value: true });
+      // Guard against a double-add: addComponent uses component.create, which
+      // throws if Lock already exists on the entity.
+      if (!Lock.has(entity)) addComponent(entity, Lock.componentId, { value: true });
     } else {
       removeComponent(entity, Lock);
     }


### PR DESCRIPTION
## Overview

In the hierarchy panel, clicking the eye icon hid an entity and clicking the padlock locked it, but clicking either icon again did nothing — both toggles worked only in the "on" direction. The `ActionArea` component computed `isEntityLocked` / `isEntityHidden` with a `useMemo` over `Lock.getOrNull(entity)` / `Hide.getOrNull(entity)` keyed on `[entity, sdk]`; neither dependency changes when a component is added or removed from the engine, so the memoized value froze at its first computation. Every subsequent click re-derived `value = !false = true` and re-issued the "add component" path, where `component.create` throws because the component already exists — making the second click appear dead.

## Behavior

- Clicking the eye icon hides the entity (and its children); clicking it again un-hides them.
- Clicking the padlock locks the entity; clicking it again unlocks it.
- The row icon updates immediately in both directions (eye ↔ crossed eye, open ↔ closed padlock).

## Implementation

- `packages/inspector/src/components/Tree/ActionArea/ActionArea.tsx` — replaced the stale `useMemo(() => X.getOrNull(entity) !== null, [entity, sdk])` derivations with the existing `useHasComponent(entity, Lock)` / `useHasComponent(entity, Hide)` hook, which subscribes to engine change events for that entity/component pair and re-renders when the component is added or removed. Also converted `Entity` / `WithSdkProps` to `import type` (lint).
- `packages/inspector/src/lib/sdk/operations/hide.ts` — guarded the add path with `Hide.has(node)`: hiding a parent whose child was already hidden individually put an already-carrying node in the tree walk, and `component.create` throws on double-add.
- `packages/inspector/src/lib/sdk/operations/lock.ts` — same `Lock.has(entity)` guard against a double-add throw.

## Testing

- Added `packages/inspector/src/lib/sdk/operations/lock.spec.ts` (4 tests) and `hide.spec.ts` (5 tests) using a real `@dcl/ecs` engine + `createEditorComponents`: toggle on adds the component, toggle off removes it (for hide: across the whole Transform tree), re-hiding/re-locking an already-hidden/locked entity does not throw, un-hiding/unlocking a clean entity does not throw, and hiding a parent whose child is already hidden does not throw.
- All operations specs pass: 13 files, 77 tests.
- `npm run typecheck`, `eslint`, and `prettier --check` pass on the touched files.
- Verified live in the running inspector with Playwright: hide → un-hide → lock → unlock on a tree entity, with each icon flip asserted via DOM waits and captured in the screenshots below.

## Screenshots

Hide → un-hide (the second click is what was broken):

| Initial | Hidden (1st click) | Un-hidden (2nd click — fixed) |
| --- | --- | --- |
| ![Initial state](https://raw.githubusercontent.com/decentraland/creator-hub/153a8335d3ffcb42be679df78fa830033073e15d/tree-toggles-1-initial.png) | ![Hidden](https://raw.githubusercontent.com/decentraland/creator-hub/153a8335d3ffcb42be679df78fa830033073e15d/tree-toggles-2-hidden.png) | ![Un-hidden](https://raw.githubusercontent.com/decentraland/creator-hub/153a8335d3ffcb42be679df78fa830033073e15d/tree-toggles-3-unhidden.png) |

Lock → unlock:

| Locked (1st click) | Unlocked (2nd click — fixed) |
| --- | --- |
| ![Locked](https://raw.githubusercontent.com/decentraland/creator-hub/153a8335d3ffcb42be679df78fa830033073e15d/tree-toggles-4-locked.png) | ![Unlocked](https://raw.githubusercontent.com/decentraland/creator-hub/153a8335d3ffcb42be679df78fa830033073e15d/tree-toggles-5-unlocked.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
