### PR TITLE
feat: expose missing SDK component properties in the inspector

### DIFF
--- a/.claude/pr-summaries/2026-08-04-material-editor-fixes.md
+++ b/.claude/pr-summaries/2026-08-04-material-editor-fixes.md
@@ -1,0 +1,34 @@
+# Material editor: albedo alpha control, zero-value defaults fix, engine-matching texture defaults
+
+## Overview
+
+Three fixes to the inspector's Material editor (`packages/inspector/src/components/EntityInspector/MaterialInspector/`):
+
+1. The PBR `albedoColor` alpha channel is now editable via a "Color Alpha" slider (and preserved for unlit `diffuseColor`).
+2. The converter no longer snaps explicit `0` values back to defaults (`||` → nullish/NaN-safe handling).
+3. The Texture editor's default wrap/filter modes now match the engine defaults (Clamp / Bilinear instead of Repeat / Point).
+
+## Albedo color alpha
+
+**Behavior:** The PBR material section shows a "Color Alpha" range field (0–1, step 0.01) directly below the Color field, following the same pattern as the ParticleSystem editor's color alphas. Alpha is written into `albedoColor.a` and read back from it. Pasting an 8-digit `#RRGGBBAA` hex into the color field also works: the hex's own alpha wins and syncs back into the slider. Unlit `diffuseColor` (also a `Color4` in `@dcl/ecs`) gets no control, but its alpha now survives edits via a hidden `diffuseColorAlpha` pass-through instead of being forced to 1.
+
+**Implementation:** New `albedoColorAlpha` / `diffuseColorAlpha` fields on `MaterialInput`; a `toColor4WithAlphaOrUndefined` helper in `MaterialInspector/utils.ts` mirrors `TextShapeInspector`'s `toColor4WithAlpha` (8-digit hex keeps its own alpha; empty/NaN alpha keeps the parsed color's alpha). The `PbrMaterial` component takes an optional `albedoColorAlpha` prop and renders the slider only when wired, so `GltfNodeModifiersInspector` (which reuses `PbrMaterial` without the prop) is unaffected.
+
+## Explicit zeros no longer snap back to defaults
+
+**Behavior:** Entering `0` for Metallic, Roughness, Specular/Direct/Emissive intensity, or choosing transparency mode Opaque (value 0) now sticks, instead of reverting to the defaults (0.5 / 1 / Auto).
+
+**Implementation:** `toMaterial` used `Number(value.x || default)`, which treats `'0'` as falsy. Replaced with a `toNumberOrDefault` helper (defined in `Texture/utils.ts`, shared with the texture converter) that falls back only on `undefined`, empty string, or NaN. Also applied to `alphaTest`, whose previous `Number(value ?? 0.5)` turned an empty string into `0`.
+
+## Texture default wrap/filter modes match the engine
+
+**Behavior:** When a texture has no explicit `wrapMode`/`filterMode`, the dropdowns now display Clamp and Bilinear — the engine defaults per the protocol (`default = TextureWrapMode.Clamp`, `default = FilterMode.Bilinear`) — instead of Repeat and Point. On save, the editor writes the engine default values (`TWM_CLAMP` = 1, `TFM_BILINEAR` = 1) rather than leaving the field unset; since these are exactly what the engine uses when unset, materializing them is rendering-neutral for existing scenes, whereas the old code silently switched unset textures to Repeat/Point on any material edit. Explicitly selected Repeat/Point (value 0) is preserved.
+
+**Implementation:** `DEFAULT_WRAP_MODE` / `DEFAULT_FILTER_MODE` constants in `Texture/utils.ts`; `fromTexture` defaults unset modes to them for all three texture kinds (texture, avatarTexture, videoTexture), and `toTexture` uses `toNumberOrDefault` with the same constants (dropping the old `?? '0'` coercion that forced unset to Repeat/Point).
+
+## Testing
+
+- `MaterialInspector/utils.spec.ts`: new cases for explicit zeros surviving `toMaterial` and a full `fromMaterial(toMaterial(...))` round trip; unset/empty numerics falling back to defaults; albedo alpha write/read/round trip incl. alpha 0 and 8-digit hex; unlit diffuse alpha pass-through; updated texture-mode expectations to the new Clamp/Bilinear defaults.
+- `Texture/utils.spec.ts`: new cases for unset modes defaulting to Clamp/Bilinear in both directions (all three texture kinds), and explicit Repeat/Point (0) being preserved.
+- Verified: `npx vitest run src/components/EntityInspector/MaterialInspector` (41 tests pass), `npm run typecheck`, `npx eslint` and `npx prettier --check` on the MaterialInspector directory — all clean.
+- Verified visually in the dev-server inspector (Playwright screenshots): Color Alpha slider default 1, set to 0.25, and a fresh Texture section showing Clamp/Bilinear defaults.

--- a/.claude/pr-summaries/2026-08-04-particle-system-rotation-texture.md
+++ b/.claude/pr-summaries/2026-08-04-particle-system-rotation-texture.md
@@ -1,0 +1,70 @@
+# ParticleSystem editor: rotation controls, full texture round-trip
+
+## Overview
+
+The inspector's ParticleSystem editor dropped several `PBParticleSystem` fields on every edit
+because its save path rebuilds the component from the editor inputs: `initialRotation` and
+`rotationOverTime` were never read or written, and only the texture `src` survived (wrap mode,
+filter mode, offset, and tiling were discarded). This PR adds UI for all of them and makes the
+converters round-trip the full component.
+
+## Rotation controls
+
+**Behavior**
+
+- New "Rotation" section (between Size and Color) with two X/Y/Z rows:
+  - Initial Rotation (deg): rotation of each particle at birth.
+  - Rotation Over Time (deg/sec): per-axis angular velocity (limited to ±180/axis by the
+    quaternion encoding, noted in the tooltip).
+- Values are entered as Euler degrees and stored as quaternions, matching the proto
+  ("converted to Euler XYZ"). Zero rotation maps back to "unset", so an untouched editor never
+  materializes the fields.
+
+**Implementation**
+
+- `utils.ts`: `fromQuaternion` / `eulerDegreesToQuaternion` / `toQuaternion` helpers using
+  Babylon's `Quaternion.RotationYawPitchRoll` / `toEulerAngles` (same convention as
+  TransformInspector); degrees rounded to 2 decimals for stable round-trips.
+- `types.ts`: `EulerInput` added to `ParticleSystemInput`.
+- `isValidInput` rejects non-numeric rotation entries.
+
+## Texture wrap/filter/offset/tiling
+
+**Behavior**
+
+- Under "Use Texture": Wrap Mode and Filter Mode dropdowns, plus Offset X/Y and Tiling X/Y
+  numeric fields.
+- Unset fields stay unset: the dropdowns display the engine defaults (Clamp / Bilinear) and the
+  numeric fields show placeholders (0 / 1), but nothing is written to the component until the
+  user sets a value. Setting one axis of offset/tiling fills the other with the engine default.
+
+**Implementation**
+
+- `types.ts`: `TextureInput` (empty string = unset), `WRAP_MODE_OPTIONS`, `FILTER_MODE_OPTIONS`,
+  `DEFAULT_WRAP_MODE`, `DEFAULT_FILTER_MODE` (from the `@dcl/ecs` `TextureWrapMode` /
+  `TextureFilterMode` enums).
+- `utils.ts`: `fromTexture` / `toTexture` / `toVector2` converters that preserve unset fields.
+
+## Save-path audit / fixes
+
+- Audited every `PBParticleSystem` field against `toComponent`: with rotation and the full
+  texture added, every field in the schema now survives an edit (shape, bursts, sprite sheet,
+  limit velocity, etc. were already carried).
+- `toComponent` now writes `texture: undefined` explicitly when "Use Texture" is off (previously
+  the key was omitted, so the single-entity save path's spread-merge over the current component
+  value silently kept the old texture and the checkbox could not actually remove it).
+
+## Testing
+
+- New `ParticleSystemInspector/utils.spec.ts` (15 tests):
+  - quaternion <-> Euler conversion in both directions, zero-maps-to-unset;
+  - texture field conversion, unset preservation, partial offset/tiling axis defaults;
+  - round-trip regression: a fully code-authored `PBParticleSystem` (every field set) survives
+    `toComponent(fromComponent(c))` unchanged; bare-texture and empty components keep their
+    unset fields unset;
+  - `isValidInput` rejection of non-numeric rotation/offset entries.
+- `npm run typecheck`, `npx eslint`, `npx prettier --check` pass on the package/directory.
+- Verified live in the dev-server inspector: added a ParticleSystem to an entity, typed rotation
+  values (which survived the engine round-trip) and enabled the texture fields (screenshots in
+  `.claude/screenshots/particle-system-rotation.png` and
+  `.claude/screenshots/particle-system-texture-fields.png`).

--- a/.claude/pr-summaries/2026-08-04-tween-continuous-modes.md
+++ b/.claude/pr-summaries/2026-08-04-tween-continuous-modes.md
@@ -1,0 +1,50 @@
+# Tween editor: continuous movement modes, unsupported-mode preservation, analytics fix
+
+## Overview
+
+Extends the inspector's Tween editor with the two continuous tween modes from the SDK protocol (`moveContinuous`, `rotateContinuous`), stops the editor from silently destroying tween modes it can't edit (e.g. `textureMove`), and fixes the remove-component analytics event that reported the wrong component name.
+
+All changes are contained in `packages/inspector/src/components/EntityInspector/TweenInspector/`.
+
+## Continuous tween modes
+
+### Behavior
+
+- The Tween Type dropdown now offers **Move Continuous** and **Rotate Continuous** alongside Move/Rotate/Scale Item.
+- Continuous modes are velocity-based (`direction` + `speed` in the `PBTween` oneof), so the Start/End vectors and the Duration/Easing controls are hidden for them; instead the editor shows:
+  - a **Direction** vector block — labeled `Direction (meters/sec)` for Move Continuous and `Direction (degrees/sec)` for Rotate Continuous,
+  - a **Speed** number field (scalar multiplier, defaults to 1).
+- Rotate Continuous edits the direction as Euler degrees and converts to the protocol's quaternion using the same Yaw/Pitch/Roll conversion the existing Rotate mode uses (and back via `toEulerAngles` when reading).
+- Duration/easing values already stored on the component are retained when switching to a continuous mode (only the controls are hidden), so switching back doesn't lose them.
+- The phantom empty dropdown entry produced by `TweenType.KEEP_ROTATING_ITEM` (it had no label and no conversion, so selecting it destroyed the mode) is no longer listed; options are now an explicit list instead of `Object.values(TweenType)`.
+
+### Implementation
+
+- `types.ts`: `ContinuousTweenType` enum (`move_continuous`, `rotate_continuous`), `UNSUPPORTED_TWEEN_TYPE` marker, and `TweenModeType` union; `TweenInput` gains `direction`, `speed`, and `unsupportedMode` fields.
+- `utils.ts`: `fromTween`/`toTween` handle the `moveContinuous`/`rotateContinuous` oneof cases; shared `quaternionToAngles`/`anglesToQuaternion` helpers extracted from the previously duplicated Rotate conversion code.
+- `TweenInspector.tsx`: conditional rendering of the Start/End/Duration/Easing group vs the Direction/Speed group based on the selected type.
+
+## Unsupported modes are preserved instead of destroyed
+
+### Behavior
+
+Previously, if an entity carried a tween mode the editor doesn't support (`textureMove`, `textureMoveContinuous`, `moveRotateScale`), any edit in the panel silently converted the component to a zero-vector Move. Now:
+
+- The dropdown shows the current mode as a disabled entry, e.g. **Texture Move (not editable)**; only Auto start / Loop remain editable.
+- Edits (e.g. toggling Auto start) keep the unsupported mode payload intact.
+- Picking a supported type from the dropdown still converts the tween explicitly.
+
+### Implementation
+
+`fromTween` maps unknown `mode.$case` values to the `unsupported` input type (remembering the case name for the label); `toTween` omits the `mode` key entirely for that type, so `useComponentInput`'s `{ ...componentValue, ...toTween(input) }` merge preserves the existing mode.
+
+## Analytics fix
+
+`handleRemove` tracked `Event.REMOVE_COMPONENT` with `componentName: CoreComponents.VIDEO_PLAYER` (copy-paste bug); it now reports `CoreComponents.TWEEN`.
+
+## Testing
+
+- New `utils.spec.ts` (10 tests): component↔input conversion for move/rotate/scale regression, moveContinuous and rotateContinuous (including quaternion↔euler round-trip), unsupported-mode detection, and mode preservation on merge.
+- `npx vitest run src/components/EntityInspector/TweenInspector` — 10/10 pass.
+- `npm run typecheck`, `npx eslint`, `npx prettier --check` — clean on the package/directory.
+- Verified end-to-end in the dev-server inspector with Playwright: added a Tween via the Add Component menu (TweenSequence still auto-added, `{"sequence":[]}` unchanged), selected each new mode and confirmed the engine received `moveContinuous`/`rotateContinuous` values (90° Y input → quaternion `(0, 0.7071, 0, 0.7071)`), and confirmed a `textureMove` tween survives an Auto start toggle intact.

--- a/packages/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.tsx
@@ -123,7 +123,15 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
         <TextField
           {...pitch}
           type="number"
-          label="Pitch"
+          label={
+            <>
+              Pitch{' '}
+              <InfoTooltip
+                text="Playback speed multiplier that shifts the sound's pitch: 1 plays the original sound, 2 plays twice as fast (one octave higher), 0.5 plays half as fast (one octave lower)."
+                type="help"
+              />
+            </>
+          }
           error={!isMixedValue(pitch.value) && !isValidPitch(String(pitch.value ?? ''))}
           autoSelect
         />

--- a/packages/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.tsx
@@ -13,9 +13,17 @@ import { useAppSelector } from '../../../redux/hooks';
 import { selectAssetCatalog } from '../../../redux/app';
 import { Block } from '../../Block';
 import { Container } from '../../Container';
-import { CheckboxField, RangeField, FileUploadField, InfoTooltip } from '../../ui';
+import { CheckboxField, RangeField, FileUploadField, InfoTooltip, TextField } from '../../ui';
 import { ACCEPTED_FILE_TYPES } from '../../ui/FileUploadField/types';
-import { fromAudioSource, toAudioSource, isValidInput, isAudio, isValidVolume } from './utils';
+import { isMixedValue } from '../../ui/utils';
+import {
+  fromAudioSource,
+  toAudioSource,
+  isValidInput,
+  isAudio,
+  isValidVolume,
+  isValidPitch,
+} from './utils';
 import type { Props } from './types';
 
 export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
@@ -59,6 +67,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
   const loop = getInputProps('loop', e => e.target.checked);
   const global = getInputProps('global', e => e.target.checked);
   const volume = getInputProps('volume', e => e.target.value);
