### PR TITLE
Remove the Test Server publish option

### DIFF
--- a/packages/creator-hub/.env.example
+++ b/packages/creator-hub/.env.example
@@ -22,7 +22,6 @@ VITE_ENABLE_DEV_APP_UPDATE=
 
 # Publish (leave empty for local dev)
 VITE_WORLDS_SERVER=
-VITE_TEST_SERVER=
 
 # Security
 VITE_ALLOWED_EXTERNAL_ORIGINS="https://github.com"

--- a/packages/creator-hub/renderer/src/components/Modals/PublishProject/steps/AlternativeServers/component.tsx
+++ b/packages/creator-hub/renderer/src/components/Modals/PublishProject/steps/AlternativeServers/component.tsx
@@ -1,5 +1,5 @@
 import { type ChangeEvent, useCallback, useState } from 'react';
-import { Button, MenuItem, Select } from 'decentraland-ui2';
+import { Button } from 'decentraland-ui2';
 
 import { misc } from '#preload';
 
@@ -53,14 +53,9 @@ export function AlternativeServers(props: Props) {
           <div className="selection">
             <div>
               <h3>{t('modal.publish_project.alternative_servers.list')}</h3>
-              <Select
-                variant="standard"
-                value="custom"
-              >
-                <MenuItem value="custom">
-                  {t('modal.publish_project.alternative_servers.options.custom_server')}
-                </MenuItem>
-              </Select>
+              <span className="server_name">
+                {t('modal.publish_project.alternative_servers.options.custom_server')}
+              </span>
               <div className="custom_input">
                 <span className="title">
                   {t('modal.publish_project.alternative_servers.custom_server_url')}

--- a/packages/creator-hub/renderer/src/components/Modals/PublishProject/steps/AlternativeServers/component.tsx
+++ b/packages/creator-hub/renderer/src/components/Modals/PublishProject/steps/AlternativeServers/component.tsx
@@ -1,5 +1,5 @@
 import { type ChangeEvent, useCallback, useState } from 'react';
-import { Button, MenuItem, Select, type SelectChangeEvent } from 'decentraland-ui2';
+import { Button, MenuItem, Select } from 'decentraland-ui2';
 
 import { misc } from '#preload';
 
@@ -11,36 +11,22 @@ import { useEditor } from '/@/hooks/useEditor';
 import GenesisPlazaPng from '/assets/images/genesis_plaza.webp';
 
 import { PublishModal } from '../../PublishModal';
-import type { AlternativeTarget, Props } from '../../types';
+import type { Props } from '../../types';
 
 import './styles.css';
 
 export function AlternativeServers(props: Props) {
   const { publishScene } = useEditor();
-  const [option, setOption] = useState<AlternativeTarget>('test');
   const [customUrl, setCustomUrl] = useState('');
   const [error, setError] = useState('');
 
   const handleClick = useCallback(() => {
-    if (option === 'custom' && !isUrl(customUrl)) {
+    if (!isUrl(customUrl)) {
       return setError(t('modal.publish_project.alternative_servers.errors.url'));
     }
-    if (option === 'test') {
-      void publishScene();
-    } else if (option === 'custom') {
-      if (!isUrl(customUrl)) {
-        return setError(t('modal.publish_project.alternative_servers.errors.url'));
-      }
-      void publishScene({ target: customUrl });
-    } else {
-      throw new Error('Invalid option');
-    }
+    void publishScene({ target: customUrl });
     props.onStep('deploy');
-  }, [option, customUrl, props.onStep, publishScene]);
-
-  const handleChangeSelect = useCallback((e: SelectChangeEvent<AlternativeTarget>) => {
-    setOption(e.target.value as AlternativeTarget);
-  }, []);
+  }, [customUrl, props.onStep, publishScene]);
 
   const handleChangeCustom = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -51,15 +37,10 @@ export function AlternativeServers(props: Props) {
   );
 
   const handleClickLearnMore = useCallback(() => {
-    if (option === 'custom') {
-      return misc.openExternal(
-        'https://docs.decentraland.org/creator/scenes-sdk7/publishing/publishing#custom-servers',
-      );
-    }
     misc.openExternal(
-      'https://docs.decentraland.org/creator/scenes-sdk7/publishing/publishing#the-test-server',
+      'https://docs.decentraland.org/creator/scenes-sdk7/publishing/publishing#custom-servers',
     );
-  }, [option]);
+  }, []);
 
   return (
     <PublishModal
@@ -74,28 +55,22 @@ export function AlternativeServers(props: Props) {
               <h3>{t('modal.publish_project.alternative_servers.list')}</h3>
               <Select
                 variant="standard"
-                value={option}
-                onChange={handleChangeSelect}
+                value="custom"
               >
-                <MenuItem value="test">
-                  {t('modal.publish_project.alternative_servers.options.test_server')}
-                </MenuItem>
                 <MenuItem value="custom">
                   {t('modal.publish_project.alternative_servers.options.custom_server')}
                 </MenuItem>
               </Select>
-              {option === 'custom' && (
-                <div className="custom_input">
-                  <span className="title">
-                    {t('modal.publish_project.alternative_servers.custom_server_url')}
-                  </span>
-                  <input
-                    value={customUrl}
-                    onChange={handleChangeCustom}
-                  />
-                  <span className="error">{error}</span>
-                </div>
-              )}
+              <div className="custom_input">
+                <span className="title">
+                  {t('modal.publish_project.alternative_servers.custom_server_url')}
+                </span>
+                <input
+                  value={customUrl}
+                  onChange={handleChangeCustom}
+                />
+                <span className="error">{error}</span>
+              </div>
             </div>
             <img
               className="thumbnail"
@@ -110,7 +85,7 @@ export function AlternativeServers(props: Props) {
               {t('option_box.learn_more')}
             </span>
             <Button onClick={handleClick}>
-              {t(`modal.publish_project.alternative_servers.action.${option}_server`)}
+              {t('modal.publish_project.alternative_servers.action.custom_server')}
             </Button>
           </div>
         </div>

--- a/packages/creator-hub/renderer/src/components/Modals/PublishProject/steps/AlternativeServers/styles.css
+++ b/packages/creator-hub/renderer/src/components/Modals/PublishProject/steps/AlternativeServers/styles.css
@@ -37,16 +37,12 @@
   width: 318px;
 }
 
-.MuiModal-root .AlternativeServers .box .selection .MuiInputBase-root {
+.MuiModal-root .AlternativeServers .box .selection .server_name {
   border-radius: 4px;
   border: 1px solid var(--white);
   padding: 5px 15px;
   width: 250px;
-}
-
-.MuiModal-root .AlternativeServers .box .selection .MuiInputBase-root::before,
-.MuiModal-root .AlternativeServers .box .selection .MuiInputBase-root::after {
-  border: none;
+  box-sizing: border-box;
 }
 
 .MuiModal-root .AlternativeServers .box .selection .custom_input {

--- a/packages/creator-hub/renderer/src/components/Modals/PublishProject/types.ts
+++ b/packages/creator-hub/renderer/src/components/Modals/PublishProject/types.ts
@@ -29,7 +29,7 @@ export type Step =
   | 'deploy';
 
 export type InitialTarget = 'worlds' | 'land';
-export type AlternativeTarget = 'test' | 'custom';
+export type AlternativeTarget = 'custom';
 
 export type TargetType = InitialTarget | AlternativeTarget;
 

--- a/packages/creator-hub/renderer/src/components/Modals/PublishProject/types.ts
+++ b/packages/creator-hub/renderer/src/components/Modals/PublishProject/types.ts
@@ -28,11 +28,6 @@ export type Step =
   | 'publish-to-land'
   | 'deploy';
 
-export type InitialTarget = 'worlds' | 'land';
-export type AlternativeTarget = 'custom';
-
-export type TargetType = InitialTarget | AlternativeTarget;
-
 export const COLORS = Object.freeze({
   occupiedParcel: '#774642',
   freeParcel: '#ff9990',

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
@@ -200,12 +200,10 @@
         "title": "Publish to a different server",
         "list": "Alternate Servers",
         "options": {
-          "test_server": "Test Server",
           "custom_server": "Custom Server"
         },
         "custom_server_url": "Server URL",
         "action": {
-          "test_server": "Publish to Test Server",
           "custom_server": "Publish to Custom Server"
         },
         "errors": {

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/es.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/es.json
@@ -200,12 +200,10 @@
         "title": "Publicar en un Servidor Alternativo",
         "list": "Servidores Alternativos",
         "options": {
-          "test_server": "Servidor de Prueba",
           "custom_server": "Servidor Personalizado"
         },
         "custom_server_url": "URL del Servidor",
         "action": {
-          "test_server": "Publicar en el Servidor de Prueba",
           "custom_server": "Publicar en Servidor Personalizado"
         },
         "errors": {

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/zh.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/zh.json
@@ -200,12 +200,10 @@
         "title": "发布到不同的服务器",
         "list": "备用服务器",
         "options": {
-          "test_server": "测试服务器",
           "custom_server": "定制服务器"
         },
         "custom_server_url": "服务器地址",
         "action": {
-          "test_server": "发布到测试服务器",
           "custom_server": "发布到自定义服务器"
         },
         "errors": {

--- a/packages/creator-hub/types/env.d.ts
+++ b/packages/creator-hub/types/env.d.ts
@@ -34,7 +34,6 @@ interface ImportMetaEnv {
 
   // Publish
   VITE_WORLDS_SERVER: string | undefined;
-  VITE_TEST_SERVER: string | undefined;
 
   // Security
   VITE_ALLOWED_EXTERNAL_ORIGINS: string | undefined;


### PR DESCRIPTION

The Test Server no longer exists, so this PR removes it from the publish flow. In the **Publish to a different server** step, Custom Server is now the only and default option.

### Changes

- **`AlternativeServers` step**: removed the Test Server entry from the server dropdown, leaving Custom Server as the only option. The server URL input is now always visible, and the publish button always validates the URL and deploys to the entered custom server. The old test-server code path (which published with no target) is gone, and the "Learn more" link now always points to the [custom servers docs](https://docs.decentraland.org/creator/scenes-sdk7/publishing/publishing#custom-servers) instead of the removed test-server section.
- **Types**: narrowed `AlternativeTarget` from `'test' | 'custom'` to `'custom'`.
- **Translations**: removed the `test_server` option and action strings from the `en`, `es`, and `zh` locales.

### Testing

- Renderer typecheck and ESLint pass on the changed files.
- Repo-wide search confirms no remaining references to the Test Server (the main process only forwards whatever deploy target it receives, so no changes were needed there).