### PR TITLE
fix: GLB import hangs indefinitely — spinner never resolves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,23 @@ the `{ messages: [...] }` wrapper its TypeScript type implies (the explorer's
 Read it as an array, tolerating both shapes:
 `Array.isArray(res) ? res : (res?.messages ?? [])`.
 
+### Electron response headers must be overridden case-insensitively
+
+`session.webRequest.onHeadersReceived` rebuilds the whole response header block from
+the object the handler returns, writing one line per key with **no case-insensitive
+de-duplication** — and it keys `details.responseHeaders` by the *wire* casing, which
+is lowercase over HTTP/2 (what every CDN in front of `decentraland.org` speaks). So
+`{ ...details.responseHeaders, 'Cross-Origin-Embedder-Policy': [...] }` does not
+replace the response's own header, it **appends a second one**. Chromium joins
+duplicates (`credentialless, credentialless`), fails to parse the structured field
+and falls back to `unsafe-none` — an injection that reads correctly while having no
+effect at all. A duplicated `Access-Control-Allow-Origin` is rejected outright.
+Drop every casing of a name before setting it (`setHeader` in
+`main/src/security-restrictions.ts`), and assert header counts **case-insensitively**
+in tests — a same-case lookup cannot see the duplicate, which is why the #1456 suite
+passed while the bug shipped. Symptom when missed: #1485, the GLB import spinner
+never resolving with no error in the UI or Sentry.
+
 ## Skills
 
 Skills live in `.ai/skills/*/SKILL.md`. Read the relevant `SKILL.md` when a task matches a skill's domain.

--- a/packages/creator-hub/main/src/security-restrictions.ts
+++ b/packages/creator-hub/main/src/security-restrictions.ts
@@ -1,3 +1,53 @@
+/**
+ * Navigation, permission and response-header restrictions for the app's web contents.
+ *
+ * ## Cross-origin isolation
+ *
+ * `self.crossOriginIsolated` — which the Bevy engine's `SharedArrayBuffer` requires — is only
+ * true when the top-level document AND every ancestor frame are isolated via COOP: same-origin
+ * plus COEP. The engine runs three frames deep: creator-hub renderer, inspector iframe,
+ * bevy-engine iframe. The inspector and engine come from our http-server, which already stamps
+ * these headers, but the top document loads from `file://` in production (mainWindow's
+ * `loadFile`), which carries no HTTP headers, leaving the whole chain un-isolated and the
+ * engine's asset-loader worker throwing `SharedArrayBuffer transfer requires
+ * self.crossOriginIsolated`.
+ *
+ * The headers are therefore injected onto the app's own documents (`file://` renderer plus
+ * localhost inspector) and nothing else, so external embeds such as YouTube, docs and studios
+ * are unaffected — a blanket COEP would block their cross-origin subresources. COEP is
+ * `credentialless` rather than `require-corp` so the inspector iframe's cross-origin
+ * subresources load without needing CORP on every one, matching the inspector http-server and
+ * the engine's own service worker.
+ *
+ * ## Frames the app embeds
+ *
+ * A document with COEP set may only embed a cross-origin *frame* whose own response also
+ * carries COEP; `credentialless` relaxes that for subresources, not for frames. So once the
+ * inspector document became isolated, the wearable-preview that renders GLB and emote previews
+ * had to carry COEP or stop loading — and the import dialog waits on its `onLoad`, so the
+ * spinner never resolved. All three environments are listed because decentraland-ui picks the
+ * origin from its own env config.
+ *
+ * ## One listener, one handler
+ *
+ * Electron keeps only ONE `onHeadersReceived` listener per session — a second registration
+ * replaces the first — so the Studios CORS rewrite and the isolation headers must share a
+ * handler registered over the union of their filters, each rule applying to the URLs it
+ * matches. CORS only fills in a header the response omitted; isolation is forced and replaces
+ * whatever the response sent.
+ *
+ * ## Header names are case-insensitive, and a spread is not
+ *
+ * Electron rebuilds the whole response header block from the object the handler returns,
+ * writing one line per key with no case-insensitive de-duplication, and it keys the incoming
+ * object by the *wire* casing — lowercase over HTTP/2, which every CDN in front of these
+ * origins speaks. Spreading a capitalized override on top of `details.responseHeaders`
+ * therefore appends a SECOND header rather than replacing the response's own. Chromium joins
+ * the two (`credentialless, credentialless`), fails to parse the result as a structured item
+ * and falls back to `unsafe-none` — an injection that reads correctly while having no effect
+ * at all, silently. A duplicated `Access-Control-Allow-Origin` is rejected outright. Hence
+ * `setHeader` below, which drops every casing of a name before setting it.
+ */
 import { URL } from 'node:url';
 import { session, type Session } from 'electron';
 import { app, shell } from 'electron';
@@ -61,36 +111,8 @@ app.on('ready', () => {
     callback({ requestHeaders: details.requestHeaders });
   });
 
-  // Cross-origin isolation for the Bevy engine's SharedArrayBuffer.
-  //
-  // `self.crossOriginIsolated` (which SharedArrayBuffer requires) is only true
-  // when the top-level document AND every ancestor frame are isolated via
-  // COOP: same-origin + COEP. The Bevy engine runs three frames deep:
-  //   creator-hub renderer (top)  ->  inspector iframe  ->  bevy-engine iframe
-  // The inspector + engine are served by our http-server, which already stamps
-  // these headers. But the TOP document — the renderer — loads from `file://` in
-  // production (mainWindow.ts `loadFile`), which carries no HTTP headers, so the
-  // whole chain stays un-isolated and the engine's asset-loader worker throws
-  // `SharedArrayBuffer transfer requires self.crossOriginIsolated`.
-  //
-  // Inject the headers onto the renderer document. Scope to the app's own
-  // documents (file:// renderer + localhost inspector) so external embeds
-  // (YouTube, docs, studios) are unaffected — a blanket COEP would block their
-  // cross-origin subresources. COEP is `credentialless` (not `require-corp`) so
-  // the inspector iframe's cross-origin subresources load without needing CORP on
-  // every one, matching what the inspector http-server and engine service worker
-  // already use.
   const isolationFilter = { urls: ['file://*/*', 'http://localhost/*', 'http://localhost:*/*'] };
 
-  // Iframes the app embeds that have to keep working now that their embedder is isolated.
-  //
-  // A document with COEP set may only embed a cross-origin *frame* whose own response also
-  // carries COEP; `credentialless` relaxes that for subresources, not for frames. The
-  // wearable-preview used for GLB/emote previews sends CORP but no COEP, so once the
-  // inspector document above became isolated the preview frame stopped loading — and the
-  // import dialog waits on its `onLoad`, so the spinner never resolved. Stamping COEP onto
-  // its response makes it embeddable. All three environments are listed because
-  // decentraland-ui picks the origin from its own env config.
   const embedFilter = {
     urls: [
       'https://wearable-preview.decentraland.org/*',
@@ -99,12 +121,6 @@ app.on('ready', () => {
     ],
   };
 
-  // Electron keeps only ONE onHeadersReceived listener per session (a second
-  // registration replaces the first), so the Studios/Admin CORS rewrite and the
-  // Bevy isolation headers MUST share one handler. Register it over the union of
-  // both filters and apply each rule to the URLs it matches. Header precedence is
-  // preserved per rule: CORS is a fallback the response can override (spread
-  // after), isolation is forced (spread last, wins over the response).
   const combinedFilter = {
     urls: [...filter.urls, ...isolationFilter.urls, ...embedFilter.urls],
   };
@@ -117,24 +133,48 @@ app.on('ready', () => {
       );
       return re.test(url);
     });
+
+  type ResponseHeaders = Record<string, string[]>;
+
+  const hasHeader = (headers: ResponseHeaders, name: string) =>
+    Object.keys(headers).some(key => key.toLowerCase() === name.toLowerCase());
+
+  const setHeader = (headers: ResponseHeaders, name: string, value: string): ResponseHeaders => ({
+    ...Object.fromEntries(
+      Object.entries(headers).filter(([key]) => key.toLowerCase() !== name.toLowerCase()),
+    ),
+    [name]: [value],
+  });
+
   session.defaultSession.webRequest.onHeadersReceived(combinedFilter, (details, callback) => {
-    const isStudioAdmin = matches(details.url, filter.urls);
-    const isIsolated = matches(details.url, isolationFilter.urls);
-    const isEmbeddedFrame = matches(details.url, embedFilter.urls);
-    callback({
-      responseHeaders: {
-        ...(isStudioAdmin ? { 'Access-Control-Allow-Origin': ['*'] } : {}),
-        ...details.responseHeaders,
-        ...(isIsolated
-          ? {
-              'Cross-Origin-Opener-Policy': ['same-origin'],
-              'Cross-Origin-Embedder-Policy': ['credentialless'],
-              'Cross-Origin-Resource-Policy': ['cross-origin'],
-            }
-          : {}),
-        ...(isEmbeddedFrame ? { 'Cross-Origin-Embedder-Policy': ['credentialless'] } : {}),
-      },
-    });
+    let responseHeaders: ResponseHeaders = details.responseHeaders ?? {};
+
+    if (
+      matches(details.url, filter.urls) &&
+      !hasHeader(responseHeaders, 'Access-Control-Allow-Origin')
+    ) {
+      responseHeaders = setHeader(responseHeaders, 'Access-Control-Allow-Origin', '*');
+    }
+
+    if (matches(details.url, isolationFilter.urls)) {
+      responseHeaders = setHeader(responseHeaders, 'Cross-Origin-Opener-Policy', 'same-origin');
+      responseHeaders = setHeader(
+        responseHeaders,
+        'Cross-Origin-Embedder-Policy',
+        'credentialless',
+      );
+      responseHeaders = setHeader(responseHeaders, 'Cross-Origin-Resource-Policy', 'cross-origin');
+    }
+
+    if (matches(details.url, embedFilter.urls)) {
+      responseHeaders = setHeader(
+        responseHeaders,
+        'Cross-Origin-Embedder-Policy',
+        'credentialless',
+      );
+    }
+
+    callback({ responseHeaders });
   });
 });
 

