### PR TITLE
fix: let the markdown video embeds load under cross-origin isolation

### DIFF
--- a/packages/creator-hub/main/src/security-restrictions.ts
+++ b/packages/creator-hub/main/src/security-restrictions.ts
@@ -22,11 +22,16 @@
  * ## Frames the app embeds
  *
  * A document with COEP set may only embed a cross-origin *frame* whose own response also
- * carries COEP; `credentialless` relaxes that for subresources, not for frames. So once the
- * inspector document became isolated, the wearable-preview that renders GLB and emote previews
- * had to carry COEP or stop loading — and the import dialog waits on its `onLoad`, so the
- * spinner never resolved. All three environments are listed because decentraland-ui picks the
- * origin from its own env config.
+ * carries COEP; `credentialless` relaxes that for subresources, not for frames, and CORP does
+ * not cover frames either. So once the inspector document became isolated, every cross-origin
+ * frame it embeds had to carry COEP or stop loading with `ERR_BLOCKED_BY_RESPONSE`. Two did:
+ * the wearable-preview behind GLB and emote previews, whose `onLoad` the import dialog waits on
+ * (so the spinner never resolved), and the video players a scene's markdown may embed, which
+ * simply rendered nothing. Neither sends an enforced COEP of its own — YouTube sends only
+ * `Cross-Origin-Embedder-Policy-Report-Only`, which does not count — so it is stamped here.
+ * Every wearable-preview environment is listed because decentraland-ui picks the origin from
+ * its own env config; the video origins mirror the inspector's markdown iframe allowlist, and
+ * a test asserts this list keeps covering it.
  *
  * ## One listener, one handler
  *
@@ -118,6 +123,9 @@ app.on('ready', () => {
       'https://wearable-preview.decentraland.org/*',
       'https://wearable-preview.decentraland.today/*',
       'https://wearable-preview.decentraland.zone/*',
+      'https://www.youtube.com/*',
+      'https://youtube.com/*',
+      'https://player.vimeo.com/*',
     ],
   };
 

--- a/packages/creator-hub/main/tests/security-restrictions.test.ts
+++ b/packages/creator-hub/main/tests/security-restrictions.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // `security-restrictions` registers its handlers as a side effect of being imported, so the
@@ -148,9 +151,42 @@ describe('response header rules', () => {
     });
   });
 
