### PR TITLE
fix: mobile QR button no longer opens the desktop explorer client

### DIFF
--- a/packages/creator-hub/main/src/modules/cli.ts
+++ b/packages/creator-hub/main/src/modules/cli.ts
@@ -26,13 +26,22 @@ import { downloadGithubRepo } from './download-github-folder';
 import { startMobileDebugServer } from './mobile-debug-server';
 import { getLanIp } from './network';
 
-export type Preview = { child: Child; url: string; opts: PreviewOptions };
+// `mobile` marks a preview that was started for the mobile-QR flow (`--mobile`): the
+// SDK runs the preview server but does NOT open the desktop client. It is tracked so a
+// later desktop Preview press restarts instead of reusing it (a reused mobile preview
+// would never open the client the user just asked for).
+export type Preview = { child: Child; url: string; opts: PreviewOptions; mobile: boolean };
 
 // Explorer deeplink param for locally generated asset bundles. sdk-commands owns the
 // abgen sidecar (--asset-bundles) and injects local-ab into the deeplink it fires only
 // when the sidecar actually booted — its presence in the captured deeplink is the
 // source of truth for whether the running preview has one.
 const LOCAL_AB_PARAM = 'local-ab';
+
+// Grace window for the mobile-QR deeplink to appear after the preview server reports
+// ready. sdk-commands prints it only with a LAN IP; if none is found it never comes, so
+// the mobile start settles (with no url) shortly after instead of hanging indefinitely.
+const MOBILE_DEEPLINK_GRACE_MS = 5000;
 
 // A large scene's first conversion can take minutes before the deeplink appears; the
 // sidecar's progress lines are streamed to the renderer so the preview button can say
