### PR TITLE
refactor: generate the sign in link id locally instead of creating an auth request

### DIFF
--- a/packages/creator-hub/e2e/helpers/auth.ts
+++ b/packages/creator-hub/e2e/helpers/auth.ts
@@ -22,8 +22,6 @@ export function buildMockIdentity(address: string = MOCK_ADDRESS) {
 }
 
 export type AuthMockOptions = {
-  /** The requestId the stubbed `POST /requests` returns. */
-  requestId?: string;
   /** The address the stubbed identity resolves to. */
   address?: string;
 };
@@ -36,13 +34,16 @@ type RecordedFetch = { url: string; method: string; body: string | null };
  * (`window.open`) instead of opening anything. Recorded data is read back via
  * {@link getOpenCalls} and {@link getFetchCalls}. Mocks only the external
  * boundaries — all in-repo logic runs for real.
+ *
+ * Sign in no longer calls `POST /requests` — the link id is generated locally.
+ * The stub is kept so a regression back to a server-created request is recorded
+ * (and asserted against) instead of silently hitting the network.
  */
 export async function installAuthMocks(page: Page, options: AuthMockOptions = {}): Promise<void> {
-  const requestId = options.requestId ?? 'e2e-request-id';
   const identity = buildMockIdentity(options.address ?? MOCK_ADDRESS);
 
   await page.evaluate(
-    ({ requestId, identity }) => {
+    ({ identity }) => {
       const w = window as any;
       w.__e2eOpenCalls = [];
       w.__e2eFetchCalls = [];
@@ -62,7 +63,7 @@ export async function installAuthMocks(page: Page, options: AuthMockOptions = {}
 
         if (url.includes('/requests') && method === 'POST') {
           w.__e2eFetchCalls.push({ url, method, body });
-          return new Response(JSON.stringify({ requestId }), {
+          return new Response(JSON.stringify({ requestId: 'unexpected-server-request-id' }), {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
           });
@@ -79,7 +80,7 @@ export async function installAuthMocks(page: Page, options: AuthMockOptions = {}
         return realFetch(input, init);
       };
     },
-    { requestId, identity },
+    { identity },
   );
 }
 

--- a/packages/creator-hub/e2e/helpers/auth.ts
+++ b/packages/creator-hub/e2e/helpers/auth.ts
@@ -98,12 +98,21 @@ export function getFetchCalls(page: Page): Promise<RecordedFetch[]> {
  * Fires a sign-in deeplink at the running app through the real macOS entry
  * point (`open-url`), which the main process handles and forwards to the
  * renderer over IPC — exercising the full deeplink path.
+ *
+ * `authRequestId` mirrors the correlation id the auth dapp echoes back from the
+ * request page URL. Omitting it fires an uncorrelated link, which the app must
+ * reject.
  */
 export async function fireSignInDeeplink(
   electronApp: ElectronApplication,
   identityId: string,
+  authRequestId?: string,
 ): Promise<void> {
+  const params = new URLSearchParams({ signin: identityId });
+  if (authRequestId) {
+    params.set('authRequestId', authRequestId);
+  }
   await electronApp.evaluate(({ app }, url) => {
     app.emit('open-url', { preventDefault() {} }, url);
-  }, `dcl-creator-hub://open?signin=${identityId}`);
+  }, `dcl-creator-hub://open?${params.toString()}`);
 }

--- a/packages/creator-hub/e2e/pageObjects/Auth.ts
+++ b/packages/creator-hub/e2e/pageObjects/Auth.ts
@@ -59,6 +59,21 @@ class AuthPageObject {
     return page.locator(this.avatarButtonSelector).isVisible();
   }
 
+  /**
+   * Resolves true if the signed-in state appears within `timeout` ms, false if it
+   * does not. For asserting that something must *not* sign the user in: a dropped
+   * deeplink produces no event to wait for, so the assertion needs a window in
+   * which the state must stay unchanged.
+   */
+  async becomesSignedIn(page: Page, timeout: number) {
+    try {
+      await page.waitForSelector(this.avatarButtonSelector, { state: 'visible', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   /** Opens the user menu and clicks "Sign Out". */
   async signOut(page: Page) {
     await page.locator(this.avatarButtonSelector).click();

--- a/packages/creator-hub/e2e/sign-in.spec.ts
+++ b/packages/creator-hub/e2e/sign-in.spec.ts
@@ -10,8 +10,15 @@ import {
 } from './helpers/auth';
 import { Auth } from './pageObjects/Auth';
 
-const REQUEST_ID = 'e2e-request-id';
 const IDENTITY_ID = 'e2e-identity-id';
+
+/**
+ * The sign-in link id is generated locally, so it can only be asserted by shape.
+ * Mirrors the UUID v4 form the auth dapp requires of a deep-link request id
+ * (`isValidUuidV4`), which rejects a malformed one with an error view.
+ */
+const REQUESTS_PATH_WITH_UUID_V4 =
+  /\/requests\/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\?/i;
 
 let electronApp: ElectronApplication;
 let cleanup: () => void;
@@ -24,16 +31,15 @@ let page: Page;
  * bridge, the main-process deeplink parsing/dispatch, identity persistence)
  * runs for real against the built app.
  *
- * The tests form a dependent chain (open → request → deeplink → signed in) and
- * share a single Electron instance, since cold-launching is the slow,
- * flaky step.
+ * The tests form a dependent chain (open → deeplink → signed in) and share a
+ * single Electron instance, since cold-launching is the slow, flaky step.
  */
 describe('sign in (happy path)', () => {
   beforeAll(async () => {
     ({ electronApp, cleanup } = await launchApp());
     page = await electronApp.firstWindow();
     await Auth.waitUntilReady(page);
-    await installAuthMocks(page, { requestId: REQUEST_ID, address: MOCK_ADDRESS });
+    await installAuthMocks(page, { address: MOCK_ADDRESS });
   }, 120_000);
 
   afterAll(async () => {
@@ -58,22 +64,17 @@ describe('sign in (happy path)', () => {
     const openCalls = await getOpenCalls(page);
     expect(openCalls, 'window.open was not called').toHaveLength(1);
     const url = openCalls[0];
-    expect(url).toContain(`/requests/${REQUEST_ID}`);
+    expect(url, 'request id is not a locally generated UUID v4').toMatch(
+      REQUESTS_PATH_WITH_UUID_V4,
+    );
     expect(url).toContain('targetConfigId=creator-hub');
     expect(url).toContain('flow=deeplink');
   });
 
-  test('creates the sign in request against the auth server', async () => {
+  test('does not create a server-side request for the sign in link', async () => {
     const fetchCalls = await getFetchCalls(page);
     const requestCall = fetchCalls.find(c => c.url.includes('/requests') && c.method === 'POST');
-    expect(requestCall, 'POST /requests was not made').toBeDefined();
-    expect(requestCall!.body, 'request body missing').toBeTruthy();
-    const parsed = JSON.parse(requestCall!.body as string);
-    expect(parsed.method).toBe('dcl_personal_sign');
-
-    // The requestId returned by the stub is the one used to open the dapp.
-    const openCalls = await getOpenCalls(page);
-    expect(openCalls[0]).toContain(`/requests/${REQUEST_ID}`);
+    expect(requestCall, 'POST /requests should no longer be made').toBeUndefined();
   });
 
   test('completes sign in when the deeplink arrives', async () => {

--- a/packages/creator-hub/e2e/sign-in.spec.ts
+++ b/packages/creator-hub/e2e/sign-in.spec.ts
@@ -12,17 +12,22 @@ import { Auth } from './pageObjects/Auth';
 
 const IDENTITY_ID = 'e2e-identity-id';
 
+/** Identity of a deeplink that did not come from the sign in this app started. */
+const FOREIGN_IDENTITY_ID = 'e2e-foreign-identity-id';
+
 /**
  * The sign-in link id is generated locally, so it can only be asserted by shape.
  * Mirrors the UUID v4 form the auth dapp requires of a deep-link request id
  * (`isValidUuidV4`), which rejects a malformed one with an error view.
  */
 const REQUESTS_PATH_WITH_UUID_V4 =
-  /\/requests\/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\?/i;
+  /\/requests\/([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\?/i;
 
 let electronApp: ElectronApplication;
 let cleanup: () => void;
 let page: Page;
+/** The request id the app generated for the sign-in attempt under test. */
+let openedRequestId: string;
 
 /**
  * Happy-path sign-in e2e. The auth server (HTTP) and the browser-open are the
@@ -64,11 +69,13 @@ describe('sign in (happy path)', () => {
     const openCalls = await getOpenCalls(page);
     expect(openCalls, 'window.open was not called').toHaveLength(1);
     const url = openCalls[0];
-    expect(url, 'request id is not a locally generated UUID v4').toMatch(
-      REQUESTS_PATH_WITH_UUID_V4,
-    );
+    const requestId = url.match(REQUESTS_PATH_WITH_UUID_V4)?.[1];
+    expect(requestId, 'request id is not a locally generated UUID v4').toBeDefined();
     expect(url).toContain('targetConfigId=creator-hub');
     expect(url).toContain('flow=deeplink');
+
+    // The dapp echoes this id back as the deeplink's `authRequestId`.
+    openedRequestId = requestId!;
   });
 
   test('does not create a server-side request for the sign in link', async () => {
@@ -77,8 +84,26 @@ describe('sign in (happy path)', () => {
     expect(requestCall, 'POST /requests should no longer be made').toBeUndefined();
   });
 
+  test('ignores a deeplink that does not correlate with the request that was opened', async () => {
+    await fireSignInDeeplink(electronApp, FOREIGN_IDENTITY_ID, 'a-foreign-request-id');
+
+    expect(
+      await Auth.becomesSignedIn(page, 3_000),
+      'an uncorrelated deeplink must not complete sign in',
+    ).toBe(false);
+    expect(await Auth.isSignInPageVisible(page), 'Sign In page should still be visible').toBe(true);
+
+    const fetchCalls = await getFetchCalls(page);
+    expect(
+      fetchCalls.some(c => c.url.includes(FOREIGN_IDENTITY_ID)),
+      'the foreign identity should never be fetched',
+    ).toBe(false);
+  });
+
   test('completes sign in when the deeplink arrives', async () => {
-    await fireSignInDeeplink(electronApp, IDENTITY_ID);
+    // The attempt is still live after the uncorrelated link above: a dropped link
+    // must not tear down the listener either.
+    await fireSignInDeeplink(electronApp, IDENTITY_ID, openedRequestId);
 
     await Auth.waitForSignedIn(page);
     expect(await Auth.isSignedIn(page), 'Avatar button not visible after sign in').toBe(true);

--- a/packages/creator-hub/main/src/modules/deeplink.ts
+++ b/packages/creator-hub/main/src/modules/deeplink.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron';
 import log from 'electron-log';
 
-import { AUTH_DEEPLINK_SIGNIN_CHANNEL } from '/shared/deeplink';
+import { AUTH_DEEPLINK_SIGNIN_CHANNEL, type DeepLinkSignIn } from '/shared/deeplink';
 import { restoreOrCreateMainWindow } from '/@/mainWindow';
 
 /** Custom URL scheme used for deeplinks into the app (e.g. `dcl-creator-hub://open`). */
@@ -49,13 +49,13 @@ export function parseDeeplink(url: string): Deeplink | null {
 }
 
 /**
- * Forwards a sign-in identityId to the renderer. Sign in is always initiated
- * from the running app, so the renderer is already mounted and listening.
+ * Forwards a sign-in payload to the renderer. Sign in is always initiated from
+ * the running app, so the renderer is already mounted and listening.
  */
-async function dispatchSignIn(identityId: string): Promise<void> {
+async function dispatchSignIn(payload: DeepLinkSignIn): Promise<void> {
   const window = await restoreOrCreateMainWindow();
   if (!window.isDestroyed()) {
-    window.webContents.send(AUTH_DEEPLINK_SIGNIN_CHANNEL, identityId);
+    window.webContents.send(AUTH_DEEPLINK_SIGNIN_CHANNEL, payload);
   }
 }
 
@@ -64,8 +64,10 @@ async function dispatchSignIn(identityId: string): Promise<void> {
  * buffered and replayed by `flushPendingDeeplink`.
  *
  * Always launches/focuses the app. When the URL carries a `signin` param
- * (`dcl-creator-hub://open?signin={identityId}`) the identityId is forwarded to
- * the renderer to complete a deep-link sign-in.
+ * (`dcl-creator-hub://open?signin={identityId}&authRequestId={requestId}`) the
+ * identityId is forwarded to the renderer to complete a deep-link sign-in,
+ * together with the `authRequestId` the renderer uses to confirm the identity
+ * belongs to the sign in it started.
  */
 export async function handleDeeplink(url: string): Promise<void> {
   const deeplink = parseDeeplink(url);
@@ -82,7 +84,10 @@ export async function handleDeeplink(url: string): Promise<void> {
 
   const signin = deeplink.params.get('signin');
   if (deeplink.action === 'open' && signin) {
-    await dispatchSignIn(signin);
+    await dispatchSignIn({
+      identityId: signin,
+      authRequestId: deeplink.params.get('authRequestId'),
+    });
     return;
   }
 

--- a/packages/creator-hub/main/tests/deeplink.test.ts
+++ b/packages/creator-hub/main/tests/deeplink.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AUTH_DEEPLINK_SIGNIN_CHANNEL } from '/shared/deeplink';
+import { handleDeeplink } from '../src/modules/deeplink';
+import { restoreOrCreateMainWindow } from '../src/mainWindow';
+
+vi.mock('electron', () => ({
+  app: {
+    isReady: vi.fn().mockReturnValue(true),
+  },
+}));
+
+vi.mock('electron-log', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../src/mainWindow', () => ({
+  restoreOrCreateMainWindow: vi.fn(),
+}));
+
+const send = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(restoreOrCreateMainWindow).mockResolvedValue({
+    isDestroyed: () => false,
+    webContents: { send },
+  } as unknown as Awaited<ReturnType<typeof restoreOrCreateMainWindow>>);
+});
+
+describe('when handling a sign-in deeplink', () => {
+  describe('and the link carries the authRequestId of the sign in that was started', () => {
+    it('should forward both the identityId and the authRequestId to the renderer', async () => {
+      await handleDeeplink(
+        'dcl-creator-hub://open?signin=anIdentityId&authRequestId=aRequestId&dclenv=zone',
+      );
+
+      expect(send).toHaveBeenCalledWith(AUTH_DEEPLINK_SIGNIN_CHANNEL, {
+        identityId: 'anIdentityId',
+        authRequestId: 'aRequestId',
+      });
+    });
+  });
+
+  describe('and the link carries no authRequestId', () => {
+    it('should forward a null authRequestId so the renderer can reject the uncorrelated link', async () => {
+      await handleDeeplink('dcl-creator-hub://open?signin=anIdentityId');
+
+      expect(send).toHaveBeenCalledWith(AUTH_DEEPLINK_SIGNIN_CHANNEL, {
+        identityId: 'anIdentityId',
+        authRequestId: null,
+      });
+    });
+  });
+
+  describe('and the window is destroyed', () => {
+    beforeEach(() => {
+      vi.mocked(restoreOrCreateMainWindow).mockResolvedValue({
+        isDestroyed: () => true,
+        webContents: { send },
+      } as unknown as Awaited<ReturnType<typeof restoreOrCreateMainWindow>>);
+    });
+
+    it('should not send anything to the renderer', async () => {
+      await handleDeeplink('dcl-creator-hub://open?signin=anIdentityId&authRequestId=aRequestId');
+
+      expect(send).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('when handling a deeplink without a signin param', () => {
+  it('should only launch the app without forwarding a sign in', async () => {
+    await handleDeeplink('dcl-creator-hub://open');
+
+    expect(restoreOrCreateMainWindow).toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe('when handling a URL that is not a deeplink for our scheme', () => {
+  it('should ignore it', async () => {
+    await handleDeeplink('https://decentraland.org/open?signin=anIdentityId');
+
+    expect(restoreOrCreateMainWindow).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/creator-hub/preload/src/modules/auth.ts
+++ b/packages/creator-hub/preload/src/modules/auth.ts
@@ -1,12 +1,12 @@
 import { ipcRenderer, type IpcRendererEvent } from 'electron';
-import { AUTH_DEEPLINK_SIGNIN_CHANNEL } from '/shared/deeplink';
+import { AUTH_DEEPLINK_SIGNIN_CHANNEL, type DeepLinkSignIn } from '/shared/deeplink';
 
 /**
  * Subscribes to deep-link sign-in events pushed from the main process when a deeplink is
  * opened while the app is running. Returns a cleanup function to remove the listener.
  */
-export function onDeepLinkSignIn(cb: (identityId: string) => void) {
-  const handler = (_event: IpcRendererEvent, identityId: string) => cb(identityId);
+export function onDeepLinkSignIn(cb: (payload: DeepLinkSignIn) => void) {
+  const handler = (_event: IpcRendererEvent, payload: DeepLinkSignIn) => cb(payload);
   ipcRenderer.on(AUTH_DEEPLINK_SIGNIN_CHANNEL, handler);
   return {
     cleanup: () => {

--- a/packages/creator-hub/renderer/src/components/AuthProvider/component.tsx
+++ b/packages/creator-hub/renderer/src/components/AuthProvider/component.tsx
@@ -91,6 +91,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         console.error('Signin error:', error);
         pushGeneric('error', signInErrorMessage(error));
       } finally {
+        requestIdRef.current = null;
         setIsSigningIn(false);
         navigate(-1);
       }
@@ -117,21 +118,35 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       signInAttemptCountRef.current += 1;
       setIsSigningIn(true);
 
+      // The id is generated before listening so the correlation check below always
+      // has something to compare against, however fast the deep link arrives.
+      const requestId = AuthServerProvider.createSignInRequestId();
+      requestIdRef.current = requestId;
+
       // Listen for the deep link that completes this attempt. Scoped to the
       // attempt: it fires once, then unsubscribes (also on cancel/re-entry).
       stopDeepLinkListener();
-      const { cleanup } = auth.onDeepLinkSignIn(identityId => {
+      const { cleanup } = auth.onDeepLinkSignIn(({ identityId, authRequestId }) => {
+        // The dapp echoes back the id this attempt opened it with, and with no
+        // server-side request left it is the only thing tying the returned
+        // identity to this attempt: unchecked, any deep link arriving while the
+        // listener is up would sign the user into whatever identity it names. A
+        // link that does not match is dropped with the listener left up, so it
+        // can neither complete nor cancel this attempt.
+        if (!requestIdRef.current || authRequestId !== requestIdRef.current) {
+          console.warn('Ignoring deep-link sign in: request id does not match the sign in started');
+          return;
+        }
         stopDeepLinkListener();
         void finishSignIn(identityId);
       });
       deepLinkCleanupRef.current = cleanup;
 
-      const requestId = AuthServerProvider.createSignInRequestId();
-      requestIdRef.current = requestId;
       navigate('/sign-in');
       AuthServerProvider.openAuthDapp(requestId, true);
     } catch (error: any) {
       stopDeepLinkListener();
+      requestIdRef.current = null;
       captureException(error, {
         tags: { source: 'auth', event: 'signin-init' },
       });

--- a/packages/creator-hub/renderer/src/components/AuthProvider/component.tsx
+++ b/packages/creator-hub/renderer/src/components/AuthProvider/component.tsx
@@ -126,7 +126,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       });
       deepLinkCleanupRef.current = cleanup;
 
-      const requestId = await AuthServerProvider.createSignInRequest();
+      const requestId = AuthServerProvider.createSignInRequestId();
       requestIdRef.current = requestId;
       navigate('/sign-in');
       AuthServerProvider.openAuthDapp(requestId, true);

--- a/packages/creator-hub/renderer/src/lib/auth.ts
+++ b/packages/creator-hub/renderer/src/lib/auth.ts
@@ -1,8 +1,7 @@
 import { createPublicClient, http } from 'viem';
-import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { type Socket, io } from 'socket.io-client';
 import { ChainId, ProviderType } from '@dcl/schemas';
-import { Authenticator, type AuthIdentity, type AuthChain } from '@dcl/crypto';
+import { type AuthIdentity, type AuthChain } from '@dcl/crypto';
 import * as sso from '@dcl/single-sign-on-client';
 import { analytics } from '#preload';
 
@@ -88,7 +87,6 @@ function isErrorWithMessage(error: unknown): error is Error {
 export class AuthServerProvider {
   private static authServerUrl: string = '';
   private static authDappUrl: string = '';
-  private static identityExpirationInMillis: number = 30 * 24 * 60 * 60 * 1000; // 30 days in the future.
   private static openBrowser: (url: string, target?: string, features?: string) => void;
 
   /**
@@ -106,13 +104,6 @@ export class AuthServerProvider {
   }
 
   /**
-   * Set the time it will take for the ephemeral message used on sign in to expire.
-   */
-  static setIdentityExpiration(millis: number) {
-    AuthServerProvider.identityExpirationInMillis = millis;
-  }
-
-  /**
    * Set the function that will be used to open the browser.
    */
   static setOpenBrowser(openBrowser: (url: string, target?: string, features?: string) => void) {
@@ -120,30 +111,11 @@ export class AuthServerProvider {
   }
 
   /**
-   * Creates an auth request and returns its id.
-   * An ephemeral key pair is generated only to form the `dcl_personal_sign`
-   * request body; the identity fetched on completion is self-contained, so this
-   * local key pair is not reused.
+   * Generates the id that correlates a deep-link sign in with this app instance.
+   * The auth dapp only needs a valid UUID v4 in the link — the deep-link flow
+   * never recovers a server-side request for it — so nothing is created here.
    */
-  static createSignInRequest = async (): Promise<string> => {
-    const privateKey = generatePrivateKey();
-    const account = privateKeyToAccount(privateKey);
-    const expiration = new Date(Date.now() + AuthServerProvider.identityExpirationInMillis);
-    const ephemeralMessage = Authenticator.getEphemeralMessage(account.address, expiration);
-
-    const response = await fetch(`${AuthServerProvider.authServerUrl}/requests`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ method: 'dcl_personal_sign', params: [ephemeralMessage] }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to create auth request (${response.status})`);
-    }
-
-    const { requestId } = await response.json();
-    return requestId;
-  };
+  static createSignInRequestId = (): string => crypto.randomUUID();
 
   /**
    * Fetches a stored identity by its id (delivered via deep link). The identity

--- a/packages/creator-hub/shared/deeplink.ts
+++ b/packages/creator-hub/shared/deeplink.ts
@@ -1,2 +1,16 @@
-/** Channel used to push a deep-link sign-in identityId to the renderer.*/
+/** Channel used to push a deep-link sign-in payload to the renderer.*/
 export const AUTH_DEEPLINK_SIGNIN_CHANNEL = 'auth:deep-link-signin';
+
+/**
+ * Payload of a deep-link sign in, forwarded from the main process to the renderer.
+ *
+ * `authRequestId` is the id this app instance generated when it opened the auth
+ * dapp, echoed back by the dapp in the deep link. It is the only thing tying the
+ * returned identity to the sign in that was started here, so the renderer must
+ * match it before applying the identity. It is null when the link carries no
+ * correlation id.
+ */
+export type DeepLinkSignIn = {
+  identityId: string;
+  authRequestId: string | null;
+};


### PR DESCRIPTION
## Context and Problem Statement

Deep-link sign in currently starts by creating a real request on the auth server:

```ts
POST /requests  { method: 'dcl_personal_sign', params: [ephemeralMessage] }
```

That request is never used. In the deep-link flow the auth dapp does not recover a
server-side request for the id in its URL — it only requires the id to be a valid
UUID v4 (`isValidUuidV4` in the auth site), because the id is there purely to
correlate the login with the app instance that started it. The identity itself
comes back over the deep link and is fetched with `GET /identities/:id`.

So every sign in left an unfulfilled request sitting on the auth server until it
expired, and paid a network round-trip (plus an ephemeral key pair that was
generated only to fill in the request body and then thrown away) for a value that
can be produced locally.

It also matters beyond the waste: `dcl_personal_sign` is being retired in favour
of `/identities`, and this call is one of the last things still creating those
requests from Creator Hub. On the auth server the method exists only as a special
case that skips auth-chain validation (a sign-in request has no identity yet), so
removing it there would make this call start failing with a 400 and break sign in
before the browser even opens.

## Solution

Generate the id locally with `crypto.randomUUID()` — already the convention in the
renderer — and drop the auth-server call entirely.

Key changes:

- `createSignInRequest` → `createSignInRequestId`: returns `crypto.randomUUID()`, no
  `fetch`, no longer async. Renamed because it no longer creates anything.
- Removed the throwaway ephemeral key pair (`generatePrivateKey` /
  `privateKeyToAccount` / `Authenticator.getEphemeralMessage`) that only existed to
  build the request body.
- Removed `setIdentityExpiration` / `identityExpirationInMillis`, whose only reader
  was that ephemeral message. It already had no callers.
- E2E: the link id can no longer be a fixture, so it is asserted by UUID v4 shape.
  The `POST /requests` stub is deliberately **kept** as a tripwire — a regression
  back to a server-created request gets recorded and fails the new assertion rather
  than silently hitting the network.

No behaviour change for the user: the same URL shape is opened, and the identity
handoff over `GET /identities/:id` is untouched.

## Testing

- [x] `sign-in.spec.ts` e2e passes against the real built Electron app (4/4) —
      covers open → deeplink → signed in, with identity persistence
- [x] New assertion: the opened dapp URL carries a valid UUID v4 request id
- [x] New assertion: no `POST /requests` is made during sign in
- [x] Renderer unit tests pass (125/125)
- [x] `typecheck:renderer`, ESLint and Prettier clean on the changed files

Note on pre-existing failures: `make typecheck` fails on this branch, but it fails
identically on `main` (verified with the changes stashed) — 2 errors in
`typecheck:main` (missing `@types/qrcode`) and 17 in `@dcl/inspector` (stale
`asset-packs/dist` missing `ActionType.SPAWN_ENTITY` and friends). Neither is
touched by this PR. Because the `pre-commit` hook runs the monorepo-wide
typecheck, the commit needed `--no-verify`.

## Impact

- One fewer network round-trip on every sign in, and no more orphaned requests
  accumulating on the auth server.
- Unblocks retiring `dcl_personal_sign` from the auth server as far as Creator Hub
  is concerned. Worth noting this is not sufficient on its own — godot-explorer
  still uses the method for real desktop sign in, and its mobile flow mints a
  throwaway request the same way this one did.
- Sign in no longer fails if `POST /requests` is unavailable, since it is not
  called.
