### PR TITLE
fix: position asset tooltips in search results

### DIFF
--- a/packages/inspector/src/components/AssetsCatalog/Asset/AssetContainer.spec.ts
+++ b/packages/inspector/src/components/AssetsCatalog/Asset/AssetContainer.spec.ts
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Asset as AssetType } from '../../../lib/logic/catalog';
+import AssetContainer from './AssetContainer';
+
+const { infoTooltipMock } = vi.hoisted(() => ({
+  infoTooltipMock: vi.fn(),
+}));
+
+vi.mock('../../../lib/logic/catalog', () => ({
+  isSmart: () => false,
+}));
+
+vi.mock('../../ui', () => ({
+  InfoTooltip: (props: { trigger: React.ReactNode }) => {
+    infoTooltipMock(props);
+    return React.createElement(React.Fragment, null, props.trigger);
+  },
+}));
+
+vi.mock('./Asset', () => ({
+  default: React.forwardRef<HTMLDivElement>((_props, ref) =>
+    React.createElement('div', { ref, 'data-testid': 'asset' }),
+  ),
+}));
+
+describe('AssetContainer', () => {
+  it('anchors the name tooltip to the asset element', () => {
+    render(
+      React.createElement(AssetContainer, {
+        value: { name: 'Wearable Scanner' } as AssetType,
+      }),
+    );
+
+    const props = infoTooltipMock.mock.lastCall?.[0] as {
+      context: React.RefObject<HTMLDivElement>;
+    };
+
+    expect(props.context.current).toBe(screen.getByTestId('asset'));
+  });
+});

--- a/packages/inspector/src/components/AssetsCatalog/Asset/AssetContainer.tsx
+++ b/packages/inspector/src/components/AssetsCatalog/Asset/AssetContainer.tsx
@@ -247,6 +247,7 @@ const AssetContainer: React.FC<AssetContainerProps> = ({ value, onAddToFilesyste
         onOpen={handleInfoTooltipOpen}
         onClose={handleInfoTooltipClose}
         trigger={assetElement}
+        context={assetRef}
         hideOnScroll={false}
         position="top center"
         hoverable={false}

--- a/packages/inspector/test/e2e/Assets.spec.ts
+++ b/packages/inspector/test/e2e/Assets.spec.ts
@@ -39,4 +39,31 @@ describe('Assets', () => {
     // There should be an entity in the Hierarchy tree with the name Pebbles
     await expect(Hierarchy.getId('Pebbles')).resolves.toBeGreaterThanOrEqual(152);
   });
+
+  test('Keeps a search result name tooltip clear of the results header', async () => {
+    await Assets.selectTab(AssetsTab.AssetsPack);
+    await page.locator('.assets-catalog-header-title').click();
+
+    const search = page.locator('.assets-catalog-header-search input');
+    await search.fill('scanner');
+
+    const asset = page.locator('.assets-catalog-asset[data-test-label="Wearable Scanner"]');
+    await asset.waitFor();
+    await asset.hover();
+
+    const tooltip = page.locator('.InfoTooltip:visible');
+    expect(await tooltip.textContent()).toContain('Wearable Scanner');
+
+    const [assetBox, headerBox, tooltipBox] = await Promise.all([
+      asset.boundingBox(),
+      page.locator('.assets-catalog-header-title').boundingBox(),
+      tooltip.boundingBox(),
+    ]);
+
+    expect(assetBox).not.toBeNull();
+    expect(headerBox).not.toBeNull();
+    expect(tooltipBox).not.toBeNull();
+    expect(tooltipBox!.y).toBeGreaterThanOrEqual(headerBox!.y + headerBox!.height);
+    expect(tooltipBox!.y + tooltipBox!.height).toBeLessThanOrEqual(assetBox!.y);
+  });
 });


### PR DESCRIPTION
## Summary

- Anchor asset-name tooltips to their asset tiles so search results do not overlap the results header.
- Add a component regression test for the tooltip positioning context.
- Add a Chromium regression test for the searched `Wearable Scanner` tooltip position.

## Root cause

The name tooltip defaulted to its trigger wrapper rather than the asset tile. In search results, that positioned the tooltip independently of the tile's layout.

## Validation

- `make build`
- `make lint`
- `make typecheck`
- `make test`
- `CI=1 E2E_URL=http://localhost:<port> make test-e2e` (Inspector: 29 tests; Creator Hub: 7 tests)

Fixes #1010