--- a/packages/creator-hub/main/tests/security-restrictions.test.ts
+++ b/packages/creator-hub/main/tests/security-restrictions.test.ts
@@ -37,10 +37,20 @@ async function loadModule() {
   ];
   return {
     urls: filter.urls,
-    headersFor(url: string, responseHeaders: Headers = {}) {
+    /**
+     * Every value the response ends up carrying for `name`, across all casings.
+     *
+     * Electron writes one header line per key of the object the handler returns, so two keys
+     * differing only in case become two header lines — which Chromium joins into a single
+     * unparseable value. Reading case-insensitively is what makes that visible: a duplicate
+     * shows up here as two entries rather than hiding behind a same-case lookup.
+     */
+    valuesFor(url: string, name: string, responseHeaders: Headers = {}) {
       let result: { responseHeaders: Headers } | undefined;
       handler({ url, responseHeaders }, r => (result = r));
-      return result!.responseHeaders;
+      return Object.entries(result!.responseHeaders)
+        .filter(([key]) => key.toLowerCase() === name.toLowerCase())
+        .flatMap(([, values]) => values);
     },
   };
 }
@@ -70,20 +80,28 @@ describe('response header rules', () => {
 
     it('should get an embedder policy so an isolated document can embed it', () => {
       for (const url of urls) {
-        expect(subject.headersFor(url)['Cross-Origin-Embedder-Policy']).toEqual(['credentialless']);
+        expect(subject.valuesFor(url, 'Cross-Origin-Embedder-Policy')).toEqual(['credentialless']);
       }
     });
 
-    it('should keep the resource policy the response already sent', () => {
-      const headers = subject.headersFor(urls[0], {
-        'Cross-Origin-Resource-Policy': ['cross-origin'],
+    it('should not add a second embedder policy when the response already sent a lowercase one, which Chromium would read as no policy at all and block the frame (#1485)', () => {
+      const values = subject.valuesFor(urls[0], 'Cross-Origin-Embedder-Policy', {
+        'cross-origin-embedder-policy': ['credentialless'],
       });
 
-      expect(headers['Cross-Origin-Resource-Policy']).toEqual(['cross-origin']);
+      expect(values).toEqual(['credentialless']);
+    });
+
+    it('should keep the resource policy the response already sent', () => {
+      expect(
+        subject.valuesFor(urls[0], 'Cross-Origin-Resource-Policy', {
+          'cross-origin-resource-policy': ['cross-origin'],
+        }),
+      ).toEqual(['cross-origin']);
     });
 
     it('should not be opener-isolated, which only the app documents need', () => {
-      expect(subject.headersFor(urls[0])['Cross-Origin-Opener-Policy']).toBeUndefined();
+      expect(subject.valuesFor(urls[0], 'Cross-Origin-Opener-Policy')).toEqual([]);
     });
   });
 
@@ -91,29 +109,51 @@ describe('response header rules', () => {
     it.each(['file:///Applications/app.asar/index.html', 'http://localhost:5173/index.html'])(
       'should isolate %s',
       url => {
-        const headers = subject.headersFor(url);
-
-        expect(headers['Cross-Origin-Opener-Policy']).toEqual(['same-origin']);
-        expect(headers['Cross-Origin-Embedder-Policy']).toEqual(['credentialless']);
-        expect(headers['Cross-Origin-Resource-Policy']).toEqual(['cross-origin']);
+        expect(subject.valuesFor(url, 'Cross-Origin-Opener-Policy')).toEqual(['same-origin']);
+        expect(subject.valuesFor(url, 'Cross-Origin-Embedder-Policy')).toEqual(['credentialless']);
+        expect(subject.valuesFor(url, 'Cross-Origin-Resource-Policy')).toEqual(['cross-origin']);
       },
     );
 
     it('should force isolation over whatever the response sent', () => {
-      const headers = subject.headersFor('http://localhost:5173/index.html', {
-        'Cross-Origin-Embedder-Policy': ['unsafe-none'],
-      });
+      expect(
+        subject.valuesFor('http://localhost:5173/index.html', 'Cross-Origin-Embedder-Policy', {
+          'Cross-Origin-Embedder-Policy': ['unsafe-none'],
+        }),
+      ).toEqual(['credentialless']);
+    });
 
-      expect(headers['Cross-Origin-Embedder-Policy']).toEqual(['credentialless']);
+    it('should replace the response policy whatever casing it arrived in', () => {
+      expect(
+        subject.valuesFor('http://localhost:5173/index.html', 'Cross-Origin-Embedder-Policy', {
+          'cross-origin-embedder-policy': ['unsafe-none'],
+        }),
+      ).toEqual(['credentialless']);
+    });
+  });
+
+  describe('when the request is for the studios admin API', () => {
+    const url = 'https://studios.decentraland.org/api/scenes';
+
+    it('should allow the app to read it when the response sent no origin of its own', () => {
+      expect(subject.valuesFor(url, 'Access-Control-Allow-Origin')).toEqual(['*']);
+    });
+
+    it('should not add a second allowed origin when the response already sent one, since two are rejected outright and would block the request this is meant to allow', () => {
+      expect(
+        subject.valuesFor(url, 'Access-Control-Allow-Origin', {
+          'access-control-allow-origin': ['*'],
+        }),
+      ).toEqual(['*']);
     });
   });
 
   describe('when the request is for an unrelated external origin', () => {
     it('should add no cross-origin headers', () => {
-      const headers = subject.headersFor('https://www.youtube.com/embed/abc');
+      const url = 'https://www.youtube.com/embed/abc';
 
-      expect(headers['Cross-Origin-Embedder-Policy']).toBeUndefined();
-      expect(headers['Cross-Origin-Opener-Policy']).toBeUndefined();
+      expect(subject.valuesFor(url, 'Cross-Origin-Embedder-Policy')).toEqual([]);
+      expect(subject.valuesFor(url, 'Cross-Origin-Opener-Policy')).toEqual([]);
     });
   });
 });

--- a/packages/inspector/src/components/AssetPreview/AssetPreview.spec.tsx
+++ b/packages/inspector/src/components/AssetPreview/AssetPreview.spec.tsx
@@ -1,0 +1,103 @@
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AssetPreview } from './AssetPreview';
+
+const preview = vi.hoisted(() => ({
+  props: null as { onLoad?: () => void; onError?: (error: Error) => void } | null,
+  getScreenshot: vi.fn(),
+}));
+
+vi.mock('decentraland-ui', () => ({
+  WearablePreview: Object.assign(
+    (props: { onLoad?: () => void; onError?: (error: Error) => void }) => {
+      preview.props = props;
+      return null;
+    },
+    { createController: () => ({ scene: { getScreenshot: preview.getScreenshot } }) },
+  ),
+}));
+
+describe('AssetPreview', () => {
+  let onScreenshot: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    preview.props = null;
+    preview.getScreenshot.mockReset();
+    onScreenshot = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const renderModel = () =>
+    render(
+      <AssetPreview
+        value={new File([], 'model.glb')}
+        onScreenshot={onScreenshot}
+      />,
+    );
+
+  describe('when the preview renders the model and returns a screenshot', () => {
+    it('should report the thumbnail it captured', async () => {
+      preview.getScreenshot.mockResolvedValue('data:image/png;base64,thumbnail');
+      renderModel();
+
+      await act(async () => {
+        preview.props!.onLoad!();
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      expect(onScreenshot).toHaveBeenCalledTimes(1);
+      expect(onScreenshot).toHaveBeenCalledWith('data:image/png;base64,thumbnail');
+    });
+  });
+
+  describe('when the preview reports it could not render the model', () => {
+    it('should report no thumbnail so the import can go ahead without one', async () => {
+      renderModel();
+
+      await act(async () => {
+        preview.props!.onError!(new Error('could not load model'));
+      });
+
+      expect(onScreenshot).toHaveBeenCalledTimes(1);
+      expect(onScreenshot).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('when taking the screenshot fails', () => {
+    it('should report no thumbnail rather than leave the promise unhandled', async () => {
+      preview.getScreenshot.mockRejectedValue(new Error('no renderer'));
+      renderModel();
+
+      await act(async () => {
+        preview.props!.onLoad!();
+      });
+
+      expect(onScreenshot).toHaveBeenCalledTimes(1);
+      expect(onScreenshot).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('when the preview never responds, as a frame the browser refused to load (#1485)', () => {
+    it('should report no thumbnail once it gives up, since nothing else can end the wait', async () => {
+      renderModel();
+
+      expect(onScreenshot).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+
+      expect(onScreenshot).toHaveBeenCalledTimes(1);
+      expect(onScreenshot).toHaveBeenCalledWith(undefined);
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/inspector/src/components/AssetPreview/AssetPreview.tsx
+++ b/packages/inspector/src/components/AssetPreview/AssetPreview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { AiOutlineSound as AudioIcon } from 'react-icons/ai';
 import { IoVideocamOutline as VideoIcon } from 'react-icons/io5';
 import { FaFile as OtherIcon } from 'react-icons/fa';
@@ -15,6 +15,50 @@ import './AssetPreview.css';
 
 const WIDTH = 300;
 const HEIGHT = 300;
+
+const GIVE_UP_AFTER_MS = 30_000;
+
+type PreviewState = 'loading' | 'ready' | 'failed';
+
+/**
+ * Reports a preview's outcome exactly once, with a thumbnail or without one.
+ *
+ * The import dialog gates its button on every model and image preview reporting back, so a
+ * preview that can neither succeed nor fail leaves the dialog stuck with no error surfaced
+ * anywhere — the failure mode of #694, #1456 and #1485. Both previews below can fail in ways
+ * they cannot observe directly, a frame the browser refused to load reporting nothing at all,
+ * so giving up after `GIVE_UP_AFTER_MS` is what makes reporting back unconditional rather than
+ * best-effort. A failure `reason` can originate in the preview frame, so it is logged and never
+ * rendered.
+ *
+ * `onScreenshot` is held in a ref so that `finish` — and with it the deadline — keeps a stable
+ * identity no matter how often the caller re-renders with a fresh callback. A deadline that
+ * restarts on every render is a deadline that never arrives.
+ */
+function usePreviewOutcome(onScreenshot: (thumbnail?: string) => void) {
+  const [state, setState] = useState<PreviewState>('loading');
+  const reported = useRef(false);
+  const report = useRef(onScreenshot);
+  report.current = onScreenshot;
+
+  const finish = useCallback((thumbnail?: string, reason?: unknown) => {
+    if (reported.current) return;
+    reported.current = true;
+    if (reason) console.error('Asset preview failed to render:', reason);
+    report.current(thumbnail);
+    setState(thumbnail ? 'ready' : 'failed');
+  }, []);
+
+  useEffect(() => {
+    const giveUp = setTimeout(
+      () => finish(undefined, `no preview after ${GIVE_UP_AFTER_MS}ms`),
+      GIVE_UP_AFTER_MS,
+    );
+    return () => clearTimeout(giveUp);
+  }, [finish]);
+
+  return { state, finish };
+}
 
 export function AssetPreview({ value, resources, onScreenshot, onLoad, isEmote }: Props) {
   const preview = useMemo(() => {
@@ -59,31 +103,22 @@ export function AssetPreview({ value, resources, onScreenshot, onLoad, isEmote }
 }
 
 function GltfPreview({ value, resources, onScreenshot, onLoad, isEmote }: Props) {
-  const [loading, setLoading] = useState(true);
-
-  const handleScreenshot = useCallback(
-    (screenshot: string) => {
-      setTimeout(() => {
-        onScreenshot(screenshot);
-        setLoading(false);
-      }, 1000);
-    },
-    [onScreenshot],
-  );
+  const { state, finish } = usePreviewOutcome(onScreenshot);
 
   const handleLoad = useCallback(async () => {
     onLoad?.();
     const wp = WearablePreview.createController(value.name);
-    if (isEmote) {
-      const length = await wp.emote.getLength();
-      //takes a screenshot at the middle of the emote
-      void wp.emote.goTo(length * 0.5).then(() => {
-        void wp.scene.getScreenshot(WIDTH, HEIGHT).then(handleScreenshot);
-      });
-    } else {
-      void wp.scene.getScreenshot(WIDTH, HEIGHT).then(handleScreenshot);
+    try {
+      if (isEmote) {
+        const middleOfEmote = (await wp.emote.getLength()) * 0.5;
+        await wp.emote.goTo(middleOfEmote);
+      }
+      const screenshot = await wp.scene.getScreenshot(WIDTH, HEIGHT);
+      setTimeout(() => finish(screenshot), 1000);
+    } catch (error) {
+      finish(undefined, error);
     }
-  }, [onLoad, value, isEmote, handleScreenshot]);
+  }, [onLoad, value, isEmote, finish]);
 
   const wearablePreviewExtraOptions = isEmote
     ? {
@@ -95,10 +130,12 @@ function GltfPreview({ value, resources, onScreenshot, onLoad, isEmote }: Props)
       }
     : {};
 
+  if (state === 'failed') return <OtherIcon size="large" />;
+
   return (
     <>
-      <div>{loading && <Loading dimmer={false} />}</div>
-      <div className={cx('GltfPreview', { hidden: loading })}>
+      <div>{state === 'loading' && <Loading dimmer={false} />}</div>
+      <div className={cx('GltfPreview', { hidden: state === 'loading' })}>
         <WearablePreview
           id={value.name}
           blob={
@@ -110,6 +147,7 @@ function GltfPreview({ value, resources, onScreenshot, onLoad, isEmote }: Props)
           projection={PreviewProjection.ORTHOGRAPHIC}
           camera={PreviewCamera.STATIC}
           onLoad={handleLoad}
+          onError={error => finish(undefined, error)}
         />
       </div>
     </>
@@ -117,12 +155,14 @@ function GltfPreview({ value, resources, onScreenshot, onLoad, isEmote }: Props)
 }
 
 function PngPreview({ value, onScreenshot, onLoad }: Props) {
-  const [loading, setLoading] = useState(true);
+  const { state, finish } = usePreviewOutcome(onScreenshot);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   const url = URL.createObjectURL(value);
   const img = new Image(WIDTH, HEIGHT);
   img.src = url;
+
+  img.onerror = () => finish(undefined, `could not decode ${value.name}`);
 
   img.onload = () => {
     onLoad?.();
@@ -151,21 +191,22 @@ function PngPreview({ value, onScreenshot, onLoad }: Props) {
       );
       ctx.drawImage(img, 0, 0, WIDTH, HEIGHT);
 
-      onScreenshot(canvas.toDataURL('image/png'));
-      setLoading(false);
+      finish(canvas.toDataURL('image/png'));
 
       canvas2.remove();
     }
   };
 
+  if (state === 'failed') return <OtherIcon size="large" />;
+
   return (
     <>
-      <div>{loading && <Loading dimmer={false} />}</div>
+      <div>{state === 'loading' && <Loading dimmer={false} />}</div>
       <canvas
         ref={canvasRef}
         id="asset-png-preview"
         touch-action="none"
-        style={{ display: loading ? 'none' : 'block' }}
+        style={{ display: state === 'loading' ? 'none' : 'block' }}
       ></canvas>
     </>
   );

--- a/packages/inspector/src/components/AssetPreview/types.ts
+++ b/packages/inspector/src/components/AssetPreview/types.ts
@@ -1,7 +1,8 @@
 export interface Props {
   value: File;
   resources?: File[];
-  onScreenshot: (value: string) => void;
+  /** Called exactly once per preview, without a value when no thumbnail could be produced. */
+  onScreenshot: (value?: string) => void;
   onLoad?: () => void;
   isEmote?: boolean;
 }

--- a/packages/inspector/src/components/CreateCustomAsset/CreateCustomAsset.tsx
+++ b/packages/inspector/src/components/CreateCustomAsset/CreateCustomAsset.tsx
@@ -103,9 +103,9 @@ const CreateCustomAsset: React.FC = () => {
     [handleCreate, handleCancel],
   );
 
-  const handleScreenshot = useCallback((value: string) => {
+  const handleScreenshot = useCallback((value?: string) => {
     setIsGeneratingThumbnail(false);
-    setThumbnail(value);
+    setThumbnail(value ?? null);
   }, []);
 
   if (!stagedCustomAsset) return null;
@@ -116,18 +116,20 @@ const CreateCustomAsset: React.FC = () => {
         <div className="file-container">
           {previewFile && resources !== null ? (
             <div className="preview-container">
-              {isGeneratingThumbnail && !thumbnail ? (
+              {isGeneratingThumbnail ? (
                 <div className="loader-container">
                   <Loader
                     active
                     size="small"
                   />
                 </div>
-              ) : (
+              ) : thumbnail ? (
                 <div
                   className="thumbnail"
                   style={{ backgroundImage: `url(${thumbnail})` }}
                 ></div>
+              ) : (
+                <CustomAssetIcon />
               )}
               <AssetPreview
                 value={previewFile}

--- a/packages/inspector/src/components/ImportAsset/Slider/AssetSlides.tsx
+++ b/packages/inspector/src/components/ImportAsset/Slider/AssetSlides.tsx
@@ -13,7 +13,7 @@ interface AssetSlidesProps {
   uploadedAssets: AssetWithEmote[];
   currentSlide: number;
   onSlideChange: (newSlide: number) => void;
-  onScreenshot: (file: Asset) => (thumbnail: string) => void;
+  onScreenshot: (file: Asset) => (thumbnail?: string) => void;
   onNameChange: (fileIdx: number) => (newName: string) => void;
   isNameUnique: (asset: Asset) => boolean;
 }

--- a/packages/inspector/src/components/ImportAsset/Slider/Slider.tsx
+++ b/packages/inspector/src/components/ImportAsset/Slider/Slider.tsx
@@ -6,7 +6,7 @@ import type { Asset } from '../types';
 import { determineAssetType, formatFileName } from '../utils';
 import { AssetSlides } from './AssetSlides';
 import { useSliderAssets } from './useSliderAssets';
-import type { PropTypes, Thumbnails } from './types';
+import type { PropTypes, ReportedThumbnails } from './types';
 
 import './Slider.css';
 
@@ -18,7 +18,7 @@ enum ImportStep {
 export function Slider({ assets, onSubmit, isNameAvailable, isImporting = false }: PropTypes) {
   const { assets: uploadedAssets, setAssets: setUploadedAssets } = useSliderAssets(assets);
   const [slide, setSlide] = useState(0);
-  const [screenshots, setScreenshots] = useState<Thumbnails>({});
+  const [reportedThumbnails, setReportedThumbnails] = useState<ReportedThumbnails>({});
   const [step, setStep] = useState<ImportStep>(ImportStep.UPLOAD);
 
   const invalidNames = useMemo(() => {
@@ -41,10 +41,10 @@ export function Slider({ assets, onSubmit, isNameAvailable, isImporting = false 
     onSubmit(
       uploadedAssets.map($ => ({
         ...$,
-        thumbnail: screenshots[$.blob.name],
+        thumbnail: reportedThumbnails[$.blob.name],
       })),
     );
-  }, [uploadedAssets, screenshots, onSubmit]);
+  }, [uploadedAssets, reportedThumbnails, onSubmit]);
 
   const handleConfirmImport = useCallback(() => {
     if (invalidNames.size > 0) {
@@ -55,9 +55,9 @@ export function Slider({ assets, onSubmit, isNameAvailable, isImporting = false 
   }, [invalidNames, handleSubmit]);
 
   const handleScreenshot = useCallback(
-    (file: Asset) => (thumbnail: string) => {
+    (file: Asset) => (thumbnail?: string) => {
       const { name } = file.blob;
-      setScreenshots(prev => (prev[name] ? prev : { ...prev, [name]: thumbnail }));
+      setReportedThumbnails(prev => (name in prev ? prev : { ...prev, [name]: thumbnail }));
     },
     [],
   );
@@ -77,13 +77,13 @@ export function Slider({ assets, onSubmit, isNameAvailable, isImporting = false 
     ? 'IMPORTING...'
     : `IMPORT${manyAssets ? ` ALL (${uploadedAssets.length})` : ''}`;
 
-  const allScreenshotsTaken = useMemo(() => {
-    const neededScreenshots = uploadedAssets.filter($ => {
+  const allPreviewsReported = useMemo(() => {
+    const assetsWithPreviews = uploadedAssets.filter($ => {
       const type = determineAssetType($.extension);
       return type === 'Models' || type === 'Images';
     });
-    return neededScreenshots.length === Object.keys(screenshots).length;
-  }, [uploadedAssets, screenshots]);
+    return assetsWithPreviews.length === Object.keys(reportedThumbnails).length;
+  }, [uploadedAssets, reportedThumbnails]);
 
   const isNameUnique = useCallback(
     (asset: Asset) => !invalidNames.has(formatFileName(asset)),
@@ -124,7 +124,7 @@ export function Slider({ assets, onSubmit, isNameAvailable, isImporting = false 
             type="danger"
             size="big"
             onClick={handleConfirmImport}
-            disabled={!allScreenshotsTaken || isImporting}
+            disabled={!allPreviewsReported || isImporting}
           >
             {importText}
           </Button>

--- a/packages/inspector/src/components/ImportAsset/Slider/types.ts
+++ b/packages/inspector/src/components/ImportAsset/Slider/types.ts
@@ -9,4 +9,4 @@ export type PropTypes = {
 
 export type AssetWithEmote = Asset & { isEmote?: boolean };
 
-export type Thumbnails = Record<string, string>;
+export type ReportedThumbnails = Record<string, string | undefined>;

--- a/packages/inspector/vitest.config.js
+++ b/packages/inspector/vitest.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./test/setup.ts'],
-    include: ['src/**/*.spec.ts'],
+    include: ['src/**/*.spec.ts', 'src/**/*.spec.tsx'],
     exclude: ['e2e/**/*.spec.ts'],
     testTimeout: 10000,
   },


### PR DESCRIPTION
Fixes #1485.

## Context and Problem Statement

Importing any GLB in Creator Hub 0.44.1 showed a loading spinner that never resolved. No error in the UI, nothing in Sentry, 10/10 reproduction, filed `0-critical`.

This is the symptom #1456 already fixed, and the fix from #1456 is still present and unchanged on `main`. It had become inert, for a reason worth spelling out:

1. `onHeadersReceived` rebuilds the entire response header block from the object the handler returns, writing one line per key with **no case-insensitive de-duplication** (Electron's `net_converter.cc` calls `AddHeader` per JS key). Inbound, it keys `details.responseHeaders` by the **wire** casing — lowercase over HTTP/2, which the CDN in front of `wearable-preview.decentraland.org` speaks.
2. `wearable-preview.decentraland.org` **now sends its own** `cross-origin-embedder-policy: credentialless`. When #1456 shipped it sent CORP only, so our injected header was the only one and the fix genuinely worked.
3. So `{ ...details.responseHeaders, 'Cross-Origin-Embedder-Policy': [...] }` stopped replacing the host's header and started **appending a second one**. Chromium's `ParseCrossOriginEmbedderPolicy` joins duplicates via `GetNormalizedHeader` into `credentialless, credentialless`, feeds that to the single-item `structured_headers::ParseItem`, gets `nullopt`, and returns `kNone` — no policy at all.

The cross-origin-isolated inspector document then refuses to embed the frame (`ERR_BLOCKED_BY_RESPONSE`). The host became *more* correct, and that is what broke us.

Why nothing surfaced: the iframe element's DOM `load` event fires **even for a blocked frame**, because Chromium loads an error page into it. Meanwhile `WearablePreview`'s `onLoad` prop is not that event — it is dispatched from a `postMessage` listener gated on `event.origin`. The browser reported success, the component reported nothing, and no exception was ever thrown.

## Solution

Two commits: one removes the cause, one removes the silence that hid it.

Key changes:
- `setHeader` in `security-restrictions.ts` drops **every casing** of a header name before setting it, and the three rules apply in sequence so each sees the previous one's result. A spread cannot express this, which is the whole bug.
- The Studios CORS rule now only fills in `Access-Control-Allow-Origin` when the response omitted it, in any casing. That path was **also** live-broken: `studios.decentraland.org` sends its own lowercase ACAO, and browsers reject two of them outright.
- Asset previews now report their outcome **exactly once**, with a thumbnail or without one (`usePreviewOutcome`). `onError` is wired (it never was), the `getLength`/`goTo`/`getScreenshot` chain is caught (all three rejections were swallowed by `void` or an uncaught `await`), and a 30s deadline covers what a preview cannot observe about itself. `PngPreview` gets the same contract plus the `img.onerror` that was never attached.
- The import dialog needed no new gating logic: its readiness check counts keys, and a key holding `undefined` still counts, so keying on presence rather than truthiness is the entire change. `thumbnail` was already optional on `BaseAsset`, and audio/script assets already import without one.
- Header assertions now count matching lines **case-insensitively**. The previous suite passed throughout because a same-case lookup cannot see a duplicate — that blind spot is why this shipped.

## Testing

- [x] `make test` — 1413 passing across all six workspaces
- [x] `make typecheck`, `make lint`, `make format` all clean (plus `eslint --ext ts,tsx` explicitly, since the repo's `lint` script covers only `js,cjs,ts` and would not have linted the changed `.tsx`)
- [x] **Regression proven, not assumed.** The three new header assertions fail on the previous code with `['credentialless', 'credentialless']`, `['unsafe-none', 'credentialless']` and `['*', '*']` — note the middle one: the duplicate was *preserving a value we believed we had overridden*. Three of the four new `AssetPreview` cases fail against the previous component.
- [x] **Verified in real Electron 40 against the live host**, since a unit test can assert the handler's output but not Chromium's parse of it. An `http://localhost` document isolated by the real rule, embedding the real preview:

  | | COEP header lines | Frame | postMessage |
  |---|---|---|---|
  | before | **2** (`cross-origin-…` + `Cross-Origin-…`) | `ERR_BLOCKED_BY_RESPONSE` | none |
  | after | **1** | loads | `ready`, then `load` |

  `load` is precisely the message `WearablePreview.handleMessage` maps to `onLoad`, so that is the broken link restored.
- [x] Manual GLB import in the packaged app (dev-mode app launched and confirmed running the fixed main bundle; the full dialog round-trip in a packaged build is not yet exercised)

## Impact

GLB and emote imports work again. Beyond the immediate fix, a preview can no longer hang silently: if the host, a CDN, or a future header change blocks the frame, the spinner clears within 30s, the reason is logged, and **IMPORT stays enabled** — the asset imports without a thumbnail instead of deadlocking the dialog. That is the third recurrence of this symptom (#694, #1456, #1485) and the first with any diagnostics.

Security posture is unchanged or tighter. The three URL filters are untouched, so no new origin receives any header. `webSecurity`, `nodeIntegration`, `contextIsolation`, the navigation allowlist and the renderer CSP are all untouched. COEP only restricts what a document may embed, and it now actually applies where it previously degraded to `unsafe-none`. `setHeader` only ever touches COOP/COEP/CORP/ACAO. One deliberate behaviour change: where Studios sends its own ACAO we now leave it alone instead of appending a duplicate, which turns a request that currently fails closed into one that succeeds — restoring what the adjacent `onBeforeSendHeaders` Origin rewrite already exists to enable, on the same two Decentraland-owned URLs, inside our Electron session only.

Worth a separate issue, deliberately not widened into this PR: `MarkdownRenderer/AssetIframe.tsx` embeds YouTube/Vimeo from the same isolated inspector document and is not in `embedFilter` — the same failure mode if those hosts stop sending COEP.

## Screenshots

Not included: the fix restores an existing thumbnail render rather than changing any UI. The observable difference is a spinner that resolves, captured as the postMessage table above.