### PR TITLE
chore(ci): pass branch names to scripts via env vars

### DIFF
--- a/.github/workflows/cleanup-deployments.yml
+++ b/.github/workflows/cleanup-deployments.yml
@@ -20,15 +20,17 @@ jobs:
           fetch-depth: 0
 
       - name: Remove PR deployment
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          branch="${{ github.event.pull_request.head.ref }}"
-          safe_branch=${branch//\//-}
+          safe_branch="${BRANCH//\//-}"
 
           if [ -d "inspector/$safe_branch" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git rm -rf "inspector/$safe_branch"
-            git commit -m "Clean up deployment for closed PR #${{ github.event.pull_request.number }}: $branch"
+            git commit -m "Clean up deployment for closed PR #${PR_NUMBER}: ${BRANCH}"
             git push
             echo "✅ Cleaned up deployment: inspector/$safe_branch"
           else

--- a/.github/workflows/creator-hub.yml
+++ b/.github/workflows/creator-hub.yml
@@ -153,27 +153,37 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SDK_TEAM_AWS_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SDK_TEAM_AWS_SECRET }}
+          S3_BUCKET: ${{ secrets.SDK_TEAM_S3_BUCKET }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           npx @dcl/cdn-uploader@next \
-            --bucket ${{ secrets.SDK_TEAM_S3_BUCKET }} \
+            --bucket "$S3_BUCKET" \
             --local-folder dist/upload \
-            --bucket-folder creator-hub/branch/${{ github.head_ref }}
+            --bucket-folder "creator-hub/branch/${HEAD_REF}"
 
       - name: Set specific windows instructions
         if: ${{ github.event.pull_request.number && matrix.os == 'windows-latest' }}
         id: windows-instructions
+        env:
+          S3_BASE_URL: ${{ secrets.SDK_TEAM_S3_BASE_URL }}
+          HEAD_REF: ${{ github.head_ref }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           echo "list<<EOF" >> $GITHUB_ENV
-          echo "[win-x64](${{ secrets.SDK_TEAM_S3_BASE_URL }}/creator-hub/branch/${{ github.head_ref }}/Decentraland%20Creator%20Hub-${{ steps.version.outputs.version }}-win-x64.exe)" >> $GITHUB_ENV
+          echo "[win-x64](${S3_BASE_URL}/creator-hub/branch/${HEAD_REF}/Decentraland%20Creator%20Hub-${VERSION}-win-x64.exe)" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
       - name: Set specific macos instructions
         if: ${{ github.event.pull_request.number && matrix.os == 'macos-latest' }}
         id: macos-instructions
+        env:
+          S3_BASE_URL: ${{ secrets.SDK_TEAM_S3_BASE_URL }}
+          HEAD_REF: ${{ github.head_ref }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           echo "list<<EOF" >> $GITHUB_ENV
-          echo "[mac-x64](${{ secrets.SDK_TEAM_S3_BASE_URL }}/creator-hub/branch/${{ github.head_ref }}/Decentraland%20Creator%20Hub-${{ steps.version.outputs.version }}-mac-x64.dmg)" >> $GITHUB_ENV
-          echo "[mac-arm64](${{ secrets.SDK_TEAM_S3_BASE_URL }}/creator-hub/branch/${{ github.head_ref }}/Decentraland%20Creator%20Hub-${{ steps.version.outputs.version }}-mac-arm64.dmg)" >> $GITHUB_ENV
+          echo "[mac-x64](${S3_BASE_URL}/creator-hub/branch/${HEAD_REF}/Decentraland%20Creator%20Hub-${VERSION}-mac-x64.dmg)" >> $GITHUB_ENV
+          echo "[mac-arm64](${S3_BASE_URL}/creator-hub/branch/${HEAD_REF}/Decentraland%20Creator%20Hub-${VERSION}-mac-arm64.dmg)" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
           content=$(cat ./.github/workflows/macos-instructions.md)
           echo "macos-instructions<<EOF" >> $GITHUB_ENV

--- a/.github/workflows/inspector.yml
+++ b/.github/workflows/inspector.yml
@@ -180,9 +180,10 @@ jobs:
 
       - name: set preview url
         id: set-preview-url
+        env:
+          SAFE_BRANCH: ${{ steps.sanitize-branch.outputs.safe_branch }}
         run: |
-          safe_branch=${{ steps.sanitize-branch.outputs.safe_branch }}
-          echo "preview_url=https://decentraland.github.io/creator-hub/inspector/$safe_branch" >> $GITHUB_OUTPUT
+          echo "preview_url=https://decentraland.github.io/creator-hub/inspector/${SAFE_BRANCH}" >> $GITHUB_OUTPUT
 
       - name: publish to npm registry
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary

GitHub substitutes `${{ }}` expressions into `run:` blocks as text before any shell starts, so an interpolated branch name is parsed as part of the script instead of arriving as data. This moves those values into `env:` and references them as quoted shell variables.

Three workflows, same change:

| File | Values moved to `env:` |
|---|---|
| `cleanup-deployments.yml` | `pull_request.head.ref`, `pull_request.number` |
| `creator-hub.yml` | `github.head_ref`, plus the S3 bucket / base-URL secrets and version in the same blocks |
| `inspector.yml` | the `sanitize-branch` step output |

Two details worth a reviewer's eye:

- In `cleanup-deployments.yml`, `${branch//\//-}` sat on the line *after* the one that used the name, so the replacement never shaped the value it was written for. It now applies to the env var before first use.
- `inspector.yml`'s `sanitize branch` step was already doing the right thing — it reads `$GITHUB_HEAD_REF` as an environment variable. Only the downstream `set preview url` step put the result back into script text, so that is the part that changed.

`ai-review.yml` already used the `env:` pattern; this brings the rest in line with it.

## Test plan

- [ ] the inspector PR preview deploys and the preview URL is correct
- [ ] a PR build uploads to `creator-hub/branch/<branch>` as before, and the win/mac download links in the PR body resolve
- [ ] closing a PR removes its `inspector/<branch>` directory from `gh-pages`

No behaviour change intended: same bucket paths, same cleanup commit message, same preview URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CW4SCgagWDAxR3PKJCMp5d