-  describe('when the request is for an unrelated external origin', () => {
+  /**
+   * The origins the inspector will put in a markdown `<iframe>`, read from its own allowlist
+   * rather than repeated here — a copy would agree with itself while drifting from the source.
+   */
+  function markdownIframeOrigins() {
+    const source = readFileSync(
+      resolve(
+        dirname(fileURLToPath(import.meta.url)),
+        '../../../inspector/src/components/SceneInfoPanel/MarkdownRenderer/utils.ts',
+      ),
+      'utf8',
+    );
+    const allowlist = source.match(/ALLOWED_EXTERNAL_IFRAME_ORIGINS[^[]*\[([^\]]*)\]/s);
+    return [...(allowlist?.[1] ?? '').matchAll(/'(https:\/\/[^']+)'/g)].map(match => match[1]);
+  }
+
+  describe('when the request is for an origin the inspector embeds in a markdown iframe', () => {
+    const origins = markdownIframeOrigins();
+
+    it('should have found the allowlist, or every assertion below passes vacuously', () => {
+      expect(origins.length).toBeGreaterThan(0);
+    });
+
+    it('should get an embedder policy, since an isolated document cannot embed a frame without one', () => {
+      for (const origin of origins) {
+        expect(
+          subject.valuesFor(`${origin}/embed/abc`, 'Cross-Origin-Embedder-Policy'),
+          `${origin} is embedded by the isolated inspector document but gets no embedder policy, so the frame is blocked with ERR_BLOCKED_BY_RESPONSE`,
+        ).toEqual(['credentialless']);
+      }
+    });
+  });
+
+  describe('when the request is for an external origin the app links to but never embeds', () => {
     it('should add no cross-origin headers', () => {
-      const url = 'https://www.youtube.com/embed/abc';
+      const url = 'https://docs.decentraland.org/introduction';
 
       expect(subject.valuesFor(url, 'Cross-Origin-Embedder-Policy')).toEqual([]);
       expect(subject.valuesFor(url, 'Cross-Origin-Opener-Policy')).toEqual([]);

--- a/packages/inspector/build.js
+++ b/packages/inspector/build.js
@@ -44,13 +44,6 @@ async function main() {
 
   if (WATCH_MODE) {
     await context.watch();
-    // esbuild serves the bundle + public/ on an internal port; a thin proxy in
-    // front stamps COOP/COEP on every response. The bevy-explorer engine wasm
-    // (served under public/bevy-engine) uses SharedArrayBuffer threads, which
-    // the browser only enables for cross-origin-isolated documents — i.e. ones
-    // served with `Cross-Origin-Opener-Policy: same-origin` +
-    // `Cross-Origin-Embedder-Policy: require-corp`. esbuild's serve() can't set
-    // response headers, so we can't add them there directly.
     const internal = await context.serve({ servedir: 'public' });
     const publicPort = await serveWithCrossOriginIsolation(internal.host, internal.port);
     console.log(`> Serving on http://localhost:${publicPort}`);
@@ -77,6 +70,21 @@ async function main() {
 // crossOriginIsolated (so SharedArrayBuffer works) while fetching cross-origin
 // no-cors subresources without credentials. This matches what the engine's own
 // service worker sets (see bevy-engine/service_worker.js + its issue #807 note).
+/**
+ * Merges `overrides` over `upstream`, dropping every casing of each overridden name.
+ *
+ * Node lowercases the header names it receives, so spreading capitalized overrides on top of
+ * them emits BOTH spellings as two header lines rather than replacing anything. The browser
+ * joins those into `credentialless, credentialless`, fails to parse it as a structured field and
+ * falls back to `unsafe-none` — isolation silently off, with headers that read as if it were on.
+ * esbuild does not currently send these, so this only matters the day something upstream does.
+ */
+function withIsolationHeaders(upstream, overrides) {
+  const overridden = new Set(Object.keys(overrides).map(name => name.toLowerCase()));
+  const kept = Object.entries(upstream).filter(([name]) => !overridden.has(name.toLowerCase()));
+  return { ...Object.fromEntries(kept), ...overrides };
+}
+
 function serveWithCrossOriginIsolation(upstreamHost, upstreamPort) {
   const server = http.createServer((req, res) => {
     const proxyReq = http.request(
@@ -88,13 +96,15 @@ function serveWithCrossOriginIsolation(upstreamHost, upstreamPort) {
         headers: req.headers,
       },
       proxyRes => {
-        res.writeHead(proxyRes.statusCode ?? 502, {
-          ...proxyRes.headers,
-          'Cross-Origin-Opener-Policy': 'same-origin',
-          'Cross-Origin-Embedder-Policy': 'credentialless',
-          // Lets the isolated top document embed the engine's own subresources.
-          'Cross-Origin-Resource-Policy': 'cross-origin',
-        });
+        res.writeHead(
+          proxyRes.statusCode ?? 502,
+          withIsolationHeaders(proxyRes.headers, {
+            'Cross-Origin-Opener-Policy': 'same-origin',
+            'Cross-Origin-Embedder-Policy': 'credentialless',
+            // Lets the isolated top document embed the engine's own subresources.
+            'Cross-Origin-Resource-Policy': 'cross-origin',
+          }),
+        );
         proxyRes.pipe(res);
       },
     );


### PR DESCRIPTION
Stacked on #1487 — it touches the same `embedFilter`, so it must merge after. Review that one first.

## Context and Problem Statement

While fixing #1485 I checked whether anything else was exposed to the same root cause. One thing is, and it is **already broken in production**.

The inspector's markdown renderer (`SceneInfoPanel/MarkdownRenderer/AssetIframe.tsx`) embeds YouTube and Vimeo players. Those frames sit inside the same cross-origin-isolated inspector document, and a document with COEP set may only embed a cross-origin *frame* whose own response also carries COEP. Neither player does:

- **Vimeo** sends no COEP at all.
- **YouTube** sends only `Cross-Origin-Embedder-Policy-Report-Only: require-corp`. Report-only does **not** satisfy an embedder's requirement — it reports, it does not opt in.

So both have been blocked with `ERR_BLOCKED_BY_RESPONSE` since #1363 isolated their embedder in 0.44.0 — the same release that caused #1485.

**It went unreported because it fails the quieter way.** `AssetIframe.tsx:27` returns `null` when the src is missing or the origin disallowed, so there is no spinner to hang: a scene's video just silently renders nothing. #1485 got `0-critical` because it froze a dialog; this one produced no symptom anyone could file.

## Solution

Key changes:
- Add the three origins from the inspector's own markdown allowlist to `embedFilter`, so their responses get COEP stamped and become embeddable.
- **Tie the two lists together with a test** rather than trusting them to stay in sync. It reads `ALLOWED_EXTERNAL_IFRAME_ORIGINS` out of the inspector's source instead of repeating it, so adding a fourth embed origin without extending the filter fails the build instead of shipping another silently dead frame. It also asserts the allowlist was actually found — a regex matching nothing would otherwise make the whole check pass vacuously.
- Fix the same latent duplicate-header bug in the inspector's dev proxy (`build.js`). Node lowercases the header names it receives, so spreading capitalized isolation headers over `proxyRes.headers` would emit both spellings as two lines. esbuild does not send those headers today so nothing is broken, but the merge no longer depends on that staying true.
- Drop a stale comment in `build.js` that claimed `require-corp` while the code sets `credentialless` — actively misleading in a file about exactly this, and already covered accurately by the docstring below it.

## Testing

- [x] `make test` — 1413 passing across all six workspaces; `make typecheck`, `make lint`, `make format` clean
- [x] **The drift test fails before the fix**, naming the consequence: `https://www.youtube.com is embedded by the isolated inspector document but gets no embedder policy, so the frame is blocked with ERR_BLOCKED_BY_RESPONSE`
- [x] **Both failure and fix verified in real Electron 40 against the live players**, since a unit test can assert the handler's output but not the browser's verdict on it:

  | Player | Without COEP stamped | With COEP stamped |
  |---|---|---|
  | `youtube.com/embed/…` | `ERR_BLOCKED_BY_RESPONSE` | loads, 1 header line |
  | `player.vimeo.com/video/…` | `ERR_BLOCKED_BY_RESPONSE` | loads, 1 header line |

- [x] The suite caught a second-order effect on its own: the existing "unrelated external origin" case used a YouTube URL, which is no longer an example of one. Moved to a docs URL.
- [ ] Manual check of a scene whose markdown embeds a video (not yet run in a packaged build)

**No test for `build.js`**: it exports nothing and sits outside the vitest `include`, and the mechanism it guards is already covered by `setHeader`'s suite in #1487. Verified by hand that Node emits both spellings — `raw header lines: 2`, joined to `"credentialless, credentialless"` — and that the new helper collapses them to one while preserving other headers.

## Impact

Video embeds in scene markdown render again. Beyond that, the drift test converts this whole class from "remember to update two lists" into a build failure.

One consideration worth a reviewer's eye: stamping `credentialless` on a third-party player means **its** cross-origin subresources load without credentials. That is fine for public video, which is what scene markdown embeds, but it would matter for private/signed Vimeo or any cookie-dependent YouTube feature. Both players load fine in the verification above.

## Screenshots

Not included — this restores an embed that currently renders nothing. The observable difference is the absence of `ERR_BLOCKED_BY_RESPONSE`, captured in the table above.