### PR TITLE
fix: bound emote detection so a stalled model cannot empty the import dialog

### DIFF
--- a/packages/inspector/src/components/AssetPreview/utils.spec.ts
+++ b/packages/inspector/src/components/AssetPreview/utils.spec.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isEmote } from './utils';
+
+const babylon = vi.hoisted(() => ({ loadAssetContainer: vi.fn() }));
+
+vi.mock('@babylonjs/core/Engines/engine', () => ({
+  Engine: class {
+    dispose() {}
+  },
+}));
+
+vi.mock('@babylonjs/core/scene', () => ({
+  Scene: class {
+    dispose() {}
+  },
+}));
+
+vi.mock('@babylonjs/core/Loading/sceneLoader', () => ({
+  SceneLoader: { LoadAssetContainerAsync: babylon.loadAssetContainer },
+}));
+
+vi.mock('@babylonjs/loaders/glTF', () => ({}));
+
+/** A loaded container rigged to the avatar armature, which is what makes a model an emote. */
+const emoteContainer = {
+  animationGroups: [{}],
+  transformNodes: [{ name: 'Armature', getChildren: () => [{ name: 'Avatar_Head' }] }],
+};
+
+describe('isEmote', () => {
+  let model: File;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:model');
+    globalThis.URL.revokeObjectURL = vi.fn();
+    babylon.loadAssetContainer.mockReset();
+    model = new File([], 'model.glb');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('when the model loads and is rigged to the avatar armature', () => {
+    it('should be an emote', async () => {
+      babylon.loadAssetContainer.mockResolvedValue(emoteContainer);
+
+      await expect(isEmote(model)).resolves.toBe(true);
+    });
+  });
+
+  describe('when the loader rejects', () => {
+    it('should not be an emote, rather than propagate', async () => {
+      babylon.loadAssetContainer.mockRejectedValue(new Error('corrupt glb'));
+
+      await expect(isEmote(model)).resolves.toBe(false);
+    });
+  });
+
+  // The import dialog awaits one of these per selected file before it renders anything, so a load
+  // that never settles leaves the modal permanently empty with nothing logged.
+  describe('when the loader never settles', () => {
+    it('should give up and report not an emote so the dialog can still open', async () => {
+      babylon.loadAssetContainer.mockReturnValue(new Promise(() => {}));
+
+      const detecting = isEmote(model);
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await expect(detecting).resolves.toBe(false);
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/inspector/src/components/AssetPreview/utils.ts
+++ b/packages/inspector/src/components/AssetPreview/utils.ts
@@ -74,26 +74,46 @@ export function toEmoteWithBlobs(file: File, resources: File[] = []): EmoteWithB
   };
 }
 
+const DETECTION_TIMEOUT = 30_000;
+
+/**
+ * Whether a file is an emote, by loading it and inspecting its rig.
+ *
+ * The import dialog awaits one of these per selected file before it renders anything, so a load
+ * that never settles would leave the modal permanently empty with nothing logged. The loader has
+ * no timeout of its own, so it races one that rejects into the catch below — `false` is the safe
+ * default either way, since it only means the file is treated as an ordinary model.
+ */
 export async function isEmote(file: File): Promise<boolean> {
   const url = URL.createObjectURL(file);
   const canvas = document.createElement('canvas');
   const engine = new Engine(canvas, false);
   const scene = new Scene(engine);
+  let timeout: ReturnType<typeof setTimeout> | undefined;
 
   try {
-    const result = await SceneLoader.LoadAssetContainerAsync(
-      '',
-      url,
-      scene,
-      undefined,
-      file.name.endsWith('.gltf') ? '.gltf' : '.glb',
-    );
+    const result = await Promise.race([
+      SceneLoader.LoadAssetContainerAsync(
+        '',
+        url,
+        scene,
+        undefined,
+        file.name.endsWith('.gltf') ? '.gltf' : '.glb',
+      ),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Timed out after ${DETECTION_TIMEOUT}ms`)),
+          DETECTION_TIMEOUT,
+        );
+      }),
+    ]);
 
     return isEmoteContainer(result);
   } catch (err) {
     console.error('Error checking if file is emote:', err);
     return false;
   } finally {
+    clearTimeout(timeout);
     URL.revokeObjectURL(url);
     scene.dispose();
     engine.dispose();


### PR DESCRIPTION
Independent of #1487 and #1488 — different root cause, no shared files, mergeable in any order.

## Context and Problem Statement

Found while auditing for other instances of the #1485 silent-hang shape. This one is a genuinely different cause on a path that #1485's fix cannot reach.

`useSliderAssets.ts:15-24` awaits `isEmote` for every selected file through `Promise.all` before the slider renders anything, and `isEmote` awaits Babylon's `LoadAssetContainerAsync` with no timeout. Its `try/catch` covers a **rejection**, not a load that simply **never settles** — a corrupt model or a lost WebGL context. When that happens `assets` stays `[]`, `Slider.tsx:107` returns `null`, and the import modal opens completely blank: nothing rendered, nothing logged, no way forward but cancel.

This runs *before* any preview mounts, so the preview-level deadline added in #1487 cannot cover it. For contrast, the two other places that wait on an external signal — `engine-iframe.ts:155` and `iframe-transport.ts:88` — both bound their waits already; this path was the outlier.

## Solution

Key changes:
- Race the loader against a timeout that **rejects into the existing catch**, so the failure path is the one already there rather than a new branch. It logs and answers `false`, and `false` only ever means "treat this as an ordinary model".
- Because `isEmote` now always settles, `Promise.all` upstream is guaranteed to settle too — so `useSliderAssets` needs **no change at all**. Fixing it at the root kept this to one source file.
- Clear the timer in the existing `finally`, alongside the URL revoke and the scene/engine dispose, so a fast load leaves nothing pending.

## Testing

- [x] `make test` — 1413 passing across all six workspaces; `make typecheck`, `make lint`, `make format` clean
- [x] **The new test reproduces the hang before the fix**: with the loader stubbed to a promise that never settles, the case fails with `Test timed out in 10000ms` — the test hanging exactly as the dialog does. The two sibling cases (loads-and-is-an-emote, loader-rejects) pass throughout, which is what proves the mocks are faithful rather than the assertion being trivially true.
- [x] New `utils.spec.ts` covers all three outcomes: rigged model → emote, rejection → not an emote, never settles → gives up, answers false, and logs.

## Impact

A model Babylon cannot finish loading no longer empties the import dialog: detection gives up after 30s, logs why, and the file imports as an ordinary model. Worst case shifts from "blank modal, cancel is the only option" to "a model that might have been an emote is imported as a static one" — and it is logged, so it is diagnosable rather than invisible.

Note the 30s only elapses in the pathological case. A normal load resolves in milliseconds and clears the timer.

## Screenshots

Not applicable — no UI change. The difference is a modal that opens rather than one that stays blank.