@@ -143,10 +152,15 @@ function getDeepLinkParam(raw: string, key: string): string | null {
 
 function getPreviewServerUrl(deepLinkUrl: string): string | null {
   try {
-    const params = new URLSearchParams(deepLinkUrl);
-    const realm = params.get('realm');
-    if (realm) {
-      const url = new URL(realm);
+    // The desktop-client deeplink carries the server as `realm=<origin>`; the mobile
+    // deeplink (`open?preview=<lanUrl>&...`, from a `--mobile` start) carries it as
+    // `preview=<lanUrl>`. Slice off any leading path (e.g. `open?`) before parsing.
+    const queryIdx = deepLinkUrl.indexOf('?');
+    const query = queryIdx >= 0 ? deepLinkUrl.slice(queryIdx + 1) : deepLinkUrl;
+    const params = new URLSearchParams(query);
+    const server = params.get('realm') ?? params.get('preview');
+    if (server) {
+      const url = new URL(server);
       return `${url.protocol}//${url.host}`;
     }
     return null;
@@ -324,7 +338,7 @@ export async function supportsAssetBundles(path: string): Promise<boolean> {
   }
 }
 
-type StartOptions = PreviewOptions & { retry?: boolean };
+type StartOptions = PreviewOptions & { retry?: boolean; mobile?: boolean };
 
 // Serializes concurrent starts per path: a second Preview press (or a mobile-QR start)
 // while a spawn is still converting must ride that spawn, not race a second one.
@@ -384,8 +398,14 @@ async function doStart(path: string, opts: StartOptions): Promise<string> {
 
   // If we have a preview running for this path, reuse it — but only if it's the
   // same client. Switching client (Unity <-> Bevy) means a different launch, so
-  // tear the old one down and start fresh below.
-  if (isPreviewRunning(preview) && preview.opts.client === opts.client) {
+  // tear the old one down and start fresh below. A mode switch (mobile QR <-> desktop
+  // Preview) also can't be reused: a mobile-mode preview never opened the desktop client,
+  // so a desktop Preview press must restart to actually launch it.
+  if (
+    isPreviewRunning(preview) &&
+    preview.opts.client === opts.client &&
+    preview.mobile === !!opts.mobile
+  ) {
     if (opts.client === PREVIEW_CLIENT.BEVY_WEB) {
       // The Bevy web client runs in the browser; sdk-commands opened the tab on
       // launch and there's no deep-link to re-issue. Re-open the stored URL so a
@@ -417,6 +437,10 @@ async function doStart(path: string, opts: StartOptions): Promise<string> {
   let stopConversionProgress = () => {};
 
   const isBevyWeb = opts.client === PREVIEW_CLIENT.BEVY_WEB;
+  // Mobile-QR start: `--mobile` makes sdk-commands serve the scene and print a capturable
+  // mobile deeplink without opening the desktop client. Only meaningful on the Unity path
+  // (the mobile app opens `decentraland://`); Bevy is web-only, so it keeps its own launch.
+  const isMobile = !!opts.mobile && !isBevyWeb;
 
   try {
     const extraArgs: string[] = [];
@@ -445,7 +469,14 @@ async function doStart(path: string, opts: StartOptions): Promise<string> {
     // option flips, mobile QR).
     const args = isBevyWeb
       ? ['start', '--bevy-web', ...generatePreviewArguments(opts)]
-      : ['start', '--explorer-alpha', '--hub', ...extraArgs, ...generatePreviewArguments(opts)];
+      : [
+          'start',
+          '--explorer-alpha',
+          '--hub',
+          ...(isMobile ? ['--mobile'] : []),
+          ...extraArgs,
+          ...generatePreviewArguments(opts),
+        ];
 
     const process = run('@dcl/sdk-commands', 'sdk-commands', {
       args,
@@ -455,7 +486,7 @@ async function doStart(path: string, opts: StartOptions): Promise<string> {
     });
 
     // registered before the deeplink resolves so the spawn can be cancelled mid-conversion
-    previewCache.set(path, { child: process, url: '', opts });
+    previewCache.set(path, { child: process, url: '', opts, mobile: isMobile });
 
     if (isBevyWeb) {
       // No deep-link on this path — sdk-commands prints this once the preview
@@ -517,12 +548,28 @@ async function doStart(path: string, opts: StartOptions): Promise<string> {
       // process death so a cancelled/failed spawn rejects here and the finally below clears
       // inflightStarts. wait() stays pending while the preview server runs, so the deeplink
       // normally wins; it only settles once the process is gone.
-      const resultLogs = await Promise.race([
-        process.waitFor(dclLauncherURL, /CliError|error:/i),
-        process.wait().then(() => {
-          throw new Error('Preview process exited before producing a deeplink');
-        }),
-      ]);
+      // Registered before any await so it can't miss a deeplink flushed early.
+      const deeplink = process.waitFor(dclLauncherURL, /CliError|error:/i);
+      const death = process.wait().then(() => {
+        throw new Error('Preview process exited before producing a deeplink');
+      });
+      // On the mobile path the desktop client never opens, so the only deeplink is the LAN
+      // QR one — which sdk-commands prints only when a LAN IP exists. Without one it never
+      // comes, so add a fallback that settles a beat after the server is up (an empty url
+      // getMobilePreview then surfaces as a failure) rather than hanging forever. A deeplink
+      // that does arrive still wins this race first, even minutes into a large conversion.
+      const racers = [deeplink, death];
+      if (isMobile) {
+        racers.push(
+          process
+            .waitFor(/Preview server is now running/i, /CliError|error:/i)
+            .then(
+              () => new Promise<string>(resolve => setTimeout(resolve, MOBILE_DEEPLINK_GRACE_MS)),
+            )
+            .then(() => ''),
+        );
+      }
+      const resultLogs = await Promise.race(racers);
 
       // Check if the error indicates that Decentraland Desktop Client is not installed
       if (resultLogs.includes(CLIENT_NOT_INSTALLED_ERROR)) {

--- a/packages/creator-hub/main/src/modules/ipc.ts
+++ b/packages/creator-hub/main/src/modules/ipc.ts
@@ -49,7 +49,7 @@ export function initIpc({ beforeQuitCleanup }: InitIpcOptions) {
 
   // cli
   handle('cli.init', (_event, path, repo) => cli.init(path, repo));
-  handle('cli.start', (_event, path, opts) => cli.start(path, opts));
+  handle('cli.start', (_event, path, opts, mobile) => cli.start(path, { ...opts, mobile }));
   handle('cli.deploy', (_event, opts) => cli.deploy(opts));
   handle('cli.killPreview', (_event, path) => cli.killPreview(path));
   handle('cli.cancelPreview', (_event, path) => cli.cancelPreview(path));

--- a/packages/creator-hub/main/tests/cli.test.ts
+++ b/packages/creator-hub/main/tests/cli.test.ts
@@ -191,6 +191,51 @@ describe('cli preview start', () => {
     });
   });
 
+  describe('when starting a mobile-QR preview', () => {
+    it('should pass --mobile so sdk-commands serves the scene without opening the desktop client', async () => {
+      const fake = createFakeChild();
+      mocks.run.mockReturnValue(fake.child);
+
+      const promise = start(path, { ...BASE_OPTS, mobile: true });
+      fake.printDeeplink('open?preview=http://192.168.0.10:8000&position=0,0');
+      await promise;
+
+      expect(spawnedArgs()).toContain('--mobile');
+    });
+
+    it('should not pass --mobile for a regular desktop preview', async () => {
+      const fake = createFakeChild();
+      mocks.run.mockReturnValue(fake.child);
+
+      const promise = start(path, BASE_OPTS);
+      fake.printDeeplink('realm=http://127.0.0.1:8000&position=0,0');
+      await promise;
+
+      expect(spawnedArgs()).not.toContain('--mobile');
+    });
+  });
+
+  describe('when a mobile-QR preview is already running and a desktop Preview is requested', () => {
+    it('should restart instead of reusing so the desktop client actually opens', async () => {
+      const fake = createFakeChild();
+      mocks.run.mockReturnValue(fake.child);
+      const first = start(path, { ...BASE_OPTS, mobile: true });
+      fake.printDeeplink('open?preview=http://192.168.0.10:8000&position=0,0');
+      await first;
+      mocks.run.mockClear();
+
+      const restarted = createFakeChild();
+      mocks.run.mockReturnValue(restarted.child);
+      const second = start(path, BASE_OPTS);
+      restarted.printDeeplink('realm=http://127.0.0.1:8000&position=0,0');
+      await second;
+
+      expect(fake.child.kill).toHaveBeenCalled();
+      expect(mocks.run).toHaveBeenCalledTimes(1);
+      expect(spawnedArgs()).not.toContain('--mobile');
+    });
+  });
+
   describe('when a preview is already running', () => {
     let fake: ReturnType<typeof createFakeChild>;
 

--- a/packages/creator-hub/preload/src/modules/editor.ts
+++ b/packages/creator-hub/preload/src/modules/editor.ts
@@ -64,8 +64,16 @@ export async function attachSceneDebugger(
   return { cleanup };
 }
 
-export async function runScene({ path, opts }: { path: string; opts: PreviewOptions }) {
-  const port = await invoke('cli.start', path, opts);
+export async function runScene({
+  path,
+  opts,
+  mobile,
+}: {
+  path: string;
+  opts: PreviewOptions;
+  mobile?: boolean;
+}) {
+  const port = await invoke('cli.start', path, opts, mobile);
   return port;
 }
 

--- a/packages/creator-hub/renderer/src/modules/store/editor/slice.ts
+++ b/packages/creator-hub/renderer/src/modules/store/editor/slice.ts
@@ -21,14 +21,17 @@ export const startInspector = createAsyncThunk('editor/startInspector', editor.s
 export const setPreviewProgress = createAction<PreviewProgress | null>('editor/setPreviewProgress');
 export const runScene = createAsyncThunk(
   'editor/runScene',
-  async ({ path, ...opts }: PreviewOptions & { path: string }, { dispatch }) => {
+  async (
+    { path, mobile, ...opts }: PreviewOptions & { path: string; mobile?: boolean },
+    { dispatch },
+  ) => {
     // Surfaces the sidecar's asset-conversion progress (a large scene's first
     // conversion can take minutes before the preview is ready)
     const subscription = editor.subscribePreviewProgress(path, progress =>
       dispatch(setPreviewProgress(progress)),
     );
     try {
-      await editor.runScene({ path, opts });
+      await editor.runScene({ path, opts, mobile });
     } finally {
       subscription.cleanup();
       dispatch(setPreviewProgress(null));
@@ -60,9 +63,10 @@ export const getMobileQR = createAsyncThunk(
   async ({ path, opts }: { path: string; opts: PreviewOptions }, { dispatch, getState }) => {
     const { editor: editorState } = getState();
 
-    // Start preview if not running
+    // Start preview if not running. `mobile: true` runs the preview server without
+    // opening the desktop client — the QR only needs the server for the phone to reach.
     if (!editorState.isPreviewRunning) {
-      await dispatch(runScene({ path, ...opts })).unwrap();
+      await dispatch(runScene({ path, ...opts, mobile: true })).unwrap();
     }
 
     // Fetch mobile QR data

--- a/packages/creator-hub/shared/types/ipc.ts
+++ b/packages/creator-hub/shared/types/ipc.ts
@@ -79,7 +79,7 @@ export interface Ipc {
   'code.removeEditor': (path: string) => Promise<EditorConfig[]>;
 
   'cli.init': (path: string, repo: string) => Promise<void>;
-  'cli.start': (path: string, opts: PreviewOptions) => Promise<string>;
+  'cli.start': (path: string, opts: PreviewOptions, mobile?: boolean) => Promise<string>;
   'cli.cancelPreview': (path: string) => Promise<void>;
   'cli.supportsAssetBundles': (path: string) => Promise<boolean>;
   'cli.deploy': (opts: DeployOptions) => Promise<number>;


### PR DESCRIPTION
## Problem

Clicking the **Mobile Preview** QR button opens the desktop Decentraland (explorer alpha) client as an unwanted side effect.

When no preview is running, `getMobileQR` starts one via `runScene`, which spawns `sdk-commands start --explorer-alpha`. The `--explorer-alpha` flag makes sdk-commands run `open decentraland://…`, launching the **desktop** client — even though the QR flow only needs the preview *server* running so the phone can reach it.

Confirmed against the SDK: the desktop-client launch is gated on `explorerAlpha && !isMobile && !skipClient` (`@dcl/sdk-commands` `start/index.js`).

## Fix

Thread a `mobile` launch flag through the QR path (`getMobileQR` → `runScene` → `cli.start` IPC → `doStart`) so it starts sdk-commands with `--mobile`. That runs the server and prints a capturable mobile deep-link **without** opening the desktop client.

- `doStart` tracks mobile mode on the preview cache entry so a later desktop **Preview** press *restarts* (to actually open the client) instead of reusing the client-less server.
- `getPreviewServerUrl` now also reads the mobile deep-link's `preview=` param (desktop uses `realm=`).
- **No-LAN guard:** sdk-commands only prints the mobile deep-link when a LAN IP exists, so the mobile start now settles shortly after "server ready" with an empty url (surfaced as the existing failure snackbar) instead of hanging forever.

When a desktop preview is **already** running and you click Mobile QR, behavior is unchanged — it reuses that server, no extra client.

## Testing

- `npm run typecheck` (main/preload/renderer): clean
- ESLint on changed files: clean
- `npm run test:main`: 53 passing (added 3 cases — `--mobile` passed on the QR path, not on desktop, and mode-mismatch triggers a restart)
- `npm run test:renderer`: 113 passing

### Manual smoke test (recommended)
From a cold state, click **Mobile Preview** and confirm only the QR modal appears (no desktop client window), then scan it from a phone on the same LAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)