+  const pitch = getInputProps('pitch', e => e.target.value);
 
   return (
     <Container
@@ -108,6 +117,15 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           {...volume}
           label="Volume"
           isValidValue={isValidVolume}
+        />
+      </Block>
+      <Block className="pitch">
+        <TextField
+          {...pitch}
+          type="number"
+          label="Pitch"
+          error={!isMixedValue(pitch.value) && !isValidPitch(String(pitch.value ?? ''))}
+          autoSelect
         />
       </Block>
     </Container>

--- a/packages/inspector/src/components/EntityInspector/AudioSourceInspector/types.ts
+++ b/packages/inspector/src/components/EntityInspector/AudioSourceInspector/types.ts
@@ -10,5 +10,9 @@ export type AudioSourceInput = {
   playing?: boolean;
   loop?: boolean;
   volume?: string;
+  pitch?: string;
   global?: boolean;
+  // Hidden pass-through (no UI control): playback-position seek, only meaningful at runtime.
+  // Carried through the input so edits from the inspector never delete it.
+  currentTime?: string;
 };

--- a/packages/inspector/src/components/EntityInspector/AudioSourceInspector/utils.spec.ts
+++ b/packages/inspector/src/components/EntityInspector/AudioSourceInspector/utils.spec.ts
@@ -1,0 +1,143 @@
+import type { PBAudioSource } from '@dcl/ecs';
+
+import {
+  fromAudioSource,
+  toAudioSource,
+  volumeFromAudioSource,
+  volumeToAudioSource,
+  pitchFromAudioSource,
+  pitchToAudioSource,
+  currentTimeFromAudioSource,
+  currentTimeToAudioSource,
+  isValidVolume,
+  isValidPitch,
+} from './utils';
+
+describe('AudioSourceInspector utils', () => {
+  describe('when converting volume between component and input', () => {
+    describe('and the volume is defined', () => {
+      it('should convert the component volume to a percentage string', () => {
+        expect(volumeFromAudioSource(0.75)).toBe('75');
+      });
+
+      it('should convert the percentage string back to a component volume', () => {
+        expect(volumeToAudioSource('75')).toBe(0.75);
+      });
+    });
+
+    describe('and the volume is undefined', () => {
+      it('should default to 100', () => {
+        expect(volumeFromAudioSource(undefined)).toBe('100');
+      });
+    });
+  });
+
+  describe('when converting pitch between component and input', () => {
+    describe('and the pitch is defined', () => {
+      it('should convert the component pitch to a string', () => {
+        expect(pitchFromAudioSource(1.5)).toBe('1.5');
+      });
+
+      it('should convert the string back to a component pitch', () => {
+        expect(pitchToAudioSource('1.5')).toBe(1.5);
+      });
+    });
+
+    describe('and the pitch is undefined', () => {
+      it('should default to 1', () => {
+        expect(pitchFromAudioSource(undefined)).toBe('1');
+        expect(pitchToAudioSource(undefined)).toBe(1);
+      });
+    });
+
+    describe('and the pitch is not a number', () => {
+      it('should fall back to the default pitch of 1', () => {
+        expect(pitchToAudioSource('not-a-number')).toBe(1);
+      });
+    });
+  });
+
+  describe('when converting currentTime between component and input', () => {
+    describe('and the currentTime is defined', () => {
+      it('should carry the value through as a string', () => {
+        expect(currentTimeFromAudioSource(12.5)).toBe('12.5');
+      });
+
+      it('should convert the string back to a number', () => {
+        expect(currentTimeToAudioSource('12.5')).toBe(12.5);
+      });
+    });
+
+    describe('and the currentTime is undefined', () => {
+      it('should stay undefined in both directions', () => {
+        expect(currentTimeFromAudioSource(undefined)).toBeUndefined();
+        expect(currentTimeToAudioSource(undefined)).toBeUndefined();
+      });
+    });
+
+    describe('and the currentTime is an empty or invalid string', () => {
+      it('should stay undefined instead of writing NaN', () => {
+        expect(currentTimeToAudioSource('')).toBeUndefined();
+        expect(currentTimeToAudioSource('not-a-number')).toBeUndefined();
+      });
+    });
+  });
+
+  describe('when validating a volume input', () => {
+    it('should accept values between 0 and 100', () => {
+      expect(isValidVolume('0')).toBe(true);
+      expect(isValidVolume('100')).toBe(true);
+    });
+
+    it('should reject values outside the range or non-numeric values', () => {
+      expect(isValidVolume('101')).toBe(false);
+      expect(isValidVolume('-1')).toBe(false);
+      expect(isValidVolume('invalid')).toBe(false);
+    });
+  });
+
+  describe('when validating a pitch input', () => {
+    it('should accept positive numeric values', () => {
+      expect(isValidPitch('1')).toBe(true);
+      expect(isValidPitch('0.5')).toBe(true);
+      expect(isValidPitch('2')).toBe(true);
+    });
+
+    it('should reject zero, negative, and non-numeric values', () => {
+      expect(isValidPitch('0')).toBe(false);
+      expect(isValidPitch('-1')).toBe(false);
+      expect(isValidPitch('invalid')).toBe(false);
+      expect(isValidPitch(undefined)).toBe(false);
+    });
+  });
+
+  describe('when round-tripping a code-authored PBAudioSource through the input converters', () => {
+    let original: PBAudioSource;
+
+    beforeEach(() => {
+      original = {
+        audioClipUrl: 'sounds/track.mp3',
+        playing: true,
+        loop: false,
+        volume: 0.75,
+        pitch: 1.5,
+        currentTime: 12.5,
+        global: true,
+      };
+    });
+
+    it('should preserve every field, including pitch and currentTime, unchanged', () => {
+      expect(toAudioSource(fromAudioSource(original))).toEqual(original);
+    });
+
+    describe('and the optional fields are not set', () => {
+      beforeEach(() => {
+        original = { audioClipUrl: 'sounds/track.mp3' };
+      });
+
+      it('should not invent a currentTime value', () => {
+        expect(toAudioSource(fromAudioSource(original)).currentTime).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/inspector/src/components/EntityInspector/AudioSourceInspector/utils.ts
+++ b/packages/inspector/src/components/EntityInspector/AudioSourceInspector/utils.ts
@@ -11,7 +11,9 @@ export const fromAudioSource = (value: PBAudioSource): AudioSourceInput => {
     loop: value.loop,
     playing: value.playing,
     volume: volumeFromAudioSource(value.volume),
+    pitch: pitchFromAudioSource(value.pitch),
     global: value.global,
+    currentTime: currentTimeFromAudioSource(value.currentTime),
   };
 };
 
@@ -21,7 +23,9 @@ export const toAudioSource = (value: AudioSourceInput): PBAudioSource => {
     loop: value.loop,
     playing: value.playing,
     volume: volumeToAudioSource(value.volume),
+    pitch: pitchToAudioSource(value.pitch),
     global: value.global,
+    currentTime: currentTimeToAudioSource(value.currentTime),
   };
 };
 
@@ -33,6 +37,25 @@ export function volumeFromAudioSource(volume: number | undefined): string {
 export function volumeToAudioSource(volume: string | undefined): number {
   const value = parseFloat(volume ?? '0');
   return parseFloat((value / 100).toFixed(2));
+}
+
+export function pitchFromAudioSource(pitch: number | undefined): string {
+  return (pitch ?? 1).toString();
+}
+
+export function pitchToAudioSource(pitch: string | undefined): number {
+  const value = parseFloat(pitch ?? '1');
+  return isNaN(value) ? 1 : value;
+}
+
+export function currentTimeFromAudioSource(currentTime: number | undefined): string | undefined {
+  return currentTime === undefined ? undefined : currentTime.toString();
+}
+
+export function currentTimeToAudioSource(currentTime: string | undefined): number | undefined {
+  if (currentTime === undefined || currentTime === '') return undefined;
+  const value = parseFloat(currentTime);
+  return isNaN(value) ? undefined : value;
 }
 
 export function isValidInput({ assets }: AssetCatalogResponse, src: string): boolean {
@@ -51,4 +74,9 @@ export const isAudio = (node: TreeNode): node is AssetNodeItem =>
 export function isValidVolume(volume: string | undefined): boolean {
   const value = (volume ?? 0).toString();
   return !isNaN(parseFloat(value)) && parseFloat(value) >= 0 && parseFloat(value) <= 100;
+}
+
+export function isValidPitch(pitch: string | undefined): boolean {
+  const value = (pitch ?? 0).toString();
+  return !isNaN(parseFloat(value)) && parseFloat(value) > 0;
 }

--- a/packages/inspector/src/components/EntityInspector/MaterialInspector/MaterialInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/MaterialInspector/MaterialInspector.tsx
@@ -72,6 +72,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           metallic={getInputProps('metallic')}
           roughness={getInputProps('roughness')}
           albedoColor={getInputProps('albedoColor')}
+          albedoColorAlpha={getInputProps('albedoColorAlpha')}
           reflectivityColor={getInputProps('reflectivityColor')}
           specularIntensity={getInputProps('specularIntensity')}
           directIntensity={getInputProps('directIntensity')}

--- a/packages/inspector/src/components/EntityInspector/MaterialInspector/PbrMaterial/PbrMaterial.tsx
+++ b/packages/inspector/src/components/EntityInspector/MaterialInspector/PbrMaterial/PbrMaterial.tsx
@@ -14,6 +14,7 @@ function PbrMaterial({
   metallic,
   roughness,
   albedoColor,
+  albedoColorAlpha,
   reflectivityColor,
   specularIntensity,
   directIntensity,
@@ -56,6 +57,16 @@ function PbrMaterial({
           {...albedoColor}
         />
       </Block>
+      {albedoColorAlpha && (
+        <Block>
+          <RangeField
+            label="Color Alpha"
+            max={1}
+            step={0.01}
+            {...albedoColorAlpha}
+          />
+        </Block>
+      )}
       <Block>
         <ColorField
           label="Reflectivity color"

--- a/packages/inspector/src/components/EntityInspector/MaterialInspector/PbrMaterial/types.ts
+++ b/packages/inspector/src/components/EntityInspector/MaterialInspector/PbrMaterial/types.ts
@@ -11,6 +11,7 @@ export type PbrMaterialProps = {
   metallic: InputProps;
   roughness: InputProps;
   albedoColor: InputProps;
+  albedoColorAlpha?: InputProps;
   reflectivityColor: InputProps;
   specularIntensity: InputProps;
   directIntensity: InputProps;

--- a/packages/inspector/src/components/EntityInspector/MaterialInspector/Texture/utils.spec.ts
+++ b/packages/inspector/src/components/EntityInspector/MaterialInspector/Texture/utils.spec.ts
@@ -138,6 +138,76 @@ describe('fromTexture', () => {
     expect(result.offset).toEqual({ x: '0.10', y: '0.30' });
     expect(result.tiling).toEqual({ x: '2.50', y: '3.00' });
   });
+
+  describe('when the wrap and filter modes are unset', () => {
+    it('should default a texture to the engine defaults (clamp and bilinear)', () => {
+      const value: TextureUnion = {
+        tex: {
+          $case: 'texture',
+          texture: {
+            src: 'image.png',
+          },
+        },
+      };
+
+      const result = fromTexture(value);
+
+      expect(result.wrapMode).toBe(String(TextureWrapMode.TWM_CLAMP));
+      expect(result.filterMode).toBe(String(TextureFilterMode.TFM_BILINEAR));
+    });
+
+    it('should default an avatarTexture to the engine defaults (clamp and bilinear)', () => {
+      const value: TextureUnion = {
+        tex: {
+          $case: 'avatarTexture',
+          avatarTexture: {
+            userId: 'user123',
+          },
+        },
+      };
+
+      const result = fromTexture(value);
+
+      expect(result.wrapMode).toBe(String(TextureWrapMode.TWM_CLAMP));
+      expect(result.filterMode).toBe(String(TextureFilterMode.TFM_BILINEAR));
+    });
+
+    it('should default a videoTexture to the engine defaults (clamp and bilinear)', () => {
+      const value: TextureUnion = {
+        tex: {
+          $case: 'videoTexture',
+          videoTexture: {
+            videoPlayerEntity: 123,
+          },
+        },
+      };
+
+      const result = fromTexture(value);
+
+      expect(result.wrapMode).toBe(String(TextureWrapMode.TWM_CLAMP));
+      expect(result.filterMode).toBe(String(TextureFilterMode.TFM_BILINEAR));
+    });
+  });
+
+  describe('when the wrap and filter modes are explicitly zero (repeat and point)', () => {
+    it('should keep the explicit values', () => {
+      const value: TextureUnion = {
+        tex: {
+          $case: 'texture',
+          texture: {
+            src: 'image.png',
+            wrapMode: TextureWrapMode.TWM_REPEAT,
+            filterMode: TextureFilterMode.TFM_POINT,
+          },
+        },
+      };
+
+      const result = fromTexture(value);
+
+      expect(result.wrapMode).toBe(String(TextureWrapMode.TWM_REPEAT));
+      expect(result.filterMode).toBe(String(TextureFilterMode.TFM_POINT));
+    });
+  });
 });
 
 describe('toTexture', () => {
@@ -233,6 +303,47 @@ describe('toTexture', () => {
     expect(result.tex.texture.filterMode).toBe(TextureFilterMode.TFM_POINT);
     expect(result.tex.texture.offset).toEqual({ x: 0.1, y: 0.3 });
     expect(result.tex.texture.tiling).toEqual({ x: 2.5, y: 3.0 });
+  });
+
+  describe('when the wrap and filter modes are empty', () => {
+    it('should write the engine defaults (clamp and bilinear)', () => {
+      const value: TextureInput = {
+        type: Texture.TT_TEXTURE,
+        src: 'image.png',
+        wrapMode: '',
+        filterMode: '',
+      };
+
+      const result = toTexture(value) as { tex: { $case: 'texture'; texture: EcsTexture } };
+
+      expect(result.tex.texture.wrapMode).toBe(TextureWrapMode.TWM_CLAMP);
+      expect(result.tex.texture.filterMode).toBe(TextureFilterMode.TFM_BILINEAR);
+    });
+  });
+
+  describe('when the input is undefined', () => {
+    it('should write the engine defaults (clamp and bilinear)', () => {
+      const result = toTexture(undefined) as { tex: { $case: 'texture'; texture: EcsTexture } };
+
+      expect(result.tex.texture.wrapMode).toBe(TextureWrapMode.TWM_CLAMP);
+      expect(result.tex.texture.filterMode).toBe(TextureFilterMode.TFM_BILINEAR);
+    });
+  });
+
+  describe('when the wrap and filter modes are explicitly zero (repeat and point)', () => {
+    it('should keep the explicit values', () => {
+      const value: TextureInput = {
+        type: Texture.TT_TEXTURE,
+        src: 'image.png',
+        wrapMode: String(TextureWrapMode.TWM_REPEAT),
+        filterMode: String(TextureFilterMode.TFM_POINT),
+      };
+
+      const result = toTexture(value) as { tex: { $case: 'texture'; texture: EcsTexture } };
+
+      expect(result.tex.texture.wrapMode).toBe(TextureWrapMode.TWM_REPEAT);
+      expect(result.tex.texture.filterMode).toBe(TextureFilterMode.TFM_POINT);
+    });
   });
 });
 

--- a/packages/inspector/src/components/EntityInspector/MaterialInspector/Texture/utils.ts
+++ b/packages/inspector/src/components/EntityInspector/MaterialInspector/Texture/utils.ts
@@ -11,21 +11,34 @@ import { isValidHttpsUrl } from '../../../../lib/utils/url';
 import { Texture } from './types';
 import type { TextureInput } from './types';
 
+// engine defaults for unset texture modes (see @dcl/ecs texture.gen:
+// "default = TextureWrapMode.Clamp" / "default = FilterMode.Bilinear")
+export const DEFAULT_WRAP_MODE = TextureWrapMode.TWM_CLAMP;
+export const DEFAULT_FILTER_MODE = TextureFilterMode.TFM_BILINEAR;
+
+// like toNumber, but also falls back to the default on undefined/empty input,
+// so an explicit "0" survives while a missing value doesn't become 0
+export const toNumberOrDefault = (value: string | undefined, def: number): number => {
+  if (value === undefined || value === '') return def;
+  const num = Number(value);
+  return isNaN(num) ? def : num;
+};
+
 export const fromTexture = (value: TextureUnion): TextureInput => {
   switch (value.tex?.$case) {
     case 'avatarTexture':
       return {
         type: Texture.TT_AVATAR_TEXTURE,
         userId: toString(value.tex.avatarTexture.userId),
-        wrapMode: toString(value.tex.avatarTexture.wrapMode),
-        filterMode: toString(value.tex.avatarTexture.filterMode),
+        wrapMode: toString(value.tex.avatarTexture.wrapMode, DEFAULT_WRAP_MODE),
+        filterMode: toString(value.tex.avatarTexture.filterMode, DEFAULT_FILTER_MODE),
       };
     case 'videoTexture':
       return {
         type: Texture.TT_VIDEO_TEXTURE,
         videoPlayerEntity: toString(value.tex.videoTexture.videoPlayerEntity),
-        wrapMode: toString(value.tex.videoTexture.wrapMode),
-        filterMode: toString(value.tex.videoTexture.filterMode),
+        wrapMode: toString(value.tex.videoTexture.wrapMode, DEFAULT_WRAP_MODE),
+        filterMode: toString(value.tex.videoTexture.filterMode, DEFAULT_FILTER_MODE),
       };
     case 'texture':
     default: {
@@ -33,8 +46,8 @@ export const fromTexture = (value: TextureUnion): TextureInput => {
       return {
         src,
         type: Texture.TT_TEXTURE,
-        wrapMode: toString(value?.tex?.texture.wrapMode),
-        filterMode: toString(value?.tex?.texture.filterMode),
+        wrapMode: toString(value?.tex?.texture.wrapMode, DEFAULT_WRAP_MODE),
+        filterMode: toString(value?.tex?.texture.filterMode, DEFAULT_FILTER_MODE),
         offset: {
           x: value?.tex?.texture.offset?.x?.toFixed(2) ?? '0',
           y: value?.tex?.texture.offset?.y?.toFixed(2) ?? '0',
@@ -56,8 +69,8 @@ export const toTexture = (value?: TextureInput): TextureUnion => {
           $case: 'avatarTexture',
           avatarTexture: {
             userId: toString(value.userId),
-            wrapMode: toNumber(value.wrapMode, TextureWrapMode.TWM_REPEAT),
-            filterMode: toNumber(value.filterMode, TextureFilterMode.TFM_POINT),
+            wrapMode: toNumberOrDefault(value.wrapMode, DEFAULT_WRAP_MODE),
+            filterMode: toNumberOrDefault(value.filterMode, DEFAULT_FILTER_MODE),
           },
         },
       };
@@ -67,8 +80,8 @@ export const toTexture = (value?: TextureInput): TextureUnion => {
           $case: 'videoTexture',
           videoTexture: {
             videoPlayerEntity: toNumber(value.videoPlayerEntity ?? '')!,
-            wrapMode: toNumber(value.wrapMode, TextureWrapMode.TWM_REPEAT),
-            filterMode: toNumber(value.filterMode, TextureFilterMode.TFM_POINT),
+            wrapMode: toNumberOrDefault(value.wrapMode, DEFAULT_WRAP_MODE),
+            filterMode: toNumberOrDefault(value.filterMode, DEFAULT_FILTER_MODE),
           },
         },
       };
@@ -79,8 +92,8 @@ export const toTexture = (value?: TextureInput): TextureUnion => {
           $case: 'texture',
           texture: {
             src,
-            wrapMode: toNumber(value?.wrapMode ?? '0', TextureWrapMode.TWM_REPEAT),
-            filterMode: toNumber(value?.filterMode ?? '0', TextureFilterMode.TFM_POINT),
+            wrapMode: toNumberOrDefault(value?.wrapMode, DEFAULT_WRAP_MODE),
+            filterMode: toNumberOrDefault(value?.filterMode, DEFAULT_FILTER_MODE),
             offset: {
               x: toNumber(value?.offset?.x ?? '0'),
               y: toNumber(value?.offset?.y ?? '0'),

--- a/packages/inspector/src/components/EntityInspector/MaterialInspector/types.ts
+++ b/packages/inspector/src/components/EntityInspector/MaterialInspector/types.ts
@@ -23,6 +23,7 @@ export type MaterialInput = {
   alphaTest?: string;
   castShadows?: boolean;
   diffuseColor?: string;
+  diffuseColorAlpha?: string;
   texture?: TextureInput;
   alphaTexture?: TextureInput;
   emissiveTexture?: TextureInput;
@@ -34,6 +35,7 @@ export type MaterialInput = {
   emissiveIntensity?: string;
   directIntensity?: string;
   albedoColor?: string;
+  albedoColorAlpha?: string;
   emissiveColor?: string;
   reflectivityColor?: string;
 };

--- a/packages/inspector/src/components/EntityInspector/MaterialInspector/utils.spec.ts
+++ b/packages/inspector/src/components/EntityInspector/MaterialInspector/utils.spec.ts
@@ -31,11 +31,12 @@ describe('fromMaterial', () => {
     expect(result.alphaTest).toBe('0.75');
     expect(result.castShadows).toBe(true);
     expect(result.diffuseColor).toEqual('#FF0000');
+    expect(result.diffuseColorAlpha).toBe('1');
     expect(result.texture).toEqual({
       type: 'texture',
       src: 'some-src',
-      wrapMode: '0',
-      filterMode: '0',
+      wrapMode: '1',
+      filterMode: '1',
       offset: { x: '0', y: '0' },
       tiling: { x: '1', y: '1' },
     });
@@ -79,8 +80,8 @@ describe('fromMaterial', () => {
     expect(result.texture).toEqual({
       type: 'texture',
       src: 'some-src',
-      wrapMode: '0',
-      filterMode: '0',
+      wrapMode: '1',
+      filterMode: '1',
       offset: { x: '0', y: '0' },
       tiling: { x: '1', y: '1' },
     });
@@ -93,7 +94,44 @@ describe('fromMaterial', () => {
     expect(result.metallic).toBe('0.5');
     expect(result.specularIntensity).toBe('1');
     expect(result.albedoColor).toBeUndefined();
+    expect(result.albedoColorAlpha).toBe('1');
     expect(result.emissiveColor).toEqual('#FF0000');
+  });
+
+  describe('when the pbr albedo color has an alpha channel', () => {
+    it('should expose the alpha through albedoColorAlpha', () => {
+      const value: PBMaterial = {
+        material: {
+          $case: 'pbr' as const,
+          pbr: {
+            albedoColor: { r: 1, g: 0, b: 0, a: 0.25 },
+          },
+        },
+      };
+
+      const result = fromMaterial(value);
+
+      expect(result.albedoColor).toBe('#FF0000');
+      expect(result.albedoColorAlpha).toBe('0.25');
+    });
+  });
+
+  describe('when the unlit diffuse color has an alpha channel', () => {
+    it('should expose the alpha through diffuseColorAlpha', () => {
+      const value: PBMaterial = {
+        material: {
+          $case: 'unlit' as const,
+          unlit: {
+            diffuseColor: { r: 0, g: 1, b: 0, a: 0.3 },
+          },
+        },
+      };
+
+      const result = fromMaterial(value);
+
+      expect(result.diffuseColor).toBe('#00FF00');
+      expect(result.diffuseColorAlpha).toBe('0.3');
+    });
   });
 });
 
@@ -183,6 +221,165 @@ describe('toMaterial', () => {
           filterMode: 2,
         },
       },
+    });
+  });
+
+  describe('when the pbr numeric inputs are explicitly zero', () => {
+    it('should keep the zeros instead of snapping back to the defaults', () => {
+      const value: MaterialInput = {
+        type: MaterialType.MT_PBR,
+        alphaTest: '0',
+        transparencyMode: '0',
+        metallic: '0',
+        roughness: '0',
+        specularIntensity: '0',
+        emissiveIntensity: '0',
+        directIntensity: '0',
+      };
+
+      const result = toMaterial(value) as {
+        material: { $case: 'pbr'; pbr: PBMaterial_PbrMaterial };
+      };
+
+      expect(result.material.pbr.alphaTest).toBe(0);
+      expect(result.material.pbr.transparencyMode).toBe(0);
+      expect(result.material.pbr.metallic).toBe(0);
+      expect(result.material.pbr.roughness).toBe(0);
+      expect(result.material.pbr.specularIntensity).toBe(0);
+      expect(result.material.pbr.emissiveIntensity).toBe(0);
+      expect(result.material.pbr.directIntensity).toBe(0);
+    });
+
+    it('should survive a round trip through fromMaterial', () => {
+      const value: MaterialInput = {
+        type: MaterialType.MT_PBR,
+        transparencyMode: '0',
+        metallic: '0',
+        roughness: '0',
+        specularIntensity: '0',
+        emissiveIntensity: '0',
+        directIntensity: '0',
+      };
+
+      const result = fromMaterial(toMaterial(value));
+
+      expect(result.transparencyMode).toBe('0');
+      expect(result.metallic).toBe('0');
+      expect(result.roughness).toBe('0');
+      expect(result.specularIntensity).toBe('0');
+      expect(result.emissiveIntensity).toBe('0');
+      expect(result.directIntensity).toBe('0');
+    });
+  });
+
+  describe('when the pbr numeric inputs are unset or empty', () => {
+    it('should fall back to the defaults', () => {
+      const value: MaterialInput = {
+        type: MaterialType.MT_PBR,
+        metallic: '',
+        roughness: '',
+      };
+
+      const result = toMaterial(value) as {
+        material: { $case: 'pbr'; pbr: PBMaterial_PbrMaterial };
+      };
+
+      expect(result.material.pbr.alphaTest).toBe(0.5);
+      expect(result.material.pbr.transparencyMode).toBe(4);
+      expect(result.material.pbr.metallic).toBe(0.5);
+      expect(result.material.pbr.roughness).toBe(0.5);
+      expect(result.material.pbr.specularIntensity).toBe(1);
+      expect(result.material.pbr.emissiveIntensity).toBe(0);
+      expect(result.material.pbr.directIntensity).toBe(1);
+    });
+  });
+
+  describe('when the pbr albedo color has an alpha input', () => {
+    it('should write the alpha into albedoColor.a', () => {
+      const value: MaterialInput = {
+        type: MaterialType.MT_PBR,
+        albedoColor: '#FF0000',
+        albedoColorAlpha: '0.25',
+      };
+
+      const result = toMaterial(value) as {
+        material: { $case: 'pbr'; pbr: PBMaterial_PbrMaterial };
+      };
+
+      expect(result.material.pbr.albedoColor).toEqual({ r: 1, g: 0, b: 0, a: 0.25 });
+    });
+
+    it('should keep zero alpha instead of snapping back to opaque', () => {
+      const value: MaterialInput = {
+        type: MaterialType.MT_PBR,
+        albedoColor: '#FF0000',
+        albedoColorAlpha: '0',
+      };
+
+      const result = toMaterial(value) as {
+        material: { $case: 'pbr'; pbr: PBMaterial_PbrMaterial };
+      };
+
+      expect(result.material.pbr.albedoColor?.a).toBe(0);
+    });
+
+    it('should survive a round trip through fromMaterial', () => {
+      const value: MaterialInput = {
+        type: MaterialType.MT_PBR,
+        albedoColor: '#FF0000',
+        albedoColorAlpha: '0.25',
+      };
+
+      const result = fromMaterial(toMaterial(value));
+
+      expect(result.albedoColor).toBe('#FF0000');
+      expect(result.albedoColorAlpha).toBe('0.25');
+    });
+  });
+
+  describe('when the pbr albedo color is an 8-digit hex', () => {
+    it('should take the alpha from the hex itself', () => {
+      const value: MaterialInput = {
+        type: MaterialType.MT_PBR,
+        albedoColor: '#FF000080',
+        albedoColorAlpha: '1',
+      };
+
+      const result = toMaterial(value) as {
+        material: { $case: 'pbr'; pbr: PBMaterial_PbrMaterial };
+      };
+
+      expect(result.material.pbr.albedoColor?.a).toBeCloseTo(0.5, 2);
+    });
+  });
+
+  describe('when the pbr albedo alpha input is missing', () => {
+    it('should keep the color opaque', () => {
+      const value: MaterialInput = {
+        type: MaterialType.MT_PBR,
+        albedoColor: '#FF0000',
+      };
+
+      const result = toMaterial(value) as {
+        material: { $case: 'pbr'; pbr: PBMaterial_PbrMaterial };
+      };
+
+      expect(result.material.pbr.albedoColor).toEqual({ r: 1, g: 0, b: 0, a: 1 });
+    });
+  });
+
+  describe('when the unlit diffuse color has an alpha input', () => {
+    it('should preserve the alpha through a round trip', () => {
+      const value: MaterialInput = {
+        type: MaterialType.MT_UNLIT,
+        diffuseColor: '#00FF00',
+        diffuseColorAlpha: '0.3',
+      };
+
+      const result = fromMaterial(toMaterial(value));
+
+      expect(result.diffuseColor).toBe('#00FF00');
+      expect(result.diffuseColorAlpha).toBe('0.3');
     });
   });
 });

--- a/packages/inspector/src/components/EntityInspector/MaterialInspector/utils.ts
+++ b/packages/inspector/src/components/EntityInspector/MaterialInspector/utils.ts
@@ -1,16 +1,26 @@
 import type { PBMaterial } from '@dcl/ecs';
 import { MaterialTransparencyMode } from '@dcl/ecs';
 
-import {
-  toColor3OrUndefined,
-  toColor4OrUndefined,
-  toHexOrUndefined,
-} from '../../ui/ColorField/utils';
+import { toColor3OrUndefined, toColor4, toHexOrUndefined } from '../../ui/ColorField/utils';
 import { mapSelectFieldOptions } from '../../ui/Dropdown/utils';
 import { toString } from '../utils';
-import { fromTexture, toTexture } from './Texture/utils';
+import { fromTexture, toTexture, toNumberOrDefault } from './Texture/utils';
 import type { MaterialInput } from './types';
 import { MaterialType } from './types';
+
+// the hex color picker is RGB-only, so the alpha channel is carried through the
+// input separately and reapplied here (same approach as TextShapeInspector)
+const toColor4WithAlphaOrUndefined = (
+  hex?: string,
+  alpha?: string,
+): ReturnType<typeof toColor4> | undefined => {
+  if (!hex) return undefined;
+  const color = toColor4(hex);
+  // an 8-digit hex (#RRGGBBAA) already carries its own alpha
+  if (hex.length > 7) return color;
+  const parsedAlpha = alpha === undefined || alpha === '' ? NaN : Number(alpha);
+  return { ...color, a: isNaN(parsedAlpha) ? color.a : parsedAlpha };
+};
 
 export const fromMaterial = (value: PBMaterial): MaterialInput => {
   switch (value.material?.$case) {
@@ -20,6 +30,7 @@ export const fromMaterial = (value: PBMaterial): MaterialInput => {
         alphaTest: String(value.material.unlit.alphaTest ?? 0.5),
         castShadows: !!(value.material.unlit.castShadows ?? true),
         diffuseColor: toHexOrUndefined(value.material.unlit.diffuseColor),
+        diffuseColorAlpha: toString(value.material.unlit.diffuseColor?.a ?? 1),
         texture: fromTexture(value.material.unlit.texture ?? {}),
         alphaTexture: fromTexture(value.material.unlit.alphaTexture ?? {}),
       };
@@ -39,6 +50,7 @@ export const fromMaterial = (value: PBMaterial): MaterialInput => {
         emissiveIntensity: toString(value.material?.pbr.emissiveIntensity ?? 0),
         directIntensity: toString(value.material?.pbr.directIntensity ?? 1),
         albedoColor: toHexOrUndefined(value.material?.pbr.albedoColor),
+        albedoColorAlpha: toString(value.material?.pbr.albedoColor?.a ?? 1),
         emissiveColor: toHexOrUndefined(value.material?.pbr.emissiveColor),
         reflectivityColor: toHexOrUndefined(value.material?.pbr.reflectivityColor),
         texture: fromTexture(value.material?.pbr.texture ?? {}),
@@ -56,9 +68,9 @@ export const toMaterial = (value: MaterialInput): PBMaterial => {
         material: {
           $case: 'unlit',
           unlit: {
-            alphaTest: Number(value.alphaTest ?? 0.5),
+            alphaTest: toNumberOrDefault(value.alphaTest, 0.5),
             castShadows: !!(value.castShadows ?? true),
-            diffuseColor: toColor4OrUndefined(value.diffuseColor),
+            diffuseColor: toColor4WithAlphaOrUndefined(value.diffuseColor, value.diffuseColorAlpha),
             texture: toTexture(value.texture),
             alphaTexture: toTexture(value.alphaTexture),
           },
@@ -70,15 +82,18 @@ export const toMaterial = (value: MaterialInput): PBMaterial => {
         material: {
           $case: 'pbr',
           pbr: {
-            alphaTest: Number(value.alphaTest ?? 0.5),
+            alphaTest: toNumberOrDefault(value.alphaTest, 0.5),
             castShadows: !!(value.castShadows ?? true),
-            transparencyMode: Number(value.transparencyMode || MaterialTransparencyMode.MTM_AUTO),
-            metallic: Number(value.metallic || 0.5),
-            roughness: Number(value.roughness || 0.5),
-            specularIntensity: Number(value.specularIntensity || 1),
-            emissiveIntensity: Number(value.emissiveIntensity || 0),
-            directIntensity: Number(value.directIntensity || 1),
-            albedoColor: toColor4OrUndefined(value.albedoColor),
+            transparencyMode: toNumberOrDefault(
+              value.transparencyMode,
+              MaterialTransparencyMode.MTM_AUTO,
+            ),
+            metallic: toNumberOrDefault(value.metallic, 0.5),
+            roughness: toNumberOrDefault(value.roughness, 0.5),
+            specularIntensity: toNumberOrDefault(value.specularIntensity, 1),
+            emissiveIntensity: toNumberOrDefault(value.emissiveIntensity, 0),
+            directIntensity: toNumberOrDefault(value.directIntensity, 1),
+            albedoColor: toColor4WithAlphaOrUndefined(value.albedoColor, value.albedoColorAlpha),
             emissiveColor: toColor3OrUndefined(value.emissiveColor),
             reflectivityColor: toColor3OrUndefined(value.reflectivityColor),
             texture: toTexture(value.texture),

--- a/packages/inspector/src/components/EntityInspector/ParticleSystemInspector/ParticleSystemInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/ParticleSystemInspector/ParticleSystemInspector.tsx
@@ -33,6 +33,10 @@ import {
   BLEND_MODE_OPTIONS,
   PLAYBACK_STATE_OPTIONS,
   SIMULATION_SPACE_OPTIONS,
+  WRAP_MODE_OPTIONS,
+  FILTER_MODE_OPTIONS,
+  DEFAULT_WRAP_MODE,
+  DEFAULT_FILTER_MODE,
 } from './types';
 import { fromComponent, toComponent, isValidInput, createDefaultBurst } from './utils';
 
@@ -161,6 +165,8 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
   const limitVelocityEnabled = getInputProps('limitVelocityEnabled', e => e.target.checked);
   const shapeType = getInputProps('shapeType');
   const textureSrc = getInputProps('texture.src');
+  const textureWrapMode = getInputProps('texture.wrapMode');
+  const textureFilterMode = getInputProps('texture.filterMode');
   const currentShape = String(shapeType.value);
 
   return (
@@ -722,6 +728,80 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
         </Block>
       </Container>
 
+      {/* Rotation */}
+      <Container
+        label="Rotation"
+        border
+        initialOpen={false}
+        rightContent={
+          <InfoTooltip
+            text="Rotate particles around their own axes. Only visible with Billboard off (or non-square textures)."
+            type="help"
+          />
+        }
+      >
+        <Block
+          label={
+            <>
+              Initial Rotation (deg){' '}
+              <InfoTooltip
+                text="Rotation of each particle at birth, in degrees per axis."
+                type="help"
+              />
+            </>
+          }
+        >
+          <TextField
+            leftLabel="X"
+            type="number"
+            {...getInputProps('initialRotation.x')}
+            autoSelect
+          />
+          <TextField
+            leftLabel="Y"
+            type="number"
+            {...getInputProps('initialRotation.y')}
+            autoSelect
+          />
+          <TextField
+            leftLabel="Z"
+            type="number"
+            {...getInputProps('initialRotation.z')}
+            autoSelect
+          />
+        </Block>
+        <Block
+          label={
+            <>
+              Rotation Over Time (deg/sec){' '}
+              <InfoTooltip
+                text="Angular velocity per axis in degrees per second. Values are limited to ±180 per axis by the underlying rotation encoding."
+                type="help"
+              />
+            </>
+          }
+        >
+          <TextField
+            leftLabel="X"
+            type="number"
+            {...getInputProps('rotationOverTime.x')}
+            autoSelect
+          />
+          <TextField
+            leftLabel="Y"
+            type="number"
+            {...getInputProps('rotationOverTime.y')}
+            autoSelect
+          />
+          <TextField
+            leftLabel="Z"
+            type="number"
+            {...getInputProps('rotationOverTime.z')}
+            autoSelect
+          />
+        </Block>
+      </Container>
+
       {/* Color */}
       <Container
         label="Color"
@@ -803,19 +883,103 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           />
         </Block>
         {!!textureEnabled.value && (
-          <Block label="Texture Path">
-            <FileUploadField
-              {...textureSrc}
-              label="Path"
-              accept={ACCEPTED_FILE_TYPES['image']}
-              options={imageOptions}
-              onDrop={handleTextureDrop}
-              onChange={handleTextureChange}
-              error={!!textureSrc.value && !isValidTexturePath(textureSrc.value)}
-              isValidFile={isModel}
-              acceptURLs
-            />
-          </Block>
+          <>
+            <Block label="Texture Path">
+              <FileUploadField
+                {...textureSrc}
+                label="Path"
+                accept={ACCEPTED_FILE_TYPES['image']}
+                options={imageOptions}
+                onDrop={handleTextureDrop}
+                onChange={handleTextureChange}
+                error={!!textureSrc.value && !isValidTexturePath(textureSrc.value)}
+                isValidFile={isModel}
+                acceptURLs
+              />
+            </Block>
+            <Block>
+              <Dropdown
+                label={
+                  <>
+                    Wrap Mode{' '}
+                    <InfoTooltip
+                      text="How the texture behaves outside the 0–1 UV range. Clamp (default): stretch edge pixels. Repeat: tile. Mirror: tile with alternating flips."
+                      type="help"
+                    />
+                  </>
+                }
+                options={WRAP_MODE_OPTIONS}
+                {...textureWrapMode}
+                value={String(textureWrapMode.value || DEFAULT_WRAP_MODE)}
+              />
+              <Dropdown
+                label={
+                  <>
+                    Filter Mode{' '}
+                    <InfoTooltip
+                      text="Texture sampling. Bilinear (default): smooth. Point: pixelated (good for pixel art). Trilinear: smooth across mipmap levels."
+                      type="help"
+                    />
+                  </>
+                }
+                options={FILTER_MODE_OPTIONS}
+                {...textureFilterMode}
+                value={String(textureFilterMode.value || DEFAULT_FILTER_MODE)}
+              />
+            </Block>
+            <Block
+              label={
+                <>
+                  Offset{' '}
+                  <InfoTooltip
+                    text="UV offset applied to the texture. Leave empty for the engine default (0, 0)."
+                    type="help"
+                  />
+                </>
+              }
+            >
+              <TextField
+                leftLabel="X"
+                type="number"
+                placeholder="0"
+                {...getInputProps('texture.offset.x')}
+                autoSelect
+              />
+              <TextField
+                leftLabel="Y"
+                type="number"
+                placeholder="0"
+                {...getInputProps('texture.offset.y')}
+                autoSelect
+              />
+            </Block>
+            <Block
+              label={
+                <>
+                  Tiling{' '}
+                  <InfoTooltip
+                    text="UV tiling multiplier for texture repetition. Leave empty for the engine default (1, 1)."
+                    type="help"
+                  />
+                </>
+              }
+            >
+              <TextField
+                leftLabel="X"
+                type="number"
+                placeholder="1"
+                {...getInputProps('texture.tiling.x')}
+                autoSelect
+              />
+              <TextField
+                leftLabel="Y"
+                type="number"
+                placeholder="1"
+                {...getInputProps('texture.tiling.y')}
+                autoSelect
+              />
+            </Block>
+          </>
         )}
         <Block>
           <Dropdown

--- a/packages/inspector/src/components/EntityInspector/ParticleSystemInspector/types.ts
+++ b/packages/inspector/src/components/EntityInspector/ParticleSystemInspector/types.ts
@@ -1,4 +1,5 @@
 import type { Entity } from '@dcl/ecs';
+import { TextureFilterMode, TextureWrapMode } from '@dcl/ecs';
 
 export enum ShapeType {
   POINT = 'point',
@@ -48,6 +49,33 @@ export const SIMULATION_SPACE_OPTIONS = [
   { label: 'World', value: String(SimulationSpace.PSS_WORLD) },
 ];
 
+export const WRAP_MODE_OPTIONS = [
+  { label: 'Repeat', value: String(TextureWrapMode.TWM_REPEAT) },
+  { label: 'Clamp', value: String(TextureWrapMode.TWM_CLAMP) },
+  { label: 'Mirror', value: String(TextureWrapMode.TWM_MIRROR) },
+];
+
+export const FILTER_MODE_OPTIONS = [
+  { label: 'Point', value: String(TextureFilterMode.TFM_POINT) },
+  { label: 'Bilinear', value: String(TextureFilterMode.TFM_BILINEAR) },
+  { label: 'Trilinear', value: String(TextureFilterMode.TFM_TRILINEAR) },
+];
+
+// Engine defaults for unset texture modes (used for display only; unset values stay unset).
+export const DEFAULT_WRAP_MODE = String(TextureWrapMode.TWM_CLAMP);
+export const DEFAULT_FILTER_MODE = String(TextureFilterMode.TFM_BILINEAR);
+
+export type EulerInput = { x: string; y: string; z: string };
+
+export type TextureInput = {
+  src: string;
+  // Empty string means "unset" (engine default); the value only gets written when the user sets it.
+  wrapMode: string;
+  filterMode: string;
+  offset: { x: string; y: string };
+  tiling: { x: string; y: string };
+};
+
 export type BurstInput = {
   time: string;
   count: string;
@@ -65,12 +93,14 @@ export type ParticleSystemInput = {
   additionalForce: { x: string; y: string; z: string };
   initialSize: { start: string; end: string };
   sizeOverTime: { start: string; end: string };
+  initialRotation: EulerInput;
+  rotationOverTime: EulerInput;
   faceTravelDirection: boolean;
   initialColor: { startColor: string; startAlpha: string; endColor: string; endAlpha: string };
   colorOverTime: { startColor: string; startAlpha: string; endColor: string; endAlpha: string };
   initialVelocitySpeed: { start: string; end: string };
   textureEnabled: boolean;
-  texture: { src: string };
+  texture: TextureInput;
   blendMode: string;
   billboard: boolean;
   spriteSheetEnabled: boolean;

--- a/packages/inspector/src/components/EntityInspector/ParticleSystemInspector/utils.spec.ts
+++ b/packages/inspector/src/components/EntityInspector/ParticleSystemInspector/utils.spec.ts
@@ -1,0 +1,218 @@
+import { TextureFilterMode, TextureWrapMode } from '@dcl/ecs';
+
+import type { ParticleSystemComponentType } from '../../../lib/sdk/components/ParticleSystem';
+import type { ParticleSystemInput } from './types';
+import { eulerDegreesToQuaternion, fromComponent, toComponent, isValidInput } from './utils';
+
+const getEmptyComponent = (): ParticleSystemComponentType => ({});
+
+const getBaseInput = (): ParticleSystemInput => fromComponent(getEmptyComponent());
+
+// A fully code-authored component with every PBParticleSystem field set. Rotations are
+// authored through the same euler->quaternion conversion the editor uses, so the values
+// are exactly representable by the editor inputs.
+const getFullComponent = (): ParticleSystemComponentType => ({
+  active: true,
+  rate: 12,
+  maxParticles: 500,
+  lifetime: 3,
+  gravity: 0.5,
+  additionalForce: { x: 1, y: 2, z: 3 },
+  initialSize: { start: 0.5, end: 2 },
+  sizeOverTime: { start: 1, end: 0.25 },
+  initialRotation: eulerDegreesToQuaternion({ x: '30', y: '45', z: '10' }),
+  rotationOverTime: eulerDegreesToQuaternion({ x: '0', y: '30', z: '-15' }),
+  faceTravelDirection: true,
+  initialColor: {
+    start: { r: 1, g: 0, b: 0, a: 0.5 },
+    end: { r: 0, g: 1, b: 0, a: 1 },
+  },
+  colorOverTime: {
+    start: { r: 0, g: 0, b: 1, a: 1 },
+    end: { r: 1, g: 1, b: 1, a: 0 },
+  },
+  initialVelocitySpeed: { start: 1, end: 4 },
+  texture: {
+    src: 'assets/scene/smoke.png',
+    wrapMode: TextureWrapMode.TWM_MIRROR,
+    filterMode: TextureFilterMode.TFM_TRILINEAR,
+    offset: { x: 0.25, y: 0.5 },
+    tiling: { x: 2, y: 3 },
+  },
+  blendMode: 1,
+  billboard: false,
+  spriteSheet: { tilesX: 4, tilesY: 4, framesPerSecond: 24 },
+  shape: { $case: 'cone', cone: { angle: 30, radius: 2 } },
+  loop: false,
+  prewarm: false,
+  simulationSpace: 1,
+  limitVelocity: { speed: 6, dampen: 0.5 },
+  playbackState: 2,
+  bursts: { values: [{ time: 0.5, count: 20, cycles: 2, interval: 0.1, probability: 0.75 }] },
+});
+
+describe('ParticleSystemInspector utils', () => {
+  describe('when converting a component into an input', () => {
+    describe('and the rotation fields are set', () => {
+      it('should convert the quaternions into euler angles in degrees', () => {
+        const input = fromComponent(getFullComponent());
+        expect(input.initialRotation).toEqual({ x: '30', y: '45', z: '10' });
+        expect(input.rotationOverTime).toEqual({ x: '0', y: '30', z: '-15' });
+      });
+    });
+    describe('and the rotation fields are unset', () => {
+      it('should default the euler angles to zero', () => {
+        const input = fromComponent(getEmptyComponent());
+        expect(input.initialRotation).toEqual({ x: '0', y: '0', z: '0' });
+        expect(input.rotationOverTime).toEqual({ x: '0', y: '0', z: '0' });
+      });
+    });
+    describe('and the texture has all fields set', () => {
+      it('should convert every texture field into strings', () => {
+        const input = fromComponent(getFullComponent());
+        expect(input.textureEnabled).toBe(true);
+        expect(input.texture).toEqual({
+          src: 'assets/scene/smoke.png',
+          wrapMode: String(TextureWrapMode.TWM_MIRROR),
+          filterMode: String(TextureFilterMode.TFM_TRILINEAR),
+          offset: { x: '0.25', y: '0.5' },
+          tiling: { x: '2', y: '3' },
+        });
+      });
+    });
+    describe('and the texture only has a src', () => {
+      it('should keep the optional texture fields as empty strings', () => {
+        const input = fromComponent({ texture: { src: 'smoke.png' } });
+        expect(input.texture).toEqual({
+          src: 'smoke.png',
+          wrapMode: '',
+          filterMode: '',
+          offset: { x: '', y: '' },
+          tiling: { x: '', y: '' },
+        });
+      });
+    });
+  });
+
+  describe('when converting an input into a component', () => {
+    describe('and the rotation inputs are zero', () => {
+      it('should leave the rotation fields unset', () => {
+        const component = toComponent(getBaseInput());
+        expect(component.initialRotation).toBeUndefined();
+        expect(component.rotationOverTime).toBeUndefined();
+      });
+    });
+    describe('and the rotation inputs are non-zero', () => {
+      it('should convert the euler angles into quaternions', () => {
+        const input = {
+          ...getBaseInput(),
+          initialRotation: { x: '30', y: '45', z: '10' },
+          rotationOverTime: { x: '0', y: '30', z: '-15' },
+        };
+        const component = toComponent(input);
+        expect(component.initialRotation).toEqual(
+          eulerDegreesToQuaternion({ x: '30', y: '45', z: '10' }),
+        );
+        expect(component.rotationOverTime).toEqual(
+          eulerDegreesToQuaternion({ x: '0', y: '30', z: '-15' }),
+        );
+      });
+    });
+    describe('and the texture is disabled', () => {
+      it('should set the texture to undefined so it gets removed on merge', () => {
+        const component = toComponent(getBaseInput());
+        expect('texture' in component).toBe(true);
+        expect(component.texture).toBeUndefined();
+      });
+    });
+    describe('and the texture is enabled without optional fields', () => {
+      it('should only write the src and keep wrap/filter/offset/tiling unset', () => {
+        const input = {
+          ...getBaseInput(),
+          textureEnabled: true,
+          texture: {
+            src: 'smoke.png',
+            wrapMode: '',
+            filterMode: '',
+            offset: { x: '', y: '' },
+            tiling: { x: '', y: '' },
+          },
+        };
+        const component = toComponent(input);
+        expect(component.texture).toEqual({ src: 'smoke.png' });
+        expect(component.texture?.wrapMode).toBeUndefined();
+        expect(component.texture?.filterMode).toBeUndefined();
+        expect(component.texture?.offset).toBeUndefined();
+        expect(component.texture?.tiling).toBeUndefined();
+      });
+    });
+    describe('and only one axis of the texture offset or tiling is set', () => {
+      it('should fill the other axis with the engine default', () => {
+        const input = {
+          ...getBaseInput(),
+          textureEnabled: true,
+          texture: {
+            src: 'smoke.png',
+            wrapMode: '',
+            filterMode: '',
+            offset: { x: '0.5', y: '' },
+            tiling: { x: '', y: '2' },
+          },
+        };
+        const component = toComponent(input);
+        expect(component.texture?.offset).toEqual({ x: 0.5, y: 0 });
+        expect(component.texture?.tiling).toEqual({ x: 1, y: 2 });
+      });
+    });
+  });
+
+  describe('when round-tripping a fully authored component through the editor converters', () => {
+    it('should return the component unchanged', () => {
+      const component = getFullComponent();
+      expect(toComponent(fromComponent(component))).toEqual(component);
+    });
+  });
+
+  describe('when round-tripping a component with a bare texture', () => {
+    it('should not materialize the unset texture fields', () => {
+      const component: ParticleSystemComponentType = { texture: { src: 'smoke.png' } };
+      const result = toComponent(fromComponent(component));
+      expect(result.texture).toEqual({ src: 'smoke.png' });
+    });
+  });
+
+  describe('when round-tripping a component without rotations or texture', () => {
+    it('should keep those fields unset', () => {
+      const result = toComponent(fromComponent(getEmptyComponent()));
+      expect(result.initialRotation).toBeUndefined();
+      expect(result.rotationOverTime).toBeUndefined();
+      expect(result.texture).toBeUndefined();
+    });
+  });
+
+  describe('when validating the input', () => {
+    describe('and a rotation field is not a number', () => {
+      it('should return false', () => {
+        const input = { ...getBaseInput(), initialRotation: { x: 'abc', y: '0', z: '0' } };
+        expect(isValidInput(input)).toBe(false);
+      });
+    });
+    describe('and a texture offset field is not a number while the texture is enabled', () => {
+      it('should return false', () => {
+        const base = getBaseInput();
+        const input = {
+          ...base,
+          textureEnabled: true,
+          texture: { ...base.texture, offset: { x: 'abc', y: '' } },
+        };
+        expect(isValidInput(input)).toBe(false);
+      });
+    });
+    describe('and the texture fields are empty strings', () => {
+      it('should return true', () => {
+        const input = { ...getBaseInput(), textureEnabled: true };
+        expect(isValidInput(input)).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/inspector/src/components/EntityInspector/ParticleSystemInspector/utils.ts
+++ b/packages/inspector/src/components/EntityInspector/ParticleSystemInspector/utils.ts
@@ -1,11 +1,79 @@
+import { Quaternion } from '@babylonjs/core';
+
 import type {
   ParticleSystemBurst,
   ParticleSystemComponentType,
   ParticleSystemShape,
+  ParticleSystemTexture,
 } from '../../../lib/sdk/components/ParticleSystem';
 import { toHex, toColor3 } from '../../ui/ColorField/utils';
-import type { ParticleSystemInput, BurstInput } from './types';
+import type { ParticleSystemInput, BurstInput, EulerInput, TextureInput } from './types';
 import { ShapeType } from './types';
+
+type QuaternionType = { x: number; y: number; z: number; w: number };
+
+const formatDegrees = (radians: number): string =>
+  String(Math.round(((radians * 180) / Math.PI) * 100) / 100);
+
+const fromQuaternion = (value: QuaternionType | undefined): EulerInput => {
+  if (!value) return { x: '0', y: '0', z: '0' };
+  const angles = new Quaternion(value.x, value.y, value.z, value.w).toEulerAngles();
+  return {
+    x: formatDegrees(angles.x),
+    y: formatDegrees(angles.y),
+    z: formatDegrees(angles.z),
+  };
+};
+
+export const eulerDegreesToQuaternion = (euler: EulerInput): QuaternionType => {
+  const quaternion = Quaternion.RotationYawPitchRoll(
+    (Number(euler.y) * Math.PI) / 180,
+    (Number(euler.x) * Math.PI) / 180,
+    (Number(euler.z) * Math.PI) / 180,
+  );
+  return { x: quaternion.x, y: quaternion.y, z: quaternion.z, w: quaternion.w };
+};
+
+// Zero rotation maps to "unset" so an untouched editor never materializes the field.
+const toQuaternion = (euler: EulerInput): QuaternionType | undefined => {
+  const isZero = Number(euler.x) === 0 && Number(euler.y) === 0 && Number(euler.z) === 0;
+  return isZero ? undefined : eulerDegreesToQuaternion(euler);
+};
+
+const fromTexture = (texture: ParticleSystemTexture | undefined): TextureInput => ({
+  src: texture?.src ?? '',
+  wrapMode: texture?.wrapMode !== undefined ? String(texture.wrapMode) : '',
+  filterMode: texture?.filterMode !== undefined ? String(texture.filterMode) : '',
+  offset: {
+    x: texture?.offset !== undefined ? String(texture.offset.x) : '',
+    y: texture?.offset !== undefined ? String(texture.offset.y) : '',
+  },
+  tiling: {
+    x: texture?.tiling !== undefined ? String(texture.tiling.x) : '',
+    y: texture?.tiling !== undefined ? String(texture.tiling.y) : '',
+  },
+});
+
+const toVector2 = (
+  value: { x: string; y: string },
+  defaultValue: number,
+): { x: number; y: number } | undefined => {
+  if (value.x === '' && value.y === '') return undefined;
+  return {
+    x: value.x === '' ? defaultValue : Number(value.x),
+    y: value.y === '' ? defaultValue : Number(value.y),
+  };
+};
+
+// Fields the user never set stay unset instead of materializing values
+// (engine defaults are Clamp / Bilinear / offset {0,0} / tiling {1,1}).
+const toTexture = (input: TextureInput): ParticleSystemTexture => ({
+  src: input.src ?? '',
+  wrapMode: input.wrapMode === '' ? undefined : Number(input.wrapMode),
+  filterMode: input.filterMode === '' ? undefined : Number(input.filterMode),
+  offset: toVector2(input.offset, 0),
+  tiling: toVector2(input.tiling, 1),
+});
 
 const fromShape = (shape: ParticleSystemShape | undefined) => {
   const sphere = shape?.$case === 'sphere' ? shape.sphere : undefined;
@@ -98,6 +166,8 @@ export const fromComponent = (value: ParticleSystemComponentType): ParticleSyste
     start: String(value.sizeOverTime?.start ?? 1),
     end: String(value.sizeOverTime?.end ?? 1),
   },
+  initialRotation: fromQuaternion(value.initialRotation),
+  rotationOverTime: fromQuaternion(value.rotationOverTime),
   faceTravelDirection: value.faceTravelDirection ?? false,
   initialColor: {
     startColor: toHex(value.initialColor?.start).toUpperCase(),
@@ -116,7 +186,7 @@ export const fromComponent = (value: ParticleSystemComponentType): ParticleSyste
     end: String(value.initialVelocitySpeed?.end ?? 1),
   },
   textureEnabled: !!value.texture,
-  texture: { src: value.texture?.src ?? '' },
+  texture: fromTexture(value.texture),
   blendMode: String(value.blendMode ?? 0),
   billboard: value.billboard ?? true,
   spriteSheetEnabled: !!value.spriteSheet,
@@ -163,6 +233,8 @@ export const toComponent = (input: ParticleSystemInput): ParticleSystemComponent
       start: Number(input.sizeOverTime.start),
       end: Number(input.sizeOverTime.end),
     },
+    initialRotation: toQuaternion(input.initialRotation),
+    rotationOverTime: toQuaternion(input.rotationOverTime),
     faceTravelDirection: input.faceTravelDirection,
     initialColor: {
       start: { ...startColor, a: Number(input.initialColor.startAlpha) },
@@ -176,6 +248,9 @@ export const toComponent = (input: ParticleSystemInput): ParticleSystemComponent
       start: Number(input.initialVelocitySpeed.start),
       end: Number(input.initialVelocitySpeed.end),
     },
+    // Explicit undefined (not a missing key) so disabling the texture actually removes it
+    // when the save path spread-merges over the current component value.
+    texture: input.textureEnabled ? toTexture(input.texture) : undefined,
     blendMode: Number(input.blendMode),
     billboard: input.billboard,
     spriteSheet: input.spriteSheetEnabled
@@ -199,10 +274,6 @@ export const toComponent = (input: ParticleSystemInput): ParticleSystemComponent
     bursts: input.bursts.length > 0 ? { values: input.bursts.map(toBurst) } : undefined,
   };
 
-  if (input.textureEnabled) {
-    component.texture = { src: input.texture.src ?? '' };
-  }
-
   return component;
 };
 
@@ -216,6 +287,15 @@ export const isValidInput = (input: ParticleSystemInput): boolean => {
     const time = Number(burst.time);
     const count = Number(burst.count);
     if (isNaN(time) || isNaN(count) || time < 0 || count < 0) return false;
+  }
+  for (const euler of [input.initialRotation, input.rotationOverTime]) {
+    if (isNaN(Number(euler.x)) || isNaN(Number(euler.y)) || isNaN(Number(euler.z))) return false;
+  }
+  if (input.textureEnabled) {
+    for (const vector of [input.texture.offset, input.texture.tiling]) {
+      if (vector.x !== '' && isNaN(Number(vector.x))) return false;
+      if (vector.y !== '' && isNaN(Number(vector.y))) return false;
+    }
   }
   return true;
 };

--- a/packages/inspector/src/components/EntityInspector/TextShapeInspector/TextShapeInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/TextShapeInspector/TextShapeInspector.tsx
@@ -37,6 +37,7 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
   if (!allEntitiesHaveTextShape) return null;
 
   const fontAutoSize = getInputProps('fontAutoSize', e => e.target.checked);
+  const textWrapping = getInputProps('textWrapping', e => e.target.checked);
 
   return (
     <Container
@@ -122,6 +123,27 @@ export default withSdk<Props>(({ sdk, entities, initialOpen = true }) => {
           leftLabel="Spacing"
           type="number"
           {...getInputProps('lineSpacing')}
+        />
+      </Block>
+      <Block>
+        <CheckboxField
+          label="Text Wrapping"
+          {...textWrapping}
+          checked={!!textWrapping.value}
+        />
+      </Block>
+      <Block label="Size">
+        <TextField
+          autoSelect
+          leftLabel="W"
+          type="number"
+          {...getInputProps('width')}
+        />
+        <TextField
+          autoSelect
+          leftLabel="H"
+          type="number"
+          {...getInputProps('height')}
         />
       </Block>
       <Block>

--- a/packages/inspector/src/components/EntityInspector/TextShapeInspector/types.ts
+++ b/packages/inspector/src/components/EntityInspector/TextShapeInspector/types.ts
@@ -11,6 +11,8 @@ export type TextShapeInput = {
   fontSize: string;
   fontAutoSize: boolean;
   textAlign: string;
+  width: string;
+  height: string;
   paddingTop: string;
   paddingRight: string;
   paddingBottom: string;
@@ -18,6 +20,14 @@ export type TextShapeInput = {
   outlineWidth: string;
   lineSpacing: string;
   lineCount: string;
+  textWrapping: boolean;
+  shadowBlur: string;
+  shadowOffsetX: string;
+  shadowOffsetY: string;
+  shadowColor: string;
   outlineColor: string;
   textColor: string;
+  // hidden pass-through: the hex color picker is RGB-only, so the alpha channel
+  // of textColor is carried here and reapplied when converting back
+  textColorAlpha: string;
 };

--- a/packages/inspector/src/components/EntityInspector/TextShapeInspector/utils.spec.ts
+++ b/packages/inspector/src/components/EntityInspector/TextShapeInspector/utils.spec.ts
@@ -11,6 +11,8 @@ describe('fromTextShape', () => {
       fontSize: 16,
       fontAutoSize: true,
       textAlign: TextAlignMode.TAM_MIDDLE_CENTER,
+      width: 2,
+      height: 3,
       paddingTop: 10,
       paddingRight: 20,
       paddingBottom: 15,
@@ -18,6 +20,11 @@ describe('fromTextShape', () => {
       outlineWidth: 1,
       lineSpacing: 200,
       lineCount: 3,
+      textWrapping: true,
+      shadowBlur: 4,
+      shadowOffsetX: 5,
+      shadowOffsetY: -6,
+      shadowColor: { r: 0, g: 1, b: 0 },
       outlineColor: { r: 1, b: 0, g: 0 },
       textColor: { r: 1, b: 0, g: 0, a: 1 },
     };
@@ -30,6 +37,8 @@ describe('fromTextShape', () => {
       fontSize: '16',
       fontAutoSize: true,
       textAlign: TextAlignMode.TAM_MIDDLE_CENTER.toString(),
+      width: '2',
+      height: '3',
       paddingTop: '10',
       paddingRight: '20',
       paddingBottom: '15',
@@ -37,8 +46,42 @@ describe('fromTextShape', () => {
       outlineWidth: '5',
       lineSpacing: '2',
       lineCount: '3',
+      textWrapping: true,
+      shadowBlur: '4',
+      shadowOffsetX: '5',
+      shadowOffsetY: '-6',
+      shadowColor: '#00FF00',
       outlineColor: '#FF0000',
       textColor: '#FF0000',
+      textColorAlpha: '1',
+    });
+  });
+
+  describe('when the protocol-only fields are unset', () => {
+    it('should fill the input with the protocol defaults', () => {
+      const result = fromTextShape({ text: 'Hello' });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          width: '1',
+          height: '1',
+          textWrapping: false,
+          shadowBlur: '0',
+          shadowOffsetX: '0',
+          shadowOffsetY: '0',
+          shadowColor: '#FFFFFF',
+          textColorAlpha: '1',
+        }),
+      );
+    });
+  });
+
+  describe('when the text color has a non-opaque alpha', () => {
+    it('should carry the alpha through textColorAlpha since the hex value is RGB-only', () => {
+      const result = fromTextShape({ text: 'Hello', textColor: { r: 1, g: 0, b: 0, a: 0.5 } });
+
+      expect(result.textColor).toBe('#FF0000');
+      expect(result.textColorAlpha).toBe('0.5');
     });
   });
 });
@@ -51,6 +94,8 @@ describe('toTextShape', () => {
       fontSize: '16',
       fontAutoSize: true,
       textAlign: TextAlignMode.TAM_MIDDLE_CENTER.toString(),
+      width: '2',
+      height: '3',
       paddingTop: '10',
       paddingRight: '20',
       paddingBottom: '15',
@@ -58,8 +103,14 @@ describe('toTextShape', () => {
       outlineWidth: '5',
       lineSpacing: '2',
       lineCount: '3',
+      textWrapping: true,
+      shadowBlur: '4',
+      shadowOffsetX: '5',
+      shadowOffsetY: '-6',
+      shadowColor: '#00FF00',
       outlineColor: '#FF0000',
       textColor: '#FF0000',
+      textColorAlpha: '1',
     };
 
     const result: PBTextShape = toTextShape(textShapeInput);
@@ -70,6 +121,8 @@ describe('toTextShape', () => {
       fontSize: 16,
       fontAutoSize: true,
       textAlign: TextAlignMode.TAM_MIDDLE_CENTER,
+      width: 2,
+      height: 3,
       paddingTop: 10,
       paddingRight: 20,
       paddingBottom: 15,
@@ -77,9 +130,83 @@ describe('toTextShape', () => {
       outlineWidth: 1,
       lineSpacing: 200,
       lineCount: 3,
+      textWrapping: true,
+      shadowBlur: 4,
+      shadowOffsetX: 5,
+      shadowOffsetY: -6,
+      shadowColor: { r: 0, g: 1, b: 0 },
       outlineColor: { r: 1, b: 0, g: 0 },
       textColor: { r: 1, b: 0, g: 0, a: 1 },
     });
+  });
+
+  describe('when the carried textColorAlpha is not opaque', () => {
+    it('should reapply the carried alpha to the RGB hex color instead of forcing 1', () => {
+      const input = fromTextShape({ text: 'Hello', textColor: { r: 1, g: 0, b: 0, a: 0.25 } });
+
+      const result = toTextShape(input);
+
+      expect(result.textColor).toEqual({ r: 1, g: 0, b: 0, a: 0.25 });
+    });
+  });
+
+  describe('when the carried textColorAlpha is empty or invalid', () => {
+    it('should fall back to the alpha parsed from the hex color', () => {
+      const result = toTextShape({
+        ...fromTextShape({ text: 'Hello' }),
+        textColor: '#FF0000',
+        textColorAlpha: '',
+      });
+
+      expect(result.textColor).toEqual({ r: 1, g: 0, b: 0, a: 1 });
+    });
+  });
+
+  describe('when the hex color itself carries an alpha channel', () => {
+    it('should use the alpha from the 8-digit hex over the carried one', () => {
+      const result = toTextShape({
+        ...fromTextShape({ text: 'Hello' }),
+        textColor: '#FF000080',
+        textColorAlpha: '1',
+      });
+
+      expect(result.textColor?.r).toBe(1);
+      expect(result.textColor?.g).toBe(0);
+      expect(result.textColor?.b).toBe(0);
+      expect(result.textColor?.a).toBeCloseTo(0.5, 1);
+    });
+  });
+});
+
+describe('when round-tripping a fully-populated code-authored PBTextShape', () => {
+  it('should survive from -> to conversion unchanged, including color alphas', () => {
+    const pbTextShape: PBTextShape = {
+      text: 'Code authored',
+      font: Font.F_MONOSPACE,
+      fontSize: 24,
+      fontAutoSize: false,
+      textAlign: TextAlignMode.TAM_BOTTOM_RIGHT,
+      width: 2.5,
+      height: 4,
+      paddingTop: 1,
+      paddingRight: 2,
+      paddingBottom: 3,
+      paddingLeft: 4,
+      lineSpacing: 250,
+      lineCount: 7,
+      textWrapping: true,
+      shadowBlur: 1.5,
+      shadowOffsetX: 0.5,
+      shadowOffsetY: -0.5,
+      outlineWidth: 2,
+      shadowColor: { r: 0, g: 0, b: 1 },
+      outlineColor: { r: 1, g: 0, b: 0 },
+      textColor: { r: 1, g: 1, b: 0, a: 0.5 },
+    };
+
+    const result = toTextShape(fromTextShape(pbTextShape));
+
+    expect(result).toEqual(pbTextShape);
   });
 });
 

--- a/packages/inspector/src/components/EntityInspector/TextShapeInspector/utils.ts
+++ b/packages/inspector/src/components/EntityInspector/TextShapeInspector/utils.ts
@@ -11,6 +11,16 @@ const toNumber = (value: string, min?: number) => {
   return min ? Math.min(num, min) : num;
 };
 
+// the hex color picker is RGB-only, so the alpha channel is carried through the
+// input separately (see TextShapeInput.textColorAlpha) and reapplied here
+const toColor4WithAlpha = (hex: string, alpha: string): NonNullable<PBTextShape['textColor']> => {
+  const color = toColor4(hex);
+  // an 8-digit hex (#RRGGBBAA) already carries its own alpha
+  if (hex && hex.length > 7) return color;
+  const parsedAlpha = alpha === '' ? NaN : Number(alpha);
+  return { ...color, a: isNaN(parsedAlpha) ? color.a : parsedAlpha };
+};
+
 export const toBabylonGUIAlignment = (value: TextAlignMode): [number, number] => {
   switch (value) {
     case TextAlignMode.TAM_TOP_LEFT:
@@ -74,6 +84,8 @@ export const fromTextShape = (value: PBTextShape): TextShapeInput => {
     fontSize: toString(value.fontSize, 10),
     fontAutoSize: !!value.fontAutoSize,
     textAlign: toString(value.textAlign, TextAlignMode.TAM_MIDDLE_CENTER),
+    width: toString(value.width, 1),
+    height: toString(value.height, 1),
     paddingTop: toString(value.paddingTop, 0),
     paddingRight: toString(value.paddingRight, 0),
     paddingBottom: toString(value.paddingBottom, 0),
@@ -81,8 +93,14 @@ export const fromTextShape = (value: PBTextShape): TextShapeInput => {
     outlineWidth: toString((value.outlineWidth ?? 0) * 5),
     lineSpacing: toString((value.lineSpacing ?? 0) / 100, 0),
     lineCount: toString(value.lineCount, ''),
+    textWrapping: !!value.textWrapping,
+    shadowBlur: toString(value.shadowBlur, 0),
+    shadowOffsetX: toString(value.shadowOffsetX, 0),
+    shadowOffsetY: toString(value.shadowOffsetY, 0),
+    shadowColor: toHex(value.shadowColor),
     outlineColor: toHex(value.outlineColor),
     textColor: toHex(value.textColor),
+    textColorAlpha: toString(value.textColor?.a, 1),
   };
 };
 
@@ -93,14 +111,21 @@ export const toTextShape = (value: TextShapeInput): PBTextShape => {
     fontSize: toNumber(value.fontSize, 0),
     fontAutoSize: !!value.fontAutoSize,
     textAlign: value.textAlign ? toNumber(value.textAlign) : undefined,
+    width: toNumber(value.width, 0),
+    height: toNumber(value.height, 0),
     paddingTop: toNumber(value.paddingTop, 0),
     paddingRight: toNumber(value.paddingRight, 0),
     paddingBottom: toNumber(value.paddingBottom, 0),
     paddingLeft: toNumber(value.paddingLeft, 0),
     outlineWidth: toNumber(value.outlineWidth, 0) / 5,
     lineSpacing: toNumber(value.lineSpacing, 0) * 100,
+    textWrapping: !!value.textWrapping,
+    shadowBlur: toNumber(value.shadowBlur, 0),
+    shadowOffsetX: toNumber(value.shadowOffsetX, 0),
+    shadowOffsetY: toNumber(value.shadowOffsetY, 0),
+    shadowColor: toColor3(value.shadowColor),
     outlineColor: toColor3(value.outlineColor),
-    textColor: toColor4(value.textColor),
+    textColor: toColor4WithAlpha(value.textColor, value.textColorAlpha),
     lineCount: value.lineCount.length > 0 ? toNumber(value.lineCount, 0) : undefined,
   };
 };

--- a/packages/inspector/src/components/EntityInspector/TweenInspector/TweenInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/TweenInspector/TweenInspector.tsx
@@ -14,12 +14,20 @@ import { Block } from '../../Block';
 import { Container } from '../../Container';
 import { TextField, CheckboxField, InfoTooltip, Dropdown, RangeField } from '../../ui';
 import { fromTween, toTween, fromTweenSequence, toTweenSequence } from './utils';
-import { type Props } from './types';
+import { ContinuousTweenType, UNSUPPORTED_TWEEN_TYPE, type Props } from './types';
 
-const TweenMapOption: Record<string, string> = {
-  [TweenType.MOVE_ITEM]: 'Move Item',
-  [TweenType.ROTATE_ITEM]: 'Rotate Item',
-  [TweenType.SCALE_ITEM]: 'Scale Item',
+const TweenTypeOptions = [
+  { label: 'Move Item', value: TweenType.MOVE_ITEM },
+  { label: 'Rotate Item', value: TweenType.ROTATE_ITEM },
+  { label: 'Scale Item', value: TweenType.SCALE_ITEM },
+  { label: 'Move Continuous', value: ContinuousTweenType.MOVE_CONTINUOUS },
+  { label: 'Rotate Continuous', value: ContinuousTweenType.ROTATE_CONTINUOUS },
+];
+
+const UnsupportedModeLabels: Record<string, string> = {
+  textureMove: 'Texture Move',
+  textureMoveContinuous: 'Texture Move Continuous',
+  moveRotateScale: 'Move, Rotate & Scale',
 };
 
 const EasingFunctionOptions = [
@@ -85,7 +93,7 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
     const gltfContainer = getComponentValue(entity, GltfContainer);
     const asset = getAssetByModel(gltfContainer.src);
     analytics.track(Event.REMOVE_COMPONENT, {
-      componentName: CoreComponents.VIDEO_PLAYER,
+      componentName: CoreComponents.TWEEN,
       itemId: asset?.id,
       itemPath: gltfContainer.src,
     });
@@ -103,6 +111,22 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
 
   const playing = getTweenInputProps('playing', e => e.target.checked);
   const loop = getTweenSequenceInputProps('loop', e => e.target.checked);
+  const tweenType = getTweenInputProps('type').value;
+  const isContinuous =
+    tweenType === ContinuousTweenType.MOVE_CONTINUOUS ||
+    tweenType === ContinuousTweenType.ROTATE_CONTINUOUS;
+  const isUnsupported = tweenType === UNSUPPORTED_TWEEN_TYPE;
+  const unsupportedMode = getTweenInputProps('unsupportedMode').value?.toString() ?? '';
+  const tweenTypeOptions = isUnsupported
+    ? [
+        ...TweenTypeOptions,
+        {
+          label: `${UnsupportedModeLabels[unsupportedMode] ?? unsupportedMode} (not editable)`,
+          value: UNSUPPORTED_TWEEN_TYPE,
+          disabled: true,
+        },
+      ]
+    : TweenTypeOptions;
 
   return (
     <Container
@@ -123,74 +147,110 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
       <Block label="Tween Type">
         <Dropdown
           placeholder="Select a Tween Type"
-          options={[
-            ...Object.values(TweenType).map(tweenType => ({
-              label: TweenMapOption[tweenType],
-              value: tweenType,
-            })),
-          ]}
+          options={tweenTypeOptions}
           {...getTweenInputProps('type')}
         />
       </Block>
-      <Block label="Start">
-        <TextField
-          autoSelect
-          leftLabel="X"
-          type="number"
-          {...getTweenInputProps('start.x')}
-        />
-        <TextField
-          autoSelect
-          leftLabel="Y"
-          type="number"
-          {...getTweenInputProps('start.y')}
-        />
-        <TextField
-          autoSelect
-          leftLabel="Z"
-          type="number"
-          {...getTweenInputProps('start.z')}
-        />
-      </Block>
-      <Block label="End">
-        <TextField
-          autoSelect
-          leftLabel="X"
-          type="number"
-          {...getTweenInputProps('end.x')}
-        />
-        <TextField
-          autoSelect
-          leftLabel="Y"
-          type="number"
-          {...getTweenInputProps('end.y')}
-        />
-        <TextField
-          autoSelect
-          leftLabel="Z"
-          type="number"
-          {...getTweenInputProps('end.z')}
-        />
-      </Block>
-      <Block>
-        <RangeField
-          step={0.1}
-          label="Duration"
-          {...getTweenInputProps('duration')}
-        />
-      </Block>
-      <Block>
-        <Dropdown
-          label="Easing Function"
-          options={[
-            ...EasingFunctionOptions.map(easingFunctionType => ({
-              label: EasingFunctionMapOption[easingFunctionType],
-              value: easingFunctionType,
-            })),
-          ]}
-          {...getTweenInputProps('easingFunction')}
-        />
-      </Block>
+      {!isContinuous && !isUnsupported && (
+        <>
+          <Block label="Start">
+            <TextField
+              autoSelect
+              leftLabel="X"
+              type="number"
+              {...getTweenInputProps('start.x')}
+            />
+            <TextField
+              autoSelect
+              leftLabel="Y"
+              type="number"
+              {...getTweenInputProps('start.y')}
+            />
+            <TextField
+              autoSelect
+              leftLabel="Z"
+              type="number"
+              {...getTweenInputProps('start.z')}
+            />
+          </Block>
+          <Block label="End">
+            <TextField
+              autoSelect
+              leftLabel="X"
+              type="number"
+              {...getTweenInputProps('end.x')}
+            />
+            <TextField
+              autoSelect
+              leftLabel="Y"
+              type="number"
+              {...getTweenInputProps('end.y')}
+            />
+            <TextField
+              autoSelect
+              leftLabel="Z"
+              type="number"
+              {...getTweenInputProps('end.z')}
+            />
+          </Block>
+          <Block>
+            <RangeField
+              step={0.1}
+              label="Duration"
+              {...getTweenInputProps('duration')}
+            />
+          </Block>
+          <Block>
+            <Dropdown
+              label="Easing Function"
+              options={[
+                ...EasingFunctionOptions.map(easingFunctionType => ({
+                  label: EasingFunctionMapOption[easingFunctionType],
+                  value: easingFunctionType,
+                })),
+              ]}
+              {...getTweenInputProps('easingFunction')}
+            />
+          </Block>
+        </>
+      )}
+      {isContinuous && (
+        <>
+          <Block
+            label={
+              tweenType === ContinuousTweenType.ROTATE_CONTINUOUS
+                ? 'Direction (degrees/sec)'
+                : 'Direction (meters/sec)'
+            }
+          >
+            <TextField
+              autoSelect
+              leftLabel="X"
+              type="number"
+              {...getTweenInputProps('direction.x')}
+            />
+            <TextField
+              autoSelect
+              leftLabel="Y"
+              type="number"
+              {...getTweenInputProps('direction.y')}
+            />
+            <TextField
+              autoSelect
+              leftLabel="Z"
+              type="number"
+              {...getTweenInputProps('direction.z')}
+            />
+          </Block>
+          <Block label="Speed">
+            <TextField
+              autoSelect
+              type="number"
+              {...getTweenInputProps('speed')}
+            />
+          </Block>
+        </>
+      )}
       <Block>
         <CheckboxField
           label="Auto start"

--- a/packages/inspector/src/components/EntityInspector/TweenInspector/types.ts
+++ b/packages/inspector/src/components/EntityInspector/TweenInspector/types.ts
@@ -6,8 +6,17 @@ export interface Props {
   initialOpen?: boolean;
 }
 
+export enum ContinuousTweenType {
+  MOVE_CONTINUOUS = 'move_continuous',
+  ROTATE_CONTINUOUS = 'rotate_continuous',
+}
+
+export const UNSUPPORTED_TWEEN_TYPE = 'unsupported';
+
+export type TweenModeType = TweenType | ContinuousTweenType | typeof UNSUPPORTED_TWEEN_TYPE;
+
 export type TweenInput = {
-  type: TweenType;
+  type: TweenModeType;
   start: {
     x: string;
     y: string;
@@ -18,6 +27,13 @@ export type TweenInput = {
     y: string;
     z: string;
   };
+  direction: {
+    x: string;
+    y: string;
+    z: string;
+  };
+  speed: string;
+  unsupportedMode: string;
   easingFunction: string;
   duration: string;
   playing?: boolean;

--- a/packages/inspector/src/components/EntityInspector/TweenInspector/utils.spec.ts
+++ b/packages/inspector/src/components/EntityInspector/TweenInspector/utils.spec.ts
@@ -1,0 +1,225 @@
+import type { PBTween } from '@dcl/ecs';
+import { EasingFunction } from '@dcl/ecs';
+import { TweenType } from '@dcl/asset-packs';
+
+import { fromTween, toTween } from './utils';
+import type { TweenInput } from './types';
+import { ContinuousTweenType, UNSUPPORTED_TWEEN_TYPE } from './types';
+
+const baseInput: TweenInput = {
+  type: TweenType.MOVE_ITEM,
+  start: { x: '0.00', y: '0.00', z: '0.00' },
+  end: { x: '0.00', y: '0.00', z: '0.00' },
+  direction: { x: '0.00', y: '0.00', z: '0.00' },
+  speed: '1.00',
+  unsupportedMode: '',
+  duration: '1',
+  easingFunction: '0',
+  playing: true,
+};
+
+describe('TweenInspector utils', () => {
+  describe('when converting a move tween from component to input', () => {
+    let value: PBTween;
+
+    beforeEach(() => {
+      value = {
+        mode: {
+          $case: 'move',
+          move: { start: { x: 1, y: 2, z: 3 }, end: { x: 4, y: 5, z: 6 } },
+        },
+        duration: 2000,
+        easingFunction: EasingFunction.EF_LINEAR,
+        playing: true,
+      };
+    });
+
+    it('should map the mode to the move item type with formatted vectors', () => {
+      const input = fromTween(value);
+      expect(input.type).toBe(TweenType.MOVE_ITEM);
+      expect(input.start).toEqual({ x: '1.00', y: '2.00', z: '3.00' });
+      expect(input.end).toEqual({ x: '4.00', y: '5.00', z: '6.00' });
+      expect(input.duration).toBe('2');
+    });
+  });
+
+  describe('when converting a move continuous tween from component to input', () => {
+    let value: PBTween;
+
+    beforeEach(() => {
+      value = {
+        mode: {
+          $case: 'moveContinuous',
+          moveContinuous: { direction: { x: 1, y: 0, z: -2.5 }, speed: 3 },
+        },
+        duration: 0,
+        easingFunction: EasingFunction.EF_LINEAR,
+        playing: true,
+      };
+    });
+
+    it('should map the mode to the move continuous type with formatted direction and speed', () => {
+      const input = fromTween(value);
+      expect(input.type).toBe(ContinuousTweenType.MOVE_CONTINUOUS);
+      expect(input.direction).toEqual({ x: '1.00', y: '0.00', z: '-2.50' });
+      expect(input.speed).toBe('3.00');
+    });
+  });
+
+  describe('when converting a rotate continuous tween from component to input', () => {
+    let value: PBTween;
+
+    beforeEach(() => {
+      value = {
+        mode: {
+          $case: 'rotateContinuous',
+          rotateContinuous: {
+            direction: { x: 0, y: Math.sin(Math.PI / 4), z: 0, w: Math.cos(Math.PI / 4) },
+            speed: 2,
+          },
+        },
+        duration: 0,
+        easingFunction: EasingFunction.EF_LINEAR,
+        playing: true,
+      };
+    });
+
+    it('should map the direction quaternion to euler degrees and keep the speed', () => {
+      const input = fromTween(value);
+      expect(input.type).toBe(ContinuousTweenType.ROTATE_CONTINUOUS);
+      expect(input.direction).toEqual({ x: '0.00', y: '90.00', z: '0.00' });
+      expect(input.speed).toBe('2.00');
+    });
+  });
+
+  describe('when converting an unsupported tween mode from component to input', () => {
+    let value: PBTween;
+
+    beforeEach(() => {
+      value = {
+        mode: {
+          $case: 'textureMove',
+          textureMove: { start: { x: 0, y: 0 }, end: { x: 1, y: 1 } },
+        },
+        duration: 1000,
+        easingFunction: EasingFunction.EF_LINEAR,
+        playing: true,
+      };
+    });
+
+    it('should mark the input as unsupported and remember the mode case', () => {
+      const input = fromTween(value);
+      expect(input.type).toBe(UNSUPPORTED_TWEEN_TYPE);
+      expect(input.unsupportedMode).toBe('textureMove');
+    });
+  });
+
+  describe('when converting a move continuous input to a component value', () => {
+    let input: TweenInput;
+
+    beforeEach(() => {
+      input = {
+        ...baseInput,
+        type: ContinuousTweenType.MOVE_CONTINUOUS,
+        direction: { x: '1', y: '0', z: '-2.5' },
+        speed: '3',
+      };
+    });
+
+    it('should build a moveContinuous mode with numeric direction and speed', () => {
+      const tween = toTween(input);
+      expect(tween.mode).toEqual({
+        $case: 'moveContinuous',
+        moveContinuous: { direction: { x: 1, y: 0, z: -2.5 }, speed: 3 },
+      });
+    });
+  });
+
+  describe('when converting a rotate continuous input to a component value', () => {
+    let input: TweenInput;
+
+    beforeEach(() => {
+      input = {
+        ...baseInput,
+        type: ContinuousTweenType.ROTATE_CONTINUOUS,
+        direction: { x: '0', y: '90', z: '0' },
+        speed: '2',
+      };
+    });
+
+    it('should build a rotateContinuous mode with a quaternion direction and the speed', () => {
+      const tween = toTween(input);
+      expect(tween.mode?.$case).toBe('rotateContinuous');
+      if (tween.mode?.$case !== 'rotateContinuous') throw new Error('wrong mode');
+      const { direction, speed } = tween.mode.rotateContinuous;
+      expect(direction?.x).toBeCloseTo(0);
+      expect(direction?.y).toBeCloseTo(Math.sin(Math.PI / 4));
+      expect(direction?.z).toBeCloseTo(0);
+      expect(direction?.w).toBeCloseTo(Math.cos(Math.PI / 4));
+      expect(speed).toBe(2);
+    });
+
+    it('should round-trip the euler degrees through the quaternion', () => {
+      const tween = toTween(input);
+      const roundTripped = fromTween({ ...tween, duration: 0 });
+      expect(roundTripped.direction).toEqual({ x: '0.00', y: '90.00', z: '0.00' });
+    });
+  });
+
+  describe('when converting an unsupported input to a component value', () => {
+    let input: TweenInput;
+
+    beforeEach(() => {
+      input = {
+        ...baseInput,
+        type: UNSUPPORTED_TWEEN_TYPE,
+        unsupportedMode: 'textureMove',
+        duration: '2',
+        easingFunction: '1',
+      };
+    });
+
+    it('should omit the mode key so merging preserves the existing mode', () => {
+      const tween = toTween(input);
+      expect('mode' in tween).toBe(false);
+      expect(tween.duration).toBe(2000);
+      expect(tween.easingFunction).toBe(1);
+    });
+
+    it('should preserve the unsupported mode when spread over the current component value', () => {
+      const current: PBTween = {
+        mode: {
+          $case: 'textureMove',
+          textureMove: { start: { x: 0, y: 0 }, end: { x: 1, y: 1 } },
+        },
+        duration: 1000,
+        easingFunction: EasingFunction.EF_LINEAR,
+        playing: true,
+      };
+      const merged = { ...current, ...toTween(input) };
+      expect(merged.mode).toEqual(current.mode);
+      expect(merged.duration).toBe(2000);
+    });
+  });
+
+  describe('when converting a rotate input to a component value', () => {
+    let input: TweenInput;
+
+    beforeEach(() => {
+      input = {
+        ...baseInput,
+        type: TweenType.ROTATE_ITEM,
+        start: { x: '0', y: '0', z: '0' },
+        end: { x: '0', y: '180', z: '0' },
+      };
+    });
+
+    it('should still build a rotate mode with quaternion start and end', () => {
+      const tween = toTween(input);
+      expect(tween.mode?.$case).toBe('rotate');
+      if (tween.mode?.$case !== 'rotate') throw new Error('wrong mode');
+      expect(tween.mode.rotate.end?.y).toBeCloseTo(1);
+      expect(tween.mode.rotate.end?.w).toBeCloseTo(0);
+    });
+  });
+});

--- a/packages/inspector/src/components/EntityInspector/TweenInspector/utils.ts
+++ b/packages/inspector/src/components/EntityInspector/TweenInspector/utils.ts
@@ -1,13 +1,19 @@
 import { Quaternion } from '@babylonjs/core';
-import type { Move, PBTween, PBTweenSequence, Rotate, Scale } from '@dcl/ecs';
+import type { PBTween, PBTweenSequence } from '@dcl/ecs';
 import { TweenType } from '@dcl/asset-packs';
 
-import type { TweenInput, TweenSequenceInput } from './types';
+import type { TweenInput, TweenModeType, TweenSequenceInput } from './types';
+import { ContinuousTweenType, UNSUPPORTED_TWEEN_TYPE } from './types';
+
+const zeroVector = () => ({ x: '0.00', y: '0.00', z: '0.00' });
 
 export const fromTween = (value: PBTween): TweenInput => {
-  let type = TweenType.MOVE_ITEM;
-  let start = { x: '0.00', y: '0.00', z: '0.00' };
-  let end = { x: '0.00', y: '0.00', z: '0.00' };
+  let type: TweenModeType = TweenType.MOVE_ITEM;
+  let start = zeroVector();
+  let end = zeroVector();
+  let direction = zeroVector();
+  let speed = '1.00';
+  let unsupportedMode = '';
 
   if (value.mode?.$case === 'move') {
     type = TweenType.MOVE_ITEM;
@@ -23,28 +29,8 @@ export const fromTween = (value: PBTween): TweenInput => {
     };
   } else if (value.mode?.$case === 'rotate') {
     type = TweenType.ROTATE_ITEM;
-    const startAngles = new Quaternion(
-      value.mode.rotate.start?.x ?? 0,
-      value.mode.rotate.start?.y ?? 0,
-      value.mode.rotate.start?.z ?? 0,
-      value.mode.rotate.start?.w ?? 0,
-    ).toEulerAngles();
-    start = {
-      x: formatAngle((startAngles.x * 180) / Math.PI),
-      y: formatAngle((startAngles.y * 180) / Math.PI),
-      z: formatAngle((startAngles.z * 180) / Math.PI),
-    };
-    const endAngles = new Quaternion(
-      value.mode.rotate.end?.x ?? 0,
-      value.mode.rotate.end?.y ?? 0,
-      value.mode.rotate.end?.z ?? 0,
-      value.mode.rotate.end?.w ?? 0,
-    ).toEulerAngles();
-    end = {
-      x: formatAngle((endAngles.x * 180) / Math.PI),
-      y: formatAngle((endAngles.y * 180) / Math.PI),
-      z: formatAngle((endAngles.z * 180) / Math.PI),
-    };
+    start = quaternionToAngles(value.mode.rotate.start);
+    end = quaternionToAngles(value.mode.rotate.end);
   } else if (value.mode?.$case === 'scale') {
     type = TweenType.SCALE_ITEM;
     start = {
@@ -57,12 +43,31 @@ export const fromTween = (value: PBTween): TweenInput => {
       y: value.mode.scale.end?.y.toFixed(2) ?? '0.00',
       z: value.mode.scale.end?.z.toFixed(2) ?? '0.00',
     };
+  } else if (value.mode?.$case === 'moveContinuous') {
+    type = ContinuousTweenType.MOVE_CONTINUOUS;
+    direction = {
+      x: value.mode.moveContinuous.direction?.x.toFixed(2) ?? '0.00',
+      y: value.mode.moveContinuous.direction?.y.toFixed(2) ?? '0.00',
+      z: value.mode.moveContinuous.direction?.z.toFixed(2) ?? '0.00',
+    };
+    speed = value.mode.moveContinuous.speed.toFixed(2);
+  } else if (value.mode?.$case === 'rotateContinuous') {
+    type = ContinuousTweenType.ROTATE_CONTINUOUS;
+    direction = quaternionToAngles(value.mode.rotateContinuous.direction);
+    speed = value.mode.rotateContinuous.speed.toFixed(2);
+  } else if (value.mode) {
+    // modes the editor can't edit yet (textureMove, textureMoveContinuous, moveRotateScale, ...)
+    type = UNSUPPORTED_TWEEN_TYPE;
+    unsupportedMode = value.mode.$case;
   }
 
   return {
     type,
     start,
     end,
+    direction,
+    speed,
+    unsupportedMode,
     duration: (value.duration / 1000).toString(),
     easingFunction: value.easingFunction.toString(),
     playing: value.playing,
@@ -70,11 +75,19 @@ export const fromTween = (value: PBTween): TweenInput => {
 };
 
 export const toTween = (value: TweenInput): PBTween => {
-  let mode:
-    | { $case: 'move'; move: Move }
-    | { $case: 'rotate'; rotate: Rotate }
-    | { $case: 'scale'; scale: Scale }
-    | undefined;
+  const base = {
+    duration: parseFloat(value.duration) * 1000,
+    easingFunction: parseInt(value.easingFunction),
+    playing: value.playing,
+  };
+
+  if (value.type === UNSUPPORTED_TWEEN_TYPE) {
+    // omit the "mode" key entirely so merging with the current component value
+    // preserves the unsupported mode instead of destroying it
+    return base;
+  }
+
+  let mode: PBTween['mode'];
 
   if (value.type === TweenType.MOVE_ITEM) {
     mode = {
@@ -93,22 +106,11 @@ export const toTween = (value: TweenInput): PBTween => {
       },
     };
   } else if (value.type === TweenType.ROTATE_ITEM) {
-    const start = Quaternion.RotationYawPitchRoll(
-      (Number(value.start.y) * Math.PI) / 180,
-      (Number(value.start.x) * Math.PI) / 180,
-      (Number(value.start.z) * Math.PI) / 180,
-    );
-    const end = Quaternion.RotationYawPitchRoll(
-      (Number(value.end.y) * Math.PI) / 180,
-      (Number(value.end.x) * Math.PI) / 180,
-      (Number(value.end.z) * Math.PI) / 180,
-    );
-
     mode = {
       $case: 'rotate',
       rotate: {
-        start: { x: start.x, y: start.y, z: start.z, w: start.w },
-        end: { x: end.x, y: end.y, z: end.z, w: end.w },
+        start: anglesToQuaternion(value.start),
+        end: anglesToQuaternion(value.end),
       },
     };
   } else if (value.type === TweenType.SCALE_ITEM) {
@@ -127,15 +129,56 @@ export const toTween = (value: TweenInput): PBTween => {
         },
       },
     };
+  } else if (value.type === ContinuousTweenType.MOVE_CONTINUOUS) {
+    mode = {
+      $case: 'moveContinuous',
+      moveContinuous: {
+        direction: {
+          x: Number(value.direction.x),
+          y: Number(value.direction.y),
+          z: Number(value.direction.z),
+        },
+        speed: Number(value.speed),
+      },
+    };
+  } else if (value.type === ContinuousTweenType.ROTATE_CONTINUOUS) {
+    mode = {
+      $case: 'rotateContinuous',
+      rotateContinuous: {
+        direction: anglesToQuaternion(value.direction),
+        speed: Number(value.speed),
+      },
+    };
   }
 
   return {
+    ...base,
     mode,
-    duration: parseFloat(value.duration) * 1000,
-    easingFunction: parseInt(value.easingFunction),
-    playing: value.playing,
   };
 };
+
+function quaternionToAngles(quaternion?: { x: number; y: number; z: number; w: number }) {
+  const angles = new Quaternion(
+    quaternion?.x ?? 0,
+    quaternion?.y ?? 0,
+    quaternion?.z ?? 0,
+    quaternion?.w ?? 0,
+  ).toEulerAngles();
+  return {
+    x: formatAngle((angles.x * 180) / Math.PI),
+    y: formatAngle((angles.y * 180) / Math.PI),
+    z: formatAngle((angles.z * 180) / Math.PI),
+  };
+}
+
+function anglesToQuaternion(angles: { x: string; y: string; z: string }) {
+  const quaternion = Quaternion.RotationYawPitchRoll(
+    (Number(angles.y) * Math.PI) / 180,
+    (Number(angles.x) * Math.PI) / 180,
+    (Number(angles.z) * Math.PI) / 180,
+  );
+  return { x: quaternion.x, y: quaternion.y, z: quaternion.z, w: quaternion.w };
+}
 
 function formatAngle(angle: number) {
   const sanitizedAngle = angle < 0 ? 360 + angle : angle;

--- a/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/VideoPlayerInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/VideoPlayerInspector.tsx
@@ -16,7 +16,15 @@ import { selectAssetCatalog } from '../../../redux/app';
 import { Block } from '../../Block';
 import { Container } from '../../Container';
 import { TextField, CheckboxField, RangeField, InfoTooltip } from '../../ui';
-import { fromVideoPlayer, toVideoPlayer, isVideo, isValidVolume } from './utils';
+import {
+  fromVideoPlayer,
+  toVideoPlayer,
+  isVideo,
+  isValidVolume,
+  isValidPlaybackRate,
+  isValidPosition,
+  isValidSpatialDistance,
+} from './utils';
 import type { Props } from './types';
 
 import './VideoPlayerInspector.css';
@@ -80,6 +88,11 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
   const loop = getInputProps('loop', e => e.target.checked);
   const volume = getInputProps('volume', e => e.target.value);
   const src = getInputProps('src');
+  const position = getInputProps('position');
+  const playbackRate = getInputProps('playbackRate');
+  const spatial = getInputProps('spatial', e => e.target.checked);
+  const spatialMinDistance = getInputProps('spatialMinDistance');
+  const spatialMaxDistance = getInputProps('spatialMaxDistance');
 
   const isVideoURLDisabled = useMemo(() => {
     return src?.value === LIVEKIT_STREAM_SRC;
@@ -128,6 +141,24 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           {...loop}
         />
       </Block>
+      <Block label="Playback Rate">
+        <TextField
+          autoSelect
+          type="number"
+          placeholder="1"
+          {...playbackRate}
+          error={!isValidPlaybackRate(playbackRate.value as string)}
+        />
+      </Block>
+      <Block label="Start Position (seconds)">
+        <TextField
+          autoSelect
+          type="number"
+          placeholder="0"
+          {...position}
+          error={!isValidPosition(position.value as string)}
+        />
+      </Block>
       <Block
         className="volume"
         label="Volume"
@@ -135,6 +166,31 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
         <RangeField
           {...volume}
           isValidValue={isValidVolume}
+        />
+      </Block>
+      <Block label="Spatial Audio">
+        <CheckboxField
+          label="Spatial"
+          checked={!!spatial.value}
+          {...spatial}
+        />
+      </Block>
+      <Block label="Spatial Distance">
+        <TextField
+          leftLabel="Min"
+          autoSelect
+          type="number"
+          placeholder="0"
+          {...spatialMinDistance}
+          error={!isValidSpatialDistance(spatialMinDistance.value as string)}
+        />
+        <TextField
+          leftLabel="Max"
+          autoSelect
+          type="number"
+          placeholder="60"
+          {...spatialMaxDistance}
+          error={!isValidSpatialDistance(spatialMaxDistance.value as string)}
         />
       </Block>
     </Container>

--- a/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/VideoPlayerInspector.tsx
+++ b/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/VideoPlayerInspector.tsx
@@ -170,14 +170,30 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
       </Block>
       <Block label="Spatial Audio">
         <CheckboxField
-          label="Spatial"
+          label={
+            <>
+              Spatial{' '}
+              <InfoTooltip
+                text="Makes the video's audio positional: the volume fades as the player moves away from this entity. When off, the audio plays at the same volume everywhere in the scene."
+                type="help"
+              />
+            </>
+          }
           checked={!!spatial.value}
           {...spatial}
         />
       </Block>
       <Block label="Spatial Distance">
         <TextField
-          leftLabel="Min"
+          leftLabel={
+            <>
+              Min{' '}
+              <InfoTooltip
+                text="Distance in meters from the entity within which the audio plays at full volume. Beyond it, the volume starts to fade."
+                type="help"
+              />
+            </>
+          }
           autoSelect
           type="number"
           placeholder="0"
@@ -185,7 +201,15 @@ export default withSdk<Props>(({ sdk, entity, initialOpen = true }) => {
           error={!isValidSpatialDistance(spatialMinDistance.value as string)}
         />
         <TextField
-          leftLabel="Max"
+          leftLabel={
+            <>
+              Max{' '}
+              <InfoTooltip
+                text="Distance in meters from the entity at which the audio becomes inaudible."
+                type="help"
+              />
+            </>
+          }
           autoSelect
           type="number"
           placeholder="60"

--- a/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/types.ts
+++ b/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/types.ts
@@ -10,5 +10,9 @@ export type VideoPlayerInput = {
   playing?: boolean;
   loop?: boolean;
   volume?: string;
+  position?: string;
   playbackRate?: string;
+  spatial?: boolean;
+  spatialMinDistance?: string;
+  spatialMaxDistance?: string;
 };

--- a/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/utils.spec.ts
+++ b/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/utils.spec.ts
@@ -1,13 +1,20 @@
+import type { PBVideoPlayer } from '@dcl/ecs';
+
 import type { TreeNode } from '../../ProjectAssetExplorer/ProjectView';
 import {
   fromVideoPlayer,
   toVideoPlayer,
   volumeFromVideoPlayer,
   volumeToVideoPlayer,
+  numberFromVideoPlayer,
+  numberToVideoPlayer,
   isValidInput,
   isVideoFile,
   isVideo,
   isValidVolume,
+  isValidPlaybackRate,
+  isValidPosition,
+  isValidSpatialDistance,
 } from './utils';
 
 describe('VideoPlayerUtils', () => {
@@ -31,6 +38,34 @@ describe('VideoPlayerUtils', () => {
         volume: '50',
       });
     });
+
+    describe('when the video player has every protocol field set', () => {
+      it('should convert all fields to their input representation', () => {
+        const videoPlayer: PBVideoPlayer = {
+          src: '/base/path/video.mp4',
+          loop: true,
+          playing: false,
+          volume: 0.5,
+          position: 12.5,
+          playbackRate: 1.25,
+          spatial: true,
+          spatialMinDistance: 4,
+          spatialMaxDistance: 42,
+        };
+        const result = fromVideoPlayer(videoPlayer);
+        expect(result).toEqual({
+          src: '/base/path/video.mp4',
+          loop: true,
+          playing: false,
+          volume: '50',
+          position: '12.5',
+          playbackRate: '1.25',
+          spatial: true,
+          spatialMinDistance: '4',
+          spatialMaxDistance: '42',
+        });
+      });
+    });
   });
 
   describe('toVideoPlayer', () => {
@@ -42,6 +77,120 @@ describe('VideoPlayerUtils', () => {
         loop: true,
         playing: false,
         volume: 0.5,
+      });
+    });
+
+    describe('when the input has every field set', () => {
+      it('should convert all fields to their protocol representation', () => {
+        const videoPlayerInput = {
+          src: 'video.mp4',
+          loop: true,
+          playing: false,
+          volume: '50',
+          position: '12.5',
+          playbackRate: '1.25',
+          spatial: true,
+          spatialMinDistance: '4',
+          spatialMaxDistance: '42',
+        };
+        const result = toVideoPlayer(videoPlayerInput);
+        expect(result).toEqual({
+          src: 'video.mp4',
+          loop: true,
+          playing: false,
+          volume: 0.5,
+          position: 12.5,
+          playbackRate: 1.25,
+          spatial: true,
+          spatialMinDistance: 4,
+          spatialMaxDistance: 42,
+        });
+      });
+    });
+
+    describe('when the numeric input fields are empty', () => {
+      it('should leave the corresponding protocol fields unset', () => {
+        const result = toVideoPlayer({
+          src: 'video.mp4',
+          position: '',
+          playbackRate: '',
+          spatialMinDistance: '',
+          spatialMaxDistance: '',
+        });
+        expect(result.position).toBeUndefined();
+        expect(result.playbackRate).toBeUndefined();
+        expect(result.spatialMinDistance).toBeUndefined();
+        expect(result.spatialMaxDistance).toBeUndefined();
+      });
+    });
+  });
+
+  describe('when a PBVideoPlayer with code-authored values goes through a fromVideoPlayer → toVideoPlayer round trip', () => {
+    it('should preserve every protocol field unchanged', () => {
+      const videoPlayer: PBVideoPlayer = {
+        src: 'https://example.com/stream.mp4',
+        playing: true,
+        position: 30,
+        volume: 0.75,
+        playbackRate: 0.5,
+        loop: false,
+        spatial: true,
+        spatialMinDistance: 2,
+        spatialMaxDistance: 100,
+      };
+      expect(toVideoPlayer(fromVideoPlayer(videoPlayer))).toEqual(videoPlayer);
+    });
+
+    describe('and the optional fields are unset', () => {
+      it('should keep them unset instead of materializing defaults', () => {
+        const videoPlayer: PBVideoPlayer = { src: 'video.mp4' };
+        const result = toVideoPlayer(fromVideoPlayer(videoPlayer));
+        expect(result.position).toBeUndefined();
+        expect(result.playbackRate).toBeUndefined();
+        expect(result.spatial).toBeUndefined();
+        expect(result.spatialMinDistance).toBeUndefined();
+        expect(result.spatialMaxDistance).toBeUndefined();
+      });
+    });
+  });
+
+  describe('numberFromVideoPlayer', () => {
+    describe('when the value is a number', () => {
+      it('should convert it to its string representation', () => {
+        expect(numberFromVideoPlayer(1.25)).toBe('1.25');
+      });
+    });
+
+    describe('when the value is zero', () => {
+      it('should convert it to "0" instead of dropping it', () => {
+        expect(numberFromVideoPlayer(0)).toBe('0');
+      });
+    });
+
+    describe('when the value is undefined', () => {
+      it('should return undefined', () => {
+        expect(numberFromVideoPlayer(undefined)).toBeUndefined();
+      });
+    });
+  });
+
+  describe('numberToVideoPlayer', () => {
+    describe('when the value is a numeric string', () => {
+      it('should parse it as a number', () => {
+        expect(numberToVideoPlayer('12.5')).toBe(12.5);
+      });
+    });
+
+    describe('when the value is empty or undefined', () => {
+      it('should return undefined', () => {
+        expect(numberToVideoPlayer('')).toBeUndefined();
+        expect(numberToVideoPlayer(undefined)).toBeUndefined();
+      });
+    });
+
+    describe('when the value is not parseable as a number', () => {
+      it('should return undefined', () => {
+        expect(numberToVideoPlayer('invalid')).toBeUndefined();
       });
     });
   });
@@ -107,6 +256,76 @@ describe('VideoPlayerUtils', () => {
     it('returns false for an invalid volume', () => {
       const result = isValidVolume('invalid');
       expect(result).toBe(false);
+    });
+  });
+
+  describe('isValidPlaybackRate', () => {
+    describe('when the rate is a positive number', () => {
+      it('should return true', () => {
+        expect(isValidPlaybackRate('0.5')).toBe(true);
+        expect(isValidPlaybackRate('2')).toBe(true);
+      });
+    });
+
+    describe('when the rate is empty', () => {
+      it('should return true since empty means unset', () => {
+        expect(isValidPlaybackRate('')).toBe(true);
+        expect(isValidPlaybackRate(undefined)).toBe(true);
+      });
+    });
+
+    describe('when the rate is zero, negative or not a number', () => {
+      it('should return false', () => {
+        expect(isValidPlaybackRate('0')).toBe(false);
+        expect(isValidPlaybackRate('-1')).toBe(false);
+        expect(isValidPlaybackRate('invalid')).toBe(false);
+      });
+    });
+  });
+
+  describe('isValidPosition', () => {
+    describe('when the position is zero or a positive number', () => {
+      it('should return true', () => {
+        expect(isValidPosition('0')).toBe(true);
+        expect(isValidPosition('12.5')).toBe(true);
+      });
+    });
+
+    describe('when the position is empty', () => {
+      it('should return true since empty means unset', () => {
+        expect(isValidPosition('')).toBe(true);
+        expect(isValidPosition(undefined)).toBe(true);
+      });
+    });
+
+    describe('when the position is negative or not a number', () => {
+      it('should return false', () => {
+        expect(isValidPosition('-1')).toBe(false);
+        expect(isValidPosition('invalid')).toBe(false);
+      });
+    });
+  });
+
+  describe('isValidSpatialDistance', () => {
+    describe('when the distance is zero or a positive number', () => {
+      it('should return true', () => {
+        expect(isValidSpatialDistance('0')).toBe(true);
+        expect(isValidSpatialDistance('60')).toBe(true);
+      });
+    });
+
+    describe('when the distance is empty', () => {
+      it('should return true since empty means unset', () => {
+        expect(isValidSpatialDistance('')).toBe(true);
+        expect(isValidSpatialDistance(undefined)).toBe(true);
+      });
+    });
+
+    describe('when the distance is negative or not a number', () => {
+      it('should return false', () => {
+        expect(isValidSpatialDistance('-5')).toBe(false);
+        expect(isValidSpatialDistance('invalid')).toBe(false);
+      });
     });
   });
 });

--- a/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/utils.ts
+++ b/packages/inspector/src/components/EntityInspector/VideoPlayerInspector/utils.ts
@@ -13,6 +13,11 @@ export const fromVideoPlayer = (value: PBVideoPlayer): VideoPlayerInput => {
     loop: value.loop,
     playing: value.playing,
     volume: volumeFromVideoPlayer(value.volume),
+    position: numberFromVideoPlayer(value.position),
+    playbackRate: numberFromVideoPlayer(value.playbackRate),
+    spatial: value.spatial,
+    spatialMinDistance: numberFromVideoPlayer(value.spatialMinDistance),
+    spatialMaxDistance: numberFromVideoPlayer(value.spatialMaxDistance),
   };
 };
 
@@ -22,8 +27,25 @@ export const toVideoPlayer = (value: VideoPlayerInput): PBVideoPlayer => {
     loop: value.loop,
     playing: value.playing,
     volume: volumeToVideoPlayer(value.volume),
+    position: numberToVideoPlayer(value.position),
+    playbackRate: numberToVideoPlayer(value.playbackRate),
+    spatial: value.spatial,
+    spatialMinDistance: numberToVideoPlayer(value.spatialMinDistance),
+    spatialMaxDistance: numberToVideoPlayer(value.spatialMaxDistance),
   };
 };
+
+// PBVideoPlayer numeric fields are proto3 `optional`: unset and 0 are distinct on the wire,
+// so an unset field must stay unset through the input round trip (empty string ⇔ undefined).
+export function numberFromVideoPlayer(value: number | undefined): string | undefined {
+  return value === undefined ? undefined : value.toString();
+}
+
+export function numberToVideoPlayer(value: string | undefined): number | undefined {
+  if (value === undefined || value === '') return undefined;
+  const parsed = parseFloat(value);
+  return isNaN(parsed) ? undefined : parsed;
+}
 
 export function volumeFromVideoPlayer(volume: number | undefined): string {
   const value = (volume ?? 1.0) * 100;
@@ -50,4 +72,19 @@ export const isVideo = (node: TreeNode): node is AssetNodeItem =>
 export function isValidVolume(volume: string | undefined): boolean {
   const value = (volume ?? 0).toString();
   return !isNaN(parseFloat(value)) && parseFloat(value) >= 0 && parseFloat(value) <= 100;
+}
+
+export function isValidPlaybackRate(rate: string | undefined): boolean {
+  if (!rate) return true; // empty means "unset" (engine default: 1)
+  return !isNaN(parseFloat(rate)) && parseFloat(rate) > 0;
+}
+
+export function isValidPosition(position: string | undefined): boolean {
+  if (!position) return true; // empty means "unset" (engine default: 0)
+  return !isNaN(parseFloat(position)) && parseFloat(position) >= 0;
+}
+
+export function isValidSpatialDistance(distance: string | undefined): boolean {
+  if (!distance) return true; // empty means "unset" (engine defaults: min 0, max 60)
+  return !isNaN(parseFloat(distance)) && parseFloat(distance) >= 0;
 }


### PR DESCRIPTION
## What

Closes the gap between the SDK/protocol component schemas and what the inspector UI exposes for six components, and fixes several converter bugs surfaced by the audit.

Beyond the new controls, every touched editor now follows one rule: **all protocol fields survive an edit**. Previously the `fromX`/`toX` converters rebuilt components from only the UI fields, so any property set from code was silently destroyed the moment the entity was touched in the editor. Fields without a control are now carried through as hidden pass-throughs.

## New fields in the UI

### VideoPlayer
- **Playback Rate** — speed multiplier, validated positive.
- **Start Position (seconds)** — playback offset.
- **Spatial Audio** — `spatial` checkbox + **Min/Max distance** fields, each with a tooltip explaining the attenuation behavior.
- These are proto3 optionals where unset ≠ 0 (an explicit `position: 0` reads as a seek), so empty inputs stay *unset* and defaults show as placeholders.

### TextShape
- **Text Wrapping** checkbox and **Size** (Width/Height) fields.
- `textColor` **alpha is preserved** through edits (previously forced to 1), and an 8-digit `#RRGGBBAA` hex is accepted.
- Shadow properties (`shadowColor`/`shadowBlur`/`shadowOffsetX/Y`) get no controls by design, but now survive edits as pass-throughs.

### AudioSource
- **Pitch** — playback-speed multiplier (1 = original, 2 = octave up, 0.5 = octave down), with an explanatory tooltip.
- `currentTime` preserved as a pass-through (a seek position isn't meaningful at edit time).

### Tween
- **Move Continuous** and **Rotate Continuous** modes: velocity-based Direction X/Y/Z (meters/sec, degrees/sec) + Speed controls; Duration/Easing hidden since they don't apply to endless constant-rate motion.
- Modes without editor support (`textureMove`, `textureMoveContinuous`, `moveRotateScale`) are now shown read-only and **preserved** instead of being silently converted to a zero-vector Move on any edit.
- Removed a phantom, label-less dropdown entry (`KEEP_ROTATING_ITEM`) that destroyed the tween mode when selected.

### ParticleSystem
- New **Rotation** section: Initial Rotation (degrees) and Rotation Over Time (degrees/sec per axis), converted to/from the protocol quaternions with the same convention as the Transform editor.
- Texture **Wrap Mode / Filter Mode** dropdowns and **Offset / Tiling** X-Y fields — previously only `src` survived an edit.

### Material
- **Color Alpha** slider (0–1) for the PBR `albedoColor`; pasting `#RRGGBBAA` also works. Unlit `diffuseColor` alpha (also Color4) is preserved via pass-through.

## Bug fixes

- **Explicit zeros snapped back to defaults** in the Material converter: `metallic`, `roughness`, `specularIntensity`, `directIntensity`, `transparencyMode`, `emissiveIntensity` used `||` instead of nullish handling (entering metallic 0 reverted to 0.5). Same class fixed in `alphaTest` (empty string became 0) and the texture numeric coercions.
- **Texture editor wrote wrong defaults**: unset `wrapMode`/`filterMode` were materialized as Repeat/Point on any material edit; they now display and write the engine defaults (Clamp/Bilinear).
- **Tween removal analytics** reported `VIDEO_PLAYER`; now reports `TWEEN`.
- **ParticleSystem "Use Texture"** could never actually remove a texture once set (the save merge kept the old value); unchecking now clears it.

## Testing

- New/extended unit suites for all six editors: 124 tests total across VideoPlayer (32), TextShape (9), AudioSource (17), Tween (10), ParticleSystem (15), Material (41) — including round-trip regressions that a fully code-authored component survives an editor edit unchanged.
- Package typecheck, ESLint, and Prettier clean; GltfNodeModifiers (which reuses the Material editor) verified unaffected.
- Each editor exercised live in the dev-server inspector, confirming values written to the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
