### PR TITLE
fix: Analytics list silently dropped deployed scenes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,14 +127,10 @@ Files matching `*.styled.ts` / `*.styled.tsx` must follow these rules:
 - No comments, no `!important`, no inline styles in styled component files.
 - Keep styled components in separate `Component.styled.ts` files alongside `Component.tsx`.
 
-## Testing Conventions
+## Gotchas
 
-- Test framework: **Vitest** (not Jest, though patterns are similar). Tests use `describe`/`it`/`beforeEach`.
-- Structure tests with `describe("when ...", () => { ... })` for context, `it("should ...", () => { ... })` for behavior.
-- Scope mocks and test data to the specific `describe` block that needs them (not globally).
-- Variables and mocks go in `beforeEach`, cleanup in `afterEach`.
-- React: use `@testing-library/react` with accessible queries (`getByRole`, `getByLabelText`).
-- E2E: Playwright for both Electron app and web inspector.
+Hard-won traps that reading the code does not reveal. Testing-specific ones live
+in [`docs/testing-standards.md`](docs/testing-standards.md).
 
 ### Redux state freeze + in-place mutating helpers
 
@@ -146,27 +142,6 @@ passed payloads read from Redux. Deep-clone (`structuredClone(x)`) at the
 boundary before passing Redux-sourced data to any mutating helper. Symptoms
 when missed: writes silently no-op, original placeholder tokens (e.g.
 `{assetPath}/...`) survive into the engine.
-
-### Asset-packs circular imports & vitest
-
-`packages/asset-packs/src/definitions.ts` re-exports every internal module via
-`export * from './...'`. Production bundlers hoist these bindings, but the
-Vitest loader resolves the re-export *before* the leaf module finishes
-evaluating — so importing constants like `COMPONENTS_WITH_ID` or `getNextId`
-through `definitions.ts` will see them as `undefined` at call time inside the
-same source tree. In `asset-packs` source files and tests, import these
-constants from the leaf module directly (`from './id'`, `from './types'`,
-etc.) rather than via the `definitions.ts` barrel.
-
-### Vitest fake timers leak across `describe` blocks
-
-`vi.useFakeTimers()` in one `describe` stays in effect for every later
-`describe` in the same file — vitest does not reset it between blocks. A later
-test that awaits a real `setTimeout` (a retry/backoff helper, a debounced
-promise) then hangs to the 5s test timeout with no indication why.
-`packages/creator-hub/shared/tests/utils.spec.ts` is the live case: the
-`debounce` and `debounceByKey` suites enable them and never restore, so anything
-added below needs its own `beforeEach(() => vi.useRealTimers())`.
 
 ### Asset-pack composite placeholders must resolve before the engine serializes
 
@@ -219,4 +194,4 @@ Skills live in `.ai/skills/*/SKILL.md`. Read the relevant `SKILL.md` when a task
 Read the relevant standards doc when the task touches its domain:
 
 - [`docs/coding-standards.md`](docs/coding-standards.md) — React patterns and antipatterns (controlled-input prop-sync, memoized components built in render). Read when touching `TextField`, the tree `<Input>`, or building any component with a buffered value.
-- [`docs/testing-standards.md`](docs/testing-standards.md) — E2E patterns (real keyboard input vs `fill()`, locators vs `ElementHandle`s, focus-actually-on-element gates, outcome waits vs fixed sleeps). Read when writing or debugging Playwright tests.
+- [`docs/testing-standards.md`](docs/testing-standards.md) — how to write a test here, plus every testing gotcha: Vitest conventions and mocking traps (`vi.mock` factories replacing whole modules, fake timers leaking across `describe`s), and E2E patterns (real keyboard input vs `fill()`, locators vs `ElementHandle`s, focus-actually-on-element gates, outcome waits vs fixed sleeps). Read before writing or debugging any test.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,16 @@ same source tree. In `asset-packs` source files and tests, import these
 constants from the leaf module directly (`from './id'`, `from './types'`,
 etc.) rather than via the `definitions.ts` barrel.
 
+### Vitest fake timers leak across `describe` blocks
+
+`vi.useFakeTimers()` in one `describe` stays in effect for every later
+`describe` in the same file — vitest does not reset it between blocks. A later
+test that awaits a real `setTimeout` (a retry/backoff helper, a debounced
+promise) then hangs to the 5s test timeout with no indication why.
+`packages/creator-hub/shared/tests/utils.spec.ts` is the live case: the
+`debounce` and `debounceByKey` suites enable them and never restore, so anything
+added below needs its own `beforeEach(() => vi.useRealTimers())`.
+
 ### Asset-pack composite placeholders must resolve before the engine serializes
 
 Asset-pack `composite.json` files encode references as portable placeholders:

--- a/docs/testing-standards.md
+++ b/docs/testing-standards.md
@@ -2,6 +2,87 @@
 
 Project-specific patterns for tests in this repo. See also: [coding-standards.md](./coding-standards.md).
 
+## Writing a test
+
+- Test framework: **Vitest** (not Jest, though patterns are similar). Tests use `describe`/`it`/`beforeEach`.
+- Structure tests with `describe("when ...", () => { ... })` for context, `it("should ...", () => { ... })` for behavior.
+- Scope mocks and test data to the specific `describe` block that needs them (not globally).
+- Variables and mocks go in `beforeEach`, cleanup in `afterEach`.
+- React: use `@testing-library/react` with accessible queries (`getByRole`, `getByLabelText`).
+- E2E: Playwright for both Electron app and web inspector.
+
+Write the failing test first. When a test had to be written after the fact,
+prove it can still fail by stashing the implementation and re-running it —
+a test that has never been red is not evidence of anything:
+
+```bash
+git stash push -- packages/creator-hub/renderer/src/lib/land.ts
+npm run test:renderer -- src/lib/land.spec.ts   # must fail here
+git stash pop
+```
+
+## Unit tests (Vitest)
+
+### `vi.mock` with a factory replaces the whole module
+
+A `vi.mock(path, () => ({ ... }))` factory is the *entire* module from then on;
+anything the real module exports but the factory omits becomes `undefined`. That
+turns adding an export to a source file into a failure in a spec that never
+mentioned it. Sometimes vitest names the problem:
+
+```
+Error: [vitest] No "getWorldSettingsInitialState" export is defined on the "../management/utils" mock.
+```
+
+but when the missing export is only *called* rather than read at import time, it
+fails as a plain `TypeError` deep inside whatever awaited it — a rejected thunk
+surfacing as `expected [] to have a length of 1`, with nothing pointing at the
+mock. Prefer a partial mock, which keeps the real module and overrides only what
+the test needs:
+
+```ts
+vi.mock('./utils', async importOriginal => ({
+  ...(await importOriginal<ManagementUtils>()),
+  fetchWorldSceneCoords: vi.fn(async () => [{ x: 0, y: 0 }]),
+}));
+```
+
+Note that `importOriginal` does **not** intercept same-module calls: a function
+kept real still calls its real neighbours, not their mocked versions.
+
+### Type `importOriginal` with a namespace import, not `typeof import()`
+
+`@typescript-eslint/consistent-type-imports` rejects inline `import()` type
+annotations, so the obvious `importOriginal<typeof import('./utils')>()` fails
+lint with ``  `import()` type annotations are forbidden``. Import the namespace as
+a type instead — it is erased at runtime, so it is safe inside a hoisted
+`vi.mock` factory:
+
+```ts
+import type * as ManagementUtils from './utils';
+```
+
+### Vitest fake timers leak across `describe` blocks
+
+`vi.useFakeTimers()` in one `describe` stays in effect for every later
+`describe` in the same file — vitest does not reset it between blocks. A later
+test that awaits a real `setTimeout` (a retry/backoff helper, a debounced
+promise) then hangs to the 5s test timeout with no indication why.
+`packages/creator-hub/shared/tests/utils.spec.ts` is the live case: the
+`debounce` and `debounceByKey` suites enable them and never restore, so anything
+added below needs its own `beforeEach(() => vi.useRealTimers())`.
+
+### Asset-packs circular imports & vitest
+
+`packages/asset-packs/src/definitions.ts` re-exports every internal module via
+`export * from './...'`. Production bundlers hoist these bindings, but the
+Vitest loader resolves the re-export *before* the leaf module finishes
+evaluating — so importing constants like `COMPONENTS_WITH_ID` or `getNextId`
+through `definitions.ts` will see them as `undefined` at call time inside the
+same source tree. In `asset-packs` source files and tests, import these
+constants from the leaf module directly (`from './id'`, `from './types'`,
+etc.) rather than via the `definitions.ts` barrel.
+
 ## E2E (Playwright)
 
 ### Type with real keyboard events, not `locator.fill()`

--- a/docs/testing-standards.md
+++ b/docs/testing-standards.md
@@ -50,6 +50,45 @@ vi.mock('./utils', async importOriginal => ({
 Note that `importOriginal` does **not** intercept same-module calls: a function
 kept real still calls its real neighbours, not their mocked versions.
 
+A module mocked this way also loses its **default** export unless the factory
+provides one. `lib/worlds` does `import fetch from 'decentraland-crypto-fetch'`,
+so a factory without a `default` leaves every worlds request calling `undefined`
+— surfacing as `Failed to fetch worlds` with zero fetch calls recorded, and
+nothing naming the mock:
+
+```ts
+vi.mock('decentraland-crypto-fetch', () => ({
+  default: (input: RequestInfo | URL, init?: RequestInit) => globalThis.fetch(input, init),
+  signedHeaderFactory: () => () => new Map(),
+}));
+```
+
+`importOriginal<T>()` takes a namespace type import
+(`import type * as Utils from './utils'`), but only for modules that declare
+their own exports. A barrel that re-exports with `export *` (`../Navbar`,
+`modules/store/land`) fails `TS2709: Cannot use namespace as a type`; there,
+drop the generic and spread `(await importOriginal()) as object`.
+
+### Rendering a page component needs a theme, and no navbar
+
+`decentraland-ui2` components read theme tokens through emotion, so a bare
+`render()` throws before the page under test appears. Wrap in
+`ThemeProvider theme={dark}` from `decentraland-ui2/dist/theme`, plus
+`MemoryRouter` for anything calling `useNavigate`.
+
+That is still not enough for a page carrying the navbar: `AvatarFace` reads a
+palette slice this environment does not populate and throws
+`Cannot read properties of undefined (reading 'secondary')` from
+`AvatarFace.styled.ts` — a stack that names neither your test nor your page.
+Stub the component and keep the enum:
+
+```ts
+vi.mock('../Navbar', async importOriginal => ({
+  ...((await importOriginal()) as object),
+  Navbar: () => null,
+}));
+```
+
 ### Type `importOriginal` with a namespace import, not `typeof import()`
 
 `@typescript-eslint/consistent-type-imports` rejects inline `import()` type

--- a/packages/creator-hub/renderer/src/components/AnalyticsPage/atScale.spec.tsx
+++ b/packages/creator-hub/renderer/src/components/AnalyticsPage/atScale.spec.tsx
@@ -1,0 +1,269 @@
+import type { ReactNode } from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dark, ThemeProvider } from 'decentraland-ui2/dist/theme';
+
+import { metrics } from '#preload';
+import { AuthServerProvider } from '/@/lib/auth';
+import { actions as placeAnalyticsActions, selectors } from '/@/modules/store/placeAnalytics';
+
+import { createTestStore, type TestStore } from '../../../tests/utils/testStore';
+
+const TEST_ADDRESS = '0x1234567890123456789012345678901234567890';
+const WORLD_COUNT = 120;
+const GENESIS_COUNT = 80;
+const TOTAL = WORLD_COUNT + GENESIS_COUNT;
+
+vi.mock('#store', async () => {
+  const { useDispatch, useSelector } = await import('react-redux');
+  return { useDispatch, useSelector };
+});
+
+vi.mock('/@/lib/auth', () => ({
+  AuthServerProvider: { getAccount: vi.fn(() => '0x1234567890123456789012345678901234567890') },
+}));
+
+vi.mock('/@/hooks/useAuth', () => ({ useAuth: () => ({ isSignedIn: true }) }));
+
+/** The navbar's avatar reads theme tokens this environment does not populate, and
+ * nothing here is about the navbar. `NavbarItem` stays real — it is an enum the
+ * page reads. */
+vi.mock('../Navbar', async importOriginal => ({
+  ...((await importOriginal()) as object),
+  Navbar: () => null,
+}));
+
+vi.mock('@dcl/single-sign-on-client', () => ({
+  localStorageGetIdentity: () => ({
+    ephemeralIdentity: { address: '0x1234567890123456789012345678901234567890' },
+  }),
+}));
+
+/**
+ * `lib/worlds` imports this module's *default* export as its fetch, so the mock
+ * has to keep one — a factory replaces the whole module, and an absent default
+ * leaves `worlds.ts` calling undefined.
+ */
+vi.mock('decentraland-crypto-fetch', () => ({
+  default: (input: RequestInfo | URL, init?: RequestInit) => globalThis.fetch(input, init),
+  signedHeaderFactory: () => () => new Map([['x-identity-auth-chain-0', 'stub']]),
+}));
+
+/**
+ * LAND discovery goes through the rentals and LAND subgraphs, which this suite
+ * is not exercising: the parcels are handed over directly so the scenes
+ * deployed on them still resolve for real.
+ */
+vi.mock('/@/modules/store/land', async importOriginal => {
+  const actual = (await importOriginal()) as object;
+  const land = Array.from({ length: 80 }, (_, index) => ({
+    id: `parcel-${index}`,
+    x: index,
+    y: 0,
+  }));
+  return {
+    ...actual,
+    fetchLandList: vi.fn(() => () => {
+      const dispatched = Promise.resolve({ land }) as Promise<{ land: unknown[] }> & {
+        unwrap: () => Promise<{ land: unknown[] }>;
+      };
+      dispatched.unwrap = () => Promise.resolve({ land });
+      return dispatched;
+    }),
+  };
+});
+
+const WORLDS = Array.from({ length: WORLD_COUNT }, (_, index) => ({
+  name: `world-${String(index).padStart(3, '0')}.dcl.eth`,
+  owner: TEST_ADDRESS,
+  title: `World ${index}`,
+  description: '',
+  thumbnail_hash: null,
+  last_deployed_at: '2026-08-01T00:00:00Z',
+  deployed_scenes: 1,
+}));
+
+const json = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  json: () => Promise.resolve(body),
+});
+
+/** The three services the list is assembled from, answering at full scale. */
+function installNetwork() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.includes('/worlds?')) {
+        const params = new URL(url).searchParams;
+        const offset = Number(params.get('offset') ?? 0);
+        const limit = Number(params.get('limit') ?? 100);
+        return Promise.resolve(
+          json({ worlds: WORLDS.slice(offset, offset + limit), total: WORLDS.length }),
+        );
+      }
+
+      if (url.includes('/scenes?')) {
+        const world = decodeURIComponent(url.split('/world/')[1].split('/scenes')[0]);
+        const index = Number(world.match(/world-(\d+)/)?.[1] ?? 0);
+        return Promise.resolve(
+          json({
+            scenes: [{ parcels: [], entity: { metadata: { scene: { base: `${index},1` } } } }],
+            total: 1,
+          }),
+        );
+      }
+
+      if (url.includes('/content/entities/active')) {
+        const pointers: string[] = JSON.parse(String(init?.body)).pointers;
+        return Promise.resolve(
+          json(
+            pointers.map(pointer => ({
+              id: `scene-${pointer}`,
+              timestamp: 1_700_000_000_000,
+              metadata: { scene: { base: pointer }, display: { title: `Genesis ${pointer}` } },
+            })),
+          ),
+        );
+      }
+
+      return Promise.reject(new Error(`unstubbed request: ${url}`));
+    }),
+  );
+}
+
+/** Answers each batched metrics request positionally, as the service does. */
+function installMetrics() {
+  vi.mocked(metrics.request).mockImplementation(
+    (request: any) =>
+      Promise.resolve({
+        ok: true,
+        data: {
+          exported_at: '2026-08-14T00:00:00.000Z',
+          source: 'test',
+          locations: request.body.locations.map((location: any, index: number) => ({
+            ...location,
+            location_key: `key-${index}`,
+            builder_project_id: null,
+            metrics: { unique_visits_60d: [{ series: 'all', period: null, value: 10 }] },
+          })),
+        },
+      }) as any,
+  );
+}
+
+describe('the analytics list at full scale', () => {
+  let store: TestStore;
+
+  beforeEach(() => {
+    vi.mocked(AuthServerProvider.getAccount).mockReturnValue(TEST_ADDRESS);
+    installNetwork();
+    installMetrics();
+    store = createTestStore();
+  });
+
+  describe('when the wallet holds more scenes than any one request returns', () => {
+    it('should answer with every scene, worlds and Genesis City alike', async () => {
+      await store.dispatch(placeAnalyticsActions.fetchAnalytics() as never);
+
+      const { places, status } = store.getState().placeAnalytics;
+      expect(status).toBe('succeeded');
+      expect(places).toHaveLength(TOTAL);
+      expect(places.filter(place => place.location.world)).toHaveLength(WORLD_COUNT);
+      expect(places.filter(place => !place.location.world)).toHaveLength(GENESIS_COUNT);
+    });
+
+    it('should page the worlds list rather than stopping at the first page', async () => {
+      await store.dispatch(placeAnalyticsActions.fetchAnalytics() as never);
+
+      const worldsCalls = vi
+        .mocked(globalThis.fetch)
+        .mock.calls.filter(([url]) => String(url).includes('/worlds?'));
+
+      expect(worldsCalls.length).toBeGreaterThan(1);
+      expect(store.getState().placeAnalytics.places.at(-1)).toBeDefined();
+    });
+
+    it('should batch the metrics request and keep every answer with what it asked for', async () => {
+      await store.dispatch(placeAnalyticsActions.fetchAnalytics() as never);
+
+      const batches = vi.mocked(metrics.request).mock.calls.map(([request]: any) => request);
+      expect(batches).toHaveLength(Math.ceil(TOTAL / 100));
+
+      const { places, metricsByPlaceId } = store.getState().placeAnalytics;
+      for (const place of places) {
+        const answer = metricsByPlaceId[place.placeId];
+        expect(answer).toBeDefined();
+        expect({ x: answer.x, y: answer.y }).toEqual({ x: place.location.x, y: place.location.y });
+      }
+    });
+
+    it('should render a row for every scene, not just the first batch', async () => {
+      await store.dispatch(placeAnalyticsActions.fetchAnalytics() as never);
+
+      expect(selectors.getVisiblePlaces(store.getState())).toHaveLength(TOTAL);
+    });
+  });
+
+  describe('when one world cannot be listed', () => {
+    beforeEach(() => {
+      const failing = 'world-042.dcl.eth';
+      const realFetch = globalThis.fetch;
+      vi.stubGlobal(
+        'fetch',
+        vi.fn((input: RequestInfo | URL, init?: RequestInit) =>
+          String(input).includes(encodeURIComponent(failing))
+            ? Promise.resolve({ ok: false, status: 503 })
+            : (realFetch as any)(input, init),
+        ),
+      );
+    });
+
+    it('should fail loudly rather than answer with a shorter list', async () => {
+      await store.dispatch(placeAnalyticsActions.fetchAnalytics() as never);
+
+      const { status, error, places } = store.getState().placeAnalytics;
+      expect(status).toBe('failed');
+      expect(error).toMatch(/world-042\.dcl\.eth/);
+      expect(places).toHaveLength(0);
+    });
+  });
+});
+
+describe('the analytics page at full scale', () => {
+  let store: TestStore;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <Provider store={store as never}>
+      <ThemeProvider theme={dark}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </ThemeProvider>
+    </Provider>
+  );
+
+  beforeEach(() => {
+    vi.mocked(AuthServerProvider.getAccount).mockReturnValue(TEST_ADDRESS);
+    installNetwork();
+    installMetrics();
+    store = createTestStore();
+  });
+
+  it('should put every scene on screen once the snapshot arrives', async () => {
+    const { AnalyticsPage } = await import('./component');
+
+    render(<AnalyticsPage />, { wrapper });
+
+    await waitFor(() => expect(store.getState().placeAnalytics.status).toBe('succeeded'), {
+      timeout: 15_000,
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('world-000.dcl.eth', { exact: false })).toBeDefined(),
+    );
+    expect(screen.getByText('world-119.dcl.eth', { exact: false })).toBeDefined();
+  }, 30_000);
+});

--- a/packages/creator-hub/renderer/src/lib/analyticsLocations.spec.ts
+++ b/packages/creator-hub/renderer/src/lib/analyticsLocations.spec.ts
@@ -112,6 +112,24 @@ describe('collectAnalyticsPlaces', () => {
     });
   });
 
+  describe('when two scenes resolve to the same coordinate', () => {
+    it('should produce one place, since the metrics are keyed by location', async () => {
+      const places = await collectAnalyticsPlaces(
+        [
+          world('twin.dcl.eth', [
+            { x: 0, y: 0 },
+            { x: 0, y: 0 },
+          ]),
+        ],
+        [],
+        THUMBNAIL,
+      );
+
+      expect(places).toHaveLength(1);
+      expect(new Set(places.map(place => place.placeId)).size).toBe(places.length);
+    });
+  });
+
   describe('when a world holds one scene', () => {
     it('should name the row with the world alone', async () => {
       const [place] = await collectAnalyticsPlaces(

--- a/packages/creator-hub/renderer/src/lib/analyticsLocations.ts
+++ b/packages/creator-hub/renderer/src/lib/analyticsLocations.ts
@@ -130,6 +130,10 @@ async function landPlaces(lands: Land[], fallbackThumbnail: string): Promise<Ana
  * The analytics service enumerates nothing, so the list is assembled here from
  * the wallet's worlds and its LAND. Both are fetched for this list rather than
  * read off the Manage page, whose own list is narrowed by its search and page.
+ *
+ * Deduplicated by location, because that is what analytics answers by: two
+ * scenes sharing a coordinate are one row, and keeping both would key them to
+ * the same metrics and lose one anyway.
  */
 export async function collectAnalyticsPlaces(
   projects: ManagedProject[],
@@ -139,7 +143,5 @@ export async function collectAnalyticsPlaces(
   const genesisCity = await landPlaces(lands, fallbackThumbnail);
   const places = [...worldPlaces(projects, fallbackThumbnail), ...genesisCity];
 
-  // Analytics answers per location, so two scenes sharing a coordinate are one
-  // row. Keeping both would key them to the same metrics and lose one anyway.
   return [...new Map(places.map(place => [place.placeId, place])).values()];
 }

--- a/packages/creator-hub/renderer/src/lib/analyticsLocations.ts
+++ b/packages/creator-hub/renderer/src/lib/analyticsLocations.ts
@@ -128,10 +128,8 @@ async function landPlaces(lands: Land[], fallbackThumbnail: string): Promise<Ana
  * Every scene the signed-in wallet owns or collaborates on.
  *
  * The analytics service enumerates nothing, so the list is assembled here from
- * what the app already knows: its managed worlds and its LAND.
- *
- * ponytail: worlds come from the managed-projects page the app already loads,
- * which is capped at 50; page through `total` if anyone holds more.
+ * the wallet's worlds and its LAND. Both are fetched for this list rather than
+ * read off the Manage page, whose own list is narrowed by its search and page.
  */
 export async function collectAnalyticsPlaces(
   projects: ManagedProject[],
@@ -139,5 +137,9 @@ export async function collectAnalyticsPlaces(
   fallbackThumbnail: string,
 ): Promise<AnalyticsPlace[]> {
   const genesisCity = await landPlaces(lands, fallbackThumbnail);
-  return [...worldPlaces(projects, fallbackThumbnail), ...genesisCity];
+  const places = [...worldPlaces(projects, fallbackThumbnail), ...genesisCity];
+
+  // Analytics answers per location, so two scenes sharing a coordinate are one
+  // row. Keeping both would key them to the same metrics and lose one anyway.
+  return [...new Map(places.map(place => [place.placeId, place])).values()];
 }

--- a/packages/creator-hub/renderer/src/lib/land.spec.ts
+++ b/packages/creator-hub/renderer/src/lib/land.spec.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Coords } from './land';
+
+const fetchMock = vi.fn();
+
+vi.mock('/shared/fetch', () => ({ fetch: (...args: unknown[]) => fetchMock(...args) }));
+
+vi.mock('/@/config', () => ({
+  config: { get: () => 'https://peer.example.org' },
+}));
+
+const { Lands } = await import('./land');
+
+const ok = (scenes: Array<{ id: string }>) => ({
+  ok: true,
+  status: 200,
+  json: () => Promise.resolve(scenes),
+});
+
+const parcels = (count: number): Coords[] =>
+  Array.from({ length: count }, (_, i): Coords => [i, 0]);
+
+describe('Lands.fetchLandPublishedScenes', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('when a scene covers several of the owned parcels', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValue(ok([{ id: 'scene-a' }, { id: 'scene-a' }, { id: 'scene-b' }]));
+    });
+
+    it('should answer once per scene rather than once per parcel', async () => {
+      const scenes = await new Lands().fetchLandPublishedScenes(parcels(3));
+
+      expect(scenes.map(scene => scene.id)).toEqual(['scene-a', 'scene-b']);
+    });
+  });
+
+  describe('when the wallet holds more parcels than one request takes', () => {
+    beforeEach(() => {
+      fetchMock.mockImplementation(() => Promise.resolve(ok([{ id: 'scene-a' }])));
+    });
+
+    it('should ask in batches and declare the body as JSON', async () => {
+      await new Lands().fetchLandPublishedScenes(parcels(250));
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' });
+      expect(JSON.parse(init.body).pointers).toHaveLength(100);
+    });
+
+    it('should allow longer than the default timeout, which a cold batch outlasts', async () => {
+      await new Lands().fetchLandPublishedScenes(parcels(100));
+
+      const [, , timeoutMs] = fetchMock.mock.calls[0];
+      expect(timeoutMs).toBeGreaterThan(5000);
+    });
+  });
+
+  describe('when a batch fails once', () => {
+    beforeEach(() => {
+      fetchMock
+        .mockRejectedValueOnce(new Error('REQUEST_TIMEOUT'))
+        .mockResolvedValue(ok([{ id: 'scene-a' }]));
+    });
+
+    it('should ask again rather than dropping those parcels', async () => {
+      const scenes = await new Lands().fetchLandPublishedScenes(parcels(10));
+
+      expect(scenes.map(scene => scene.id)).toEqual(['scene-a']);
+    });
+  });
+
+  describe('when a batch keeps failing', () => {
+    it('should throw, so the parcels are never silently missing from the list', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 503 });
+
+      await expect(new Lands().fetchLandPublishedScenes(parcels(10))).rejects.toThrow();
+    });
+
+    it('should throw when the request itself keeps erroring', async () => {
+      fetchMock.mockRejectedValue(new Error('REQUEST_TIMEOUT'));
+
+      await expect(new Lands().fetchLandPublishedScenes(parcels(10))).rejects.toThrow(
+        'REQUEST_TIMEOUT',
+      );
+    });
+  });
+
+  describe('when the wallet holds no parcels', () => {
+    it('should ask for nothing', async () => {
+      expect(await new Lands().fetchLandPublishedScenes([])).toEqual([]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/creator-hub/renderer/src/lib/land.ts
+++ b/packages/creator-hub/renderer/src/lib/land.ts
@@ -1,7 +1,7 @@
 import fromUnixTime from 'date-fns/fromUnixTime';
 import { config } from '/@/config';
 import { fetch } from '/shared/fetch';
-import { chunk } from '/shared/utils';
+import { chunk, retry } from '/shared/utils';
 import type { WorldDeployment } from './worlds';
 
 // TheGraph has a limit of a maximum of 1000 results per entity per query
@@ -9,6 +9,12 @@ const MAX_RESULTS = 1000;
 
 /** A large estate can hold hundreds of parcels; the content server takes them in batches. */
 const MAX_POINTERS_PER_REQUEST = 100;
+
+/**
+ * Resolving a batch of pointers answers with every scene's full entity record, so
+ * it runs to hundreds of kilobytes and outlasts the default timeout on a cold cache.
+ */
+const ENTITIES_TIMEOUT_MS = 30_000;
 
 const SEPARATOR = ',';
 
@@ -497,27 +503,29 @@ export class Lands {
    * one scene costs one request and yields one entity, not a hundred.
    */
   public async fetchLandPublishedScenes(coords: Coords[]): Promise<LandDeployment[]> {
-    const byEntityId = new Map<string, LandDeployment>();
+    const groups = await Promise.all(
+      chunk(coords, MAX_POINTERS_PER_REQUEST).map(group =>
+        retry(async () => {
+          const result = await fetch(
+            `${this.PEER_URL}/content/entities/active`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ pointers: group.map(([x, y]) => coordsToId(x, y)) }),
+            },
+            ENTITIES_TIMEOUT_MS,
+          );
 
-    for (const group of chunk(coords, MAX_POINTERS_PER_REQUEST)) {
-      try {
-        const result = await fetch(`${this.PEER_URL}/content/entities/active`, {
-          method: 'POST',
-          body: JSON.stringify({
-            pointers: group.map(([x, y]) => coordsToId(x, y)),
-          }),
-        });
-
-        if (result.ok) {
-          for (const scene of (await result.json()) as LandDeployment[]) {
-            byEntityId.set(scene.id, scene);
+          if (!result.ok) {
+            throw new Error(`Failed to resolve ${group.length} parcels: ${result.status}`);
           }
-        }
-      } catch (error) {
-        // Silent fail - these parcels may not have a scene deployed
-      }
-    }
+          return (await result.json()) as LandDeployment[];
+        }),
+      ),
+    );
 
+    // One scene covers however many of the owned parcels pointed at it.
+    const byEntityId = new Map(groups.flat().map(scene => [scene.id, scene]));
     return [...byEntityId.values()];
   }
 }

--- a/packages/creator-hub/renderer/src/lib/land.ts
+++ b/packages/creator-hub/renderer/src/lib/land.ts
@@ -524,7 +524,6 @@ export class Lands {
       ),
     );
 
-    // One scene covers however many of the owned parcels pointed at it.
     const byEntityId = new Map(groups.flat().map(scene => [scene.id, scene]));
     return [...byEntityId.values()];
   }

--- a/packages/creator-hub/renderer/src/modules/store/management/slice.spec.ts
+++ b/packages/creator-hub/renderer/src/modules/store/management/slice.spec.ts
@@ -3,6 +3,7 @@ import { AuthServerProvider } from '../../../lib/auth';
 import type { ManagedProject } from '../../../../../shared/types/manage';
 import { SortBy, FilterBy, ManagedProjectType } from '../../../../../shared/types/manage';
 import { createTestStore } from '../../../../tests/utils/testStore';
+import type * as ManagementUtils from './utils';
 import {
   actions,
   initialState,
@@ -151,7 +152,8 @@ vi.mock('../../../lib/auth', () => ({
   },
 }));
 
-vi.mock('./utils', () => ({
+vi.mock('./utils', async importOriginal => ({
+  ...(await importOriginal<ManagementUtils>()),
   fetchWorldSceneCoords: vi.fn(async () => [{ x: 0, y: 0 }]),
   getThumbnailUrlFromDeployment: vi.fn((deployment, getContentUrl) => {
     if (deployment?.metadata?.display?.favicon) {
@@ -1024,6 +1026,10 @@ describe('management slice', () => {
   });
 
   describe('fetchWorlds', () => {
+    beforeEach(() => {
+      mockWorldsAPI.fetchWorldScenes.mockResolvedValue({ scenes: [], total: 0 });
+    });
+
     it('should fetch and transform worlds successfully on first page', async () => {
       const mockWorlds = {
         worlds: [

--- a/packages/creator-hub/renderer/src/modules/store/management/slice.ts
+++ b/packages/creator-hub/renderer/src/modules/store/management/slice.ts
@@ -20,10 +20,10 @@ import { fetchLandList, actions as landActions } from '/@/modules/store/land';
 import type { AccountHoldings } from '/@/lib/account';
 import { Account } from '/@/lib/account';
 import {
-  fetchWorldSceneCoords,
   getThumbnailUrlFromDeployment,
   getWorldPermissionsInitialState,
   getWorldSettingsInitialState,
+  toManagedProject,
 } from './utils';
 import type {
   AddressPermissionPayload,
@@ -157,32 +157,7 @@ export const fetchWorlds = createAsyncThunk(
     }
 
     const worldProjects: ManagedProject[] = await Promise.all(
-      worldsResponse.worlds.map(world =>
-        limit(async () => ({
-          id: world.name,
-          displayName: world.name,
-          type: ManagedProjectType.WORLD,
-          role:
-            world.owner?.toLowerCase() === address.toLowerCase()
-              ? WorldRoleType.OWNER
-              : WorldRoleType.COLLABORATOR,
-          deployment: world.owner // If world has never been deployed, backend returns null in the owner and every field.
-            ? {
-                title: world.title || world.name,
-                description: world.description || '',
-                thumbnail: world.thumbnailHash
-                  ? WorldsAPI.getContentSrcUrl(world.thumbnailHash)
-                  : '',
-
-                lastPublishedAt: world.lastDeployedAt
-                  ? new Date(world.lastDeployedAt).getTime()
-                  : 0,
-                scenesCount: world.deployedScenes || 0,
-              }
-            : undefined,
-          scenes: world.deployedScenes ? await fetchWorldSceneCoords(WorldsAPI, world.name) : [],
-        })),
-      ),
+      worldsResponse.worlds.map(world => limit(() => toManagedProject(WorldsAPI, world, address))),
     );
 
     return { worlds: worldProjects, total: worldsResponse.total };

--- a/packages/creator-hub/renderer/src/modules/store/management/utils.spec.ts
+++ b/packages/creator-hub/renderer/src/modules/store/management/utils.spec.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorldData, WorldScene, Worlds } from '../../../lib/worlds';
+import { fetchAllDeployedWorlds, fetchWorldSceneCoords } from './utils';
+
+const TEST_ADDRESS = '0xowner';
+
+const scene = (base: string | undefined, parcels: string[] = []): WorldScene =>
+  ({
+    parcels,
+    entity: base ? { metadata: { scene: { base } } } : {},
+  }) as unknown as WorldScene;
+
+const world = (name: string, deployedScenes = 1): WorldData =>
+  ({
+    name,
+    owner: TEST_ADDRESS,
+    deployedScenes,
+    title: name,
+    description: '',
+    thumbnailHash: null,
+    lastDeployedAt: null,
+  }) as unknown as WorldData;
+
+const createWorldsApi = () =>
+  ({
+    fetchWorlds: vi.fn(),
+    fetchWorldScenes: vi.fn(),
+    getContentSrcUrl: vi.fn((hash: string) => `https://content.com/${hash}`),
+  }) as unknown as Worlds & {
+    fetchWorlds: ReturnType<typeof vi.fn>;
+    fetchWorldScenes: ReturnType<typeof vi.fn>;
+  };
+
+describe('fetchWorldSceneCoords', () => {
+  let worldsApi: ReturnType<typeof createWorldsApi>;
+
+  beforeEach(() => {
+    worldsApi = createWorldsApi();
+  });
+
+  describe('when the world holds more scenes than one page returns', () => {
+    beforeEach(() => {
+      worldsApi.fetchWorldScenes.mockImplementation(
+        (_name: string, params: { limit: number; offset: number }) => {
+          const all = Array.from({ length: 250 }, (_, i) => scene(`${i},0`));
+          return Promise.resolve({
+            scenes: all.slice(params.offset, params.offset + params.limit),
+            total: all.length,
+          });
+        },
+      );
+    });
+
+    it('should page through total rather than stopping at the first page', async () => {
+      const coords = await fetchWorldSceneCoords(worldsApi, 'big.dcl.eth');
+
+      expect(coords).toHaveLength(250);
+      expect(coords?.[249]).toEqual({ x: 249, y: 0 });
+    });
+  });
+
+  describe('when the world holds no scenes', () => {
+    beforeEach(() => {
+      worldsApi.fetchWorldScenes.mockResolvedValue({ scenes: [], total: 0 });
+    });
+
+    it('should report an empty list, which is not a failure', async () => {
+      expect(await fetchWorldSceneCoords(worldsApi, 'empty.dcl.eth')).toEqual([]);
+    });
+  });
+
+  describe('when the scene lookup answers nothing', () => {
+    beforeEach(() => {
+      worldsApi.fetchWorldScenes.mockResolvedValue(null);
+    });
+
+    it('should report null, so a failure is not read as "no scenes"', async () => {
+      expect(await fetchWorldSceneCoords(worldsApi, 'broken.dcl.eth')).toBeNull();
+    });
+  });
+
+  describe('when the scene lookup throws', () => {
+    beforeEach(() => {
+      worldsApi.fetchWorldScenes.mockRejectedValue(new Error('REQUEST_TIMEOUT'));
+    });
+
+    it('should report null rather than an empty list', async () => {
+      expect(await fetchWorldSceneCoords(worldsApi, 'broken.dcl.eth')).toBeNull();
+    });
+  });
+
+  describe('when a later page fails', () => {
+    beforeEach(() => {
+      worldsApi.fetchWorldScenes
+        .mockResolvedValueOnce({ scenes: [scene('0,0')], total: 200 })
+        .mockResolvedValue(null);
+    });
+
+    it('should report null rather than the pages it managed to read', async () => {
+      expect(await fetchWorldSceneCoords(worldsApi, 'flaky.dcl.eth')).toBeNull();
+    });
+  });
+
+  describe('when a scene carries no base in its metadata', () => {
+    beforeEach(() => {
+      worldsApi.fetchWorldScenes.mockResolvedValue({
+        scenes: [scene(undefined, ['10,0', '9,0', '11,0'])],
+        total: 1,
+      });
+    });
+
+    it('should fall back to the numerically lowest parcel, not the lowest string', async () => {
+      expect(await fetchWorldSceneCoords(worldsApi, 'nobase.dcl.eth')).toEqual([{ x: 9, y: 0 }]);
+    });
+  });
+});
+
+describe('fetchAllDeployedWorlds', () => {
+  let worldsApi: ReturnType<typeof createWorldsApi>;
+
+  beforeEach(() => {
+    worldsApi = createWorldsApi();
+    worldsApi.fetchWorldScenes.mockResolvedValue({ scenes: [scene('0,0')], total: 1 });
+  });
+
+  describe('when the wallet holds more worlds than one page returns', () => {
+    beforeEach(() => {
+      const all = Array.from({ length: 120 }, (_, i) => world(`w${i}.dcl.eth`));
+      worldsApi.fetchWorlds.mockImplementation((params: { limit: number; offset: number }) =>
+        Promise.resolve({
+          worlds: all.slice(params.offset, params.offset + params.limit),
+          total: all.length,
+        }),
+      );
+    });
+
+    it('should page through total rather than returning the first page', async () => {
+      const projects = await fetchAllDeployedWorlds(worldsApi, TEST_ADDRESS);
+
+      expect(projects).toHaveLength(120);
+      expect(projects[119].id).toBe('w119.dcl.eth');
+    });
+
+    it('should not carry the manage page search, sort or offset into the query', async () => {
+      await fetchAllDeployedWorlds(worldsApi, TEST_ADDRESS);
+
+      for (const [params] of worldsApi.fetchWorlds.mock.calls) {
+        expect(params).toMatchObject({
+          has_deployed_scenes: true,
+          authorized_deployer: TEST_ADDRESS,
+        });
+        expect(params.search).toBeUndefined();
+        expect(params.sort).toBeUndefined();
+      }
+    });
+  });
+
+  describe('when the worlds request keeps failing', () => {
+    beforeEach(() => {
+      worldsApi.fetchWorlds.mockResolvedValue(null);
+    });
+
+    it('should throw rather than answer with a short list', async () => {
+      await expect(fetchAllDeployedWorlds(worldsApi, TEST_ADDRESS)).rejects.toThrow();
+    });
+  });
+
+  describe('when the worlds request fails once', () => {
+    beforeEach(() => {
+      worldsApi.fetchWorlds
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue({ worlds: [world('recovered.dcl.eth')], total: 1 });
+    });
+
+    it('should retry, since a timeout says nothing about the next call', async () => {
+      const projects = await fetchAllDeployedWorlds(worldsApi, TEST_ADDRESS);
+
+      expect(projects.map(project => project.id)).toEqual(['recovered.dcl.eth']);
+    });
+  });
+
+  describe('when one world cannot be listed', () => {
+    beforeEach(() => {
+      worldsApi.fetchWorlds.mockResolvedValue({
+        worlds: [world('fine.dcl.eth'), world('broken.dcl.eth')],
+        total: 2,
+      });
+      worldsApi.fetchWorldScenes.mockImplementation((name: string) =>
+        name === 'broken.dcl.eth'
+          ? Promise.resolve(null)
+          : Promise.resolve({ scenes: [], total: 0 }),
+      );
+    });
+
+    it('should name it rather than answer with the worlds it could read', async () => {
+      await expect(fetchAllDeployedWorlds(worldsApi, TEST_ADDRESS)).rejects.toThrow(
+        /broken\.dcl\.eth/,
+      );
+    });
+  });
+});

--- a/packages/creator-hub/renderer/src/modules/store/management/utils.ts
+++ b/packages/creator-hub/renderer/src/modules/store/management/utils.ts
@@ -45,9 +45,12 @@ async function readAllPages<T>(
   while (items.length < total) {
     const result = await retry(async () => {
       const answer = await page(items.length);
-      if (!answer) throw new Error('Page not available');
+      if (!answer) throw new Error(`No answer for the page at offset ${items.length}`);
       return answer;
-    }).catch(() => null);
+    }).catch(error => {
+      console.warn('[paged-read] gave up on a page after retries', error);
+      return null;
+    });
 
     if (!result) return null;
     if (result.items.length === 0) break;
@@ -152,7 +155,9 @@ export async function fetchAllDeployedWorlds(
     worlds.map(world => toManagedProject(worldsApi, world, address)),
   );
 
-  const unreadable = projects.filter(project => !project.scenes).map(project => project.id);
+  const unreadable = projects
+    .filter(project => project.scenes === undefined)
+    .map(project => project.id);
   if (unreadable.length > 0) {
     throw new Error(`Failed to list the scenes deployed in ${unreadable.join(', ')}`);
   }

--- a/packages/creator-hub/renderer/src/modules/store/management/utils.ts
+++ b/packages/creator-hub/renderer/src/modules/store/management/utils.ts
@@ -1,37 +1,157 @@
+import type { ManagedProject } from '/shared/types/manage';
+import { ManagedProjectType } from '/shared/types/manage';
+import { retry } from '/shared/utils';
+
 import { parseCoords } from '/@/lib/land';
-import type { WorldScene, Worlds } from '/@/lib/worlds';
+import type { WorldData, WorldScene, Worlds } from '/@/lib/worlds';
+import { WorldRoleType } from '/@/lib/worlds';
 
 import type { WorldPermissionsState, WorldSettingsState } from './slice';
+
+type SceneCoords = { x: number; y: number };
+
+const PAGE_LIMIT = 100;
 
 /**
  * Where a deployed scene sits, as the analytics API keys it.
  *
- * `scene.base` is the authoritative base parcel; the smallest parcel is the
+ * `scene.base` is the authoritative base parcel; the lowest parcel is the
  * fallback for a deployment whose metadata is missing it, so a scene is never
- * dropped for want of a coordinate.
+ * dropped for want of a coordinate. Compared as coordinates rather than as
+ * strings — `"10,0"` sorts before `"9,0"` — because two scenes resolving to the
+ * same base collide downstream.
  */
-function sceneBase(scene: WorldScene): { x: number; y: number } | null {
-  const candidate = scene.entity?.metadata?.scene?.base ?? [...(scene.parcels ?? [])].sort()[0];
-  return candidate ? parseCoords(candidate) : null;
+function sceneBase(scene: WorldScene): SceneCoords | null {
+  const base = scene.entity?.metadata?.scene?.base;
+  if (base) return parseCoords(base);
+
+  const parcels = (scene.parcels ?? []).map(parseCoords).filter(coords => coords !== null);
+  return parcels.sort((a, b) => a.x - b.x || a.y - b.y)[0] ?? null;
+}
+
+/**
+ * Walks an offset-paged endpoint until `total` is covered, retrying a page that
+ * fails and giving up as `null` once it keeps failing.
+ *
+ * These endpoints answer `null` rather than throwing, so a page that never
+ * arrives has to be told apart from one that is genuinely empty.
+ */
+async function readAllPages<T>(
+  page: (offset: number) => Promise<{ items: T[]; total: number } | null>,
+): Promise<T[] | null> {
+  const items: T[] = [];
+  let total = Infinity;
+
+  while (items.length < total) {
+    const result = await retry(async () => {
+      const answer = await page(items.length);
+      if (!answer) throw new Error('Page not available');
+      return answer;
+    }).catch(() => null);
+
+    if (!result) return null;
+    if (result.items.length === 0) break;
+
+    items.push(...result.items);
+    total = result.total;
+  }
+
+  return items;
 }
 
 /**
  * Base coordinates of every scene deployed in a world, for analytics lookups.
  *
- * Never throws: this is enrichment on top of the worlds list, so a world whose
- * scenes cannot be listed still shows up everywhere it did before — it just has
- * no coordinates to ask analytics about.
+ * `null` means the lookup failed, which is a different answer from `[]`: a world
+ * whose scenes cannot be listed contributes no analytics rows, and reading that
+ * as "no scenes" is how a transient failure turns into a silently shorter list.
  */
 export async function fetchWorldSceneCoords(
   worldsApi: Worlds,
   worldName: string,
-): Promise<Array<{ x: number; y: number }>> {
+): Promise<SceneCoords[] | null> {
   try {
-    const response = await worldsApi.fetchWorldScenes(worldName);
-    return (response?.scenes ?? []).map(sceneBase).filter(coords => coords !== null);
+    const scenes = await readAllPages(async offset => {
+      const response = await worldsApi.fetchWorldScenes(worldName, {
+        limit: PAGE_LIMIT,
+        offset,
+      });
+      return response && { items: response.scenes, total: response.total };
+    });
+
+    return scenes?.map(sceneBase).filter(coords => coords !== null) ?? null;
   } catch {
-    return [];
+    return null;
   }
+}
+
+/** A world as the app models it, with the coordinates of everything deployed in it. */
+export async function toManagedProject(
+  worldsApi: Worlds,
+  world: WorldData,
+  address: string,
+): Promise<ManagedProject> {
+  return {
+    id: world.name,
+    displayName: world.name,
+    type: ManagedProjectType.WORLD,
+    role:
+      world.owner?.toLowerCase() === address.toLowerCase()
+        ? WorldRoleType.OWNER
+        : WorldRoleType.COLLABORATOR,
+    // If a world has never been deployed the backend nulls the owner and every other field.
+    deployment: world.owner
+      ? {
+          title: world.title || world.name,
+          description: world.description || '',
+          thumbnail: world.thumbnailHash ? worldsApi.getContentSrcUrl(world.thumbnailHash) : '',
+          lastPublishedAt: world.lastDeployedAt ? new Date(world.lastDeployedAt).getTime() : 0,
+          scenesCount: world.deployedScenes || 0,
+        }
+      : undefined,
+    // Left undefined when the lookup failed, so "we could not ask" stays
+    // distinguishable from "there are none".
+    scenes: world.deployedScenes
+      ? ((await fetchWorldSceneCoords(worldsApi, world.name)) ?? undefined)
+      : [],
+  };
+}
+
+/**
+ * Every world the wallet has deployed to, whoever is asking and whatever the
+ * Manage page is currently showing.
+ *
+ * The Manage page's own list is narrowed by its search box, sort and page, so
+ * anything that needs the whole set has to ask for it separately.
+ */
+export async function fetchAllDeployedWorlds(
+  worldsApi: Worlds,
+  address: string,
+): Promise<ManagedProject[]> {
+  const worlds = await readAllPages(async offset => {
+    const response = await worldsApi.fetchWorlds({
+      has_deployed_scenes: true,
+      authorized_deployer: address,
+      limit: PAGE_LIMIT,
+      offset,
+    });
+    return response && { items: response.worlds, total: response.total };
+  });
+
+  if (!worlds) throw new Error('Failed to fetch worlds');
+
+  const projects = await Promise.all(
+    worlds.map(world => toManagedProject(worldsApi, world, address)),
+  );
+
+  // A world we could not list contributes no scenes, which reads downstream as a
+  // creator who owns fewer than they do. Better to say so than to answer short.
+  const unreadable = projects.filter(project => !project.scenes).map(project => project.id);
+  if (unreadable.length > 0) {
+    throw new Error(`Failed to list the scenes deployed in ${unreadable.join(', ')}`);
+  }
+
+  return projects;
 }
 
 export const getThumbnailUrlFromDeployment = (

--- a/packages/creator-hub/renderer/src/modules/store/management/utils.ts
+++ b/packages/creator-hub/renderer/src/modules/store/management/utils.ts
@@ -85,12 +85,19 @@ export async function fetchWorldSceneCoords(
   }
 }
 
-/** A world as the app models it, with the coordinates of everything deployed in it. */
+/**
+ * A world as the app models it, with the coordinates of everything deployed in it.
+ *
+ * `scenes` is left undefined when the lookup failed, keeping "we could not ask"
+ * distinguishable from "there are none".
+ */
 export async function toManagedProject(
   worldsApi: Worlds,
   world: WorldData,
   address: string,
 ): Promise<ManagedProject> {
+  const hasEverBeenDeployed = Boolean(world.owner);
+
   return {
     id: world.name,
     displayName: world.name,
@@ -99,8 +106,7 @@ export async function toManagedProject(
       world.owner?.toLowerCase() === address.toLowerCase()
         ? WorldRoleType.OWNER
         : WorldRoleType.COLLABORATOR,
-    // If a world has never been deployed the backend nulls the owner and every other field.
-    deployment: world.owner
+    deployment: hasEverBeenDeployed
       ? {
           title: world.title || world.name,
           description: world.description || '',
@@ -109,8 +115,6 @@ export async function toManagedProject(
           scenesCount: world.deployedScenes || 0,
         }
       : undefined,
-    // Left undefined when the lookup failed, so "we could not ask" stays
-    // distinguishable from "there are none".
     scenes: world.deployedScenes
       ? ((await fetchWorldSceneCoords(worldsApi, world.name)) ?? undefined)
       : [],
@@ -123,6 +127,10 @@ export async function toManagedProject(
  *
  * The Manage page's own list is narrowed by its search box, sort and page, so
  * anything that needs the whole set has to ask for it separately.
+ *
+ * Throws rather than answering short: a world whose scenes could not be listed
+ * contributes none, which reads downstream as a creator who owns fewer than
+ * they do.
  */
 export async function fetchAllDeployedWorlds(
   worldsApi: Worlds,
@@ -144,8 +152,6 @@ export async function fetchAllDeployedWorlds(
     worlds.map(world => toManagedProject(worldsApi, world, address)),
   );
 
-  // A world we could not list contributes no scenes, which reads downstream as a
-  // creator who owns fewer than they do. Better to say so than to answer short.
   const unreadable = projects.filter(project => !project.scenes).map(project => project.id);
   if (unreadable.length > 0) {
     throw new Error(`Failed to list the scenes deployed in ${unreadable.join(', ')}`);

--- a/packages/creator-hub/renderer/src/modules/store/placeAnalytics/slice.spec.ts
+++ b/packages/creator-hub/renderer/src/modules/store/placeAnalytics/slice.spec.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MetricsWindow, SortBy } from '../../../../../shared/types/place-analytics';
+import { FilterBy } from '../../../../../shared/types/manage';
 import { AuthServerProvider } from '../../../lib/auth';
 import type { AnalyticsPlace } from '../../../lib/analyticsLocations';
 import type { LocationMetrics } from '../../../lib/metricsApi';
 import { fetchAnalytics as fetchAnalyticsSnapshot } from '../../../lib/placeAnalytics';
 import { createTestStore } from '../../../../tests/utils/testStore';
+import type * as ManagementUtils from '../management/utils';
+import { fetchAllDeployedWorlds } from '../management/utils';
+import { actions as managementActions } from '../management';
 import { actions, fetchAnalytics, initialState, selectors } from './slice';
 
 const TEST_ADDRESS = '0x123abc';
@@ -53,17 +57,27 @@ vi.mock('../../../lib/auth', () => ({
   AuthServerProvider: { getAccount: vi.fn() },
 }));
 
-vi.mock('/@/modules/store/management', async () => {
-  const actual = await import('../management');
+vi.mock('../../../lib/worlds', async () => {
+  const actual = await import('../../../lib/worlds');
+  return { ...actual, Worlds: vi.fn() };
+});
+
+vi.mock('../management/utils', async importOriginal => ({
+  ...(await importOriginal<ManagementUtils>()),
+  fetchAllDeployedWorlds: vi.fn(),
+}));
+
+vi.mock('/@/modules/store/land', async () => {
+  const actual = await import('../land');
   return {
     ...actual,
     // Dispatching an RTK thunk returns a promise carrying `unwrap`, which is
     // what the slice awaits. Defined inline: vi.mock factories are hoisted.
-    fetchAllManagedProjectsData: vi.fn(() => () => {
-      const dispatched = Promise.resolve([]) as Promise<unknown[]> & {
-        unwrap: () => Promise<unknown[]>;
+    fetchLandList: vi.fn(() => () => {
+      const dispatched = Promise.resolve({ land: [] }) as Promise<{ land: unknown[] }> & {
+        unwrap: () => Promise<{ land: unknown[] }>;
       };
-      dispatched.unwrap = () => Promise.resolve([]);
+      dispatched.unwrap = () => Promise.resolve({ land: [] });
       return dispatched;
     }),
   };
@@ -74,12 +88,56 @@ describe('placeAnalytics slice', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fetchAllDeployedWorlds).mockResolvedValue([]);
     store = createTestStore();
+  });
+
+  describe('when the manage page has already narrowed its own list', () => {
+    const OWN_WORLDS = [{ id: 'bananarama.dcl.eth' }] as any;
+
+    beforeEach(() => {
+      vi.mocked(AuthServerProvider.getAccount).mockReturnValue(TEST_ADDRESS);
+      vi.mocked(fetchAnalyticsSnapshot).mockResolvedValue(SNAPSHOT);
+      vi.mocked(fetchAllDeployedWorlds).mockResolvedValue(OWN_WORLDS);
+    });
+
+    it('should build the list from its own worlds fetch, not the manage page state', async () => {
+      store.dispatch(managementActions.setSearchQuery('nothing-matches-this'));
+      store.dispatch(managementActions.setPublishFilter(FilterBy.UNPUBLISHED));
+
+      await store.dispatch(fetchAnalytics());
+
+      expect(fetchAllDeployedWorlds).toHaveBeenCalledWith(expect.anything(), TEST_ADDRESS);
+      expect(fetchAnalyticsSnapshot).toHaveBeenCalledWith(OWN_WORLDS, []);
+    });
+
+    it('should not read a management fetch that is still in flight', async () => {
+      store.dispatch(managementActions.setPage(3));
+
+      await store.dispatch(fetchAnalytics());
+
+      expect(fetchAnalyticsSnapshot).toHaveBeenCalledWith(OWN_WORLDS, []);
+    });
+  });
+
+  describe('when a fetch is already in flight', () => {
+    beforeEach(() => {
+      vi.mocked(AuthServerProvider.getAccount).mockReturnValue(TEST_ADDRESS);
+      vi.mocked(fetchAllDeployedWorlds).mockResolvedValue([]);
+      vi.mocked(fetchAnalyticsSnapshot).mockResolvedValue(SNAPSHOT);
+    });
+
+    it('should not start a second one that could overwrite it with staler data', async () => {
+      await Promise.all([store.dispatch(fetchAnalytics()), store.dispatch(fetchAnalytics())]);
+
+      expect(fetchAnalyticsSnapshot).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('when fetching analytics with a connected account', () => {
     beforeEach(() => {
       vi.mocked(AuthServerProvider.getAccount).mockReturnValue(TEST_ADDRESS);
+      vi.mocked(fetchAllDeployedWorlds).mockResolvedValue([]);
       vi.mocked(fetchAnalyticsSnapshot).mockResolvedValue(SNAPSHOT);
     });
 

--- a/packages/creator-hub/renderer/src/modules/store/placeAnalytics/slice.spec.ts
+++ b/packages/creator-hub/renderer/src/modules/store/placeAnalytics/slice.spec.ts
@@ -69,17 +69,14 @@ vi.mock('../management/utils', async importOriginal => ({
 
 vi.mock('/@/modules/store/land', async () => {
   const actual = await import('../land');
+
+  /** What `dispatch(thunk())` resolves to: a promise that also carries `unwrap`. */
+  const asDispatchedThunk = <T>(value: T) =>
+    Object.assign(Promise.resolve(value), { unwrap: () => Promise.resolve(value) });
+
   return {
     ...actual,
-    // Dispatching an RTK thunk returns a promise carrying `unwrap`, which is
-    // what the slice awaits. Defined inline: vi.mock factories are hoisted.
-    fetchLandList: vi.fn(() => () => {
-      const dispatched = Promise.resolve({ land: [] }) as Promise<{ land: unknown[] }> & {
-        unwrap: () => Promise<{ land: unknown[] }>;
-      };
-      dispatched.unwrap = () => Promise.resolve({ land: [] });
-      return dispatched;
-    }),
+    fetchLandList: vi.fn(() => () => asDispatchedThunk({ land: [] as unknown[] })),
   };
 });
 

--- a/packages/creator-hub/renderer/src/modules/store/placeAnalytics/slice.ts
+++ b/packages/creator-hub/renderer/src/modules/store/placeAnalytics/slice.ts
@@ -8,8 +8,10 @@ import type { AnalyticsPlace } from '/@/lib/analyticsLocations';
 import type { LocationMetrics } from '/@/lib/metricsApi';
 import { toSummary } from '/@/lib/placeAnalytics.adapter';
 import { fetchAnalytics as fetchAnalyticsSnapshot } from '/@/lib/placeAnalytics';
+import { Worlds } from '/@/lib/worlds';
 import type { AppState } from '/@/modules/store';
-import { fetchAllManagedProjectsData } from '/@/modules/store/management';
+import { fetchLandList } from '/@/modules/store/land';
+import { fetchAllDeployedWorlds } from '/@/modules/store/management/utils';
 import { createAsyncThunk } from '/@/modules/store/thunk';
 
 import { sortPlaces } from './utils';
@@ -20,21 +22,30 @@ import { sortPlaces } from './utils';
  * One batched request answers the whole feature — the list and every tab of the
  * detail page — so this is the only thunk. Switching window or opening a scene
  * re-reads the same snapshot rather than fetching again.
+ *
+ * The scenes to ask about are fetched here rather than read out of the
+ * management slice: that slice holds the Manage page's own list, narrowed by its
+ * search box, filter and page, so borrowing it makes this list silently inherit
+ * a view the creator set somewhere else.
  */
 export const fetchAnalytics = createAsyncThunk(
   'placeAnalytics/fetchAnalytics',
-  async (_: void, { dispatch, getState }) => {
+  async (_: void, { dispatch }) => {
     const connectedAccount = AuthServerProvider.getAccount();
     if (!connectedAccount) throw new Error('No connected account found');
 
-    // The scenes to ask about come from the app's own knowledge of what this
-    // wallet holds, which the managed-projects page loads.
-    if (getState().management.status === 'idle') {
-      await dispatch(fetchAllManagedProjectsData({ address: connectedAccount })).unwrap();
-    }
+    const [projects, { land }] = await Promise.all([
+      fetchAllDeployedWorlds(new Worlds(), connectedAccount),
+      dispatch(fetchLandList({ address: connectedAccount })).unwrap(),
+    ]);
 
-    const { management, land } = getState();
-    return fetchAnalyticsSnapshot(management.projects, land.data);
+    return fetchAnalyticsSnapshot(projects, land);
+  },
+  {
+    // A second run would rebuild the list from whatever the store held when it
+    // started, and the slower one wins.
+    condition: (_: void, { getState }) =>
+      (getState() as AppState).placeAnalytics.status !== 'loading',
   },
 );
 

--- a/packages/creator-hub/renderer/src/modules/store/placeAnalytics/slice.ts
+++ b/packages/creator-hub/renderer/src/modules/store/placeAnalytics/slice.ts
@@ -27,6 +27,9 @@ import { sortPlaces } from './utils';
  * management slice: that slice holds the Manage page's own list, narrowed by its
  * search box, filter and page, so borrowing it makes this list silently inherit
  * a view the creator set somewhere else.
+ *
+ * Skipped while one is already running: a second run would rebuild the list from
+ * whatever the store held when it started, and the slower one wins.
  */
 export const fetchAnalytics = createAsyncThunk(
   'placeAnalytics/fetchAnalytics',
@@ -42,8 +45,6 @@ export const fetchAnalytics = createAsyncThunk(
     return fetchAnalyticsSnapshot(projects, land);
   },
   {
-    // A second run would rebuild the list from whatever the store held when it
-    // started, and the slower one wins.
     condition: (_: void, { getState }) =>
       (getState() as AppState).placeAnalytics.status !== 'loading',
   },

--- a/packages/creator-hub/shared/tests/utils.spec.ts
+++ b/packages/creator-hub/shared/tests/utils.spec.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { debounce, debounceByKey, isValidFolderName, getBaseName } from '../utils';
+import { debounce, debounceByKey, isValidFolderName, getBaseName, retry } from '../utils';
 
 describe('isValidFolderName', () => {
   it('should accept a normal name', () => {
@@ -181,5 +181,41 @@ describe('debounceByKey', () => {
     // Should have executed only the last call
     expect(mockFn).toHaveBeenCalledTimes(1);
     expect(mockFn).toHaveBeenLastCalledWith('a');
+  });
+});
+
+describe('retry', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('when the first attempt fails', () => {
+    it('should answer with the next one, since a timeout says nothing about it', async () => {
+      const attempt = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('REQUEST_TIMEOUT'))
+        .mockResolvedValue('ok');
+
+      expect(await retry(attempt, 2, 0)).toBe('ok');
+      expect(attempt).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('when every attempt fails', () => {
+    it('should let the last failure through rather than swallowing it', async () => {
+      const attempt = vi.fn().mockRejectedValue(new Error('gone'));
+
+      await expect(retry(attempt, 3, 0)).rejects.toThrow('gone');
+      expect(attempt).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('when the first attempt succeeds', () => {
+    it('should not try again', async () => {
+      const attempt = vi.fn().mockResolvedValue('ok');
+
+      expect(await retry(attempt, 3, 0)).toBe('ok');
+      expect(attempt).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/creator-hub/shared/utils.ts
+++ b/packages/creator-hub/shared/utils.ts
@@ -88,6 +88,23 @@ export const chunk = <T>(items: T[], size: number): T[][] =>
     items.slice(index * size, index * size + size),
   );
 
+/**
+ * Runs `attempt` again after a pause if it throws, and lets the last failure through.
+ *
+ * For reads across the internet, where a timeout or a 5xx says nothing about
+ * whether the next call will work.
+ */
+export async function retry<T>(attempt: () => Promise<T>, attempts = 2, pauseMs = 500): Promise<T> {
+  for (let remaining = attempts - 1; ; remaining--) {
+    try {
+      return await attempt();
+    } catch (error) {
+      if (remaining <= 0) throw error;
+      await delay(pauseMs);
+    }
+  }
+}
+
 export function debounce<F extends (...args: any[]) => void>(func: F, delay: number) {
   let timer: ReturnType<typeof setTimeout>;
   return function (...args: Parameters<F>) {


### PR DESCRIPTION
## Context and Problem Statement

Since the Analytics page shipped (#1447), the list of deployed scenes sometimes
showed everything and sometimes a subset, with no error and no way to tell which
had happened. Which scenes went missing varied between loads.

The list was assembled from Redux state the page did not own, through a
discovery path where **every** failure degraded into a missing row rather than an
error. Seven distinct paths could shrink it:

1. `management.projects` is the **Manage page's** result set, narrowed by its
   search box, `publishFilter` and page. Leaving Manage on `UNPUBLISHED` and
   opening Analytics rendered no world rows at all; a leftover search term
   narrowed it; `PROJECTS_PAGE_LIMIT` capped it at 50 worlds.
2. The `if (management.status === 'idle')` guard did not wait for an in-flight
   load. `AuthProvider` dispatches `fetchAllManagedProjectsData` in the same
   render pass that flips `isSignedIn`, so the thunk regularly fell through, read
   `[]`, and cached an empty snapshot as `succeeded` — indistinguishable from
   "you have no Places yet".
3. `land.data` was read with no readiness check, and `fetchLandList` is
   dispatched from exactly one place — inside the thunk skipped by (2). Every
   Genesis City scene could vanish while world rows still rendered.
4. `fetchWorldSceneCoords` caught everything and returned `[]`, which reads as
   "no scenes", so a world whose lookup failed contributed zero rows. One
   request per world at `pLimit(6)`, so a different subset dropped each run.
5. `fetchLandPublishedScenes` skipped a failed pointer chunk in a bare `catch`,
   losing up to 100 parcels' scenes silently.
6. `fetchWorldScenes` was never paginated past its undeclared 100-scene page.
7. Duplicate `placeId`s collapsed in `metricsByPlaceId`, and `getVisiblePlaces`
   dropped any place missing from it — surfacing as "no results for your search".

The metrics transport was **not** at fault and is unchanged: it already throws on
a request/response length mismatch and uses `Promise.all`, so it fails loud.

## Solution

Two themes: make the page own its inputs, and make every silent drop loud.

Causes 1–3 looked like three bugs but shared one root — the thunk borrowed Redux
state it did not own. Having it fetch its own worlds and LAND removes all three
along with the status guard and the conditional `await`, leaving the slice
smaller than before.

Key changes:
- `fetchAllDeployedWorlds` fetches the wallet's worlds unfiltered (no `search`,
  no `sort`) and pages through `total`, replacing the borrowed 50-world window.
- The thunk dispatches `fetchLandList` itself and no longer reads
  `management.status` or `land.data`.
- `fetchWorldSceneCoords` answers `null` on failure vs `[]` for "none"; the
  analytics path throws naming the world it could not list.
- `fetchLandPublishedScenes` runs chunks concurrently, retries once and throws.
  It also sends `Content-Type: application/json` and allows 30s — measured, a
  cold 100-pointer batch takes ~1.2s but the inherited default was 5s.
- One `readAllPages` helper paginates both endpoints. Verified against the live
  services: `GET /world/{name}/scenes` is a real cursor (stable `total`, no gaps,
  empty past the end), while `POST /content/entities/active` ignores
  `limit`/`offset` entirely — it is pointer resolution, not a listing, so its
  chunk size is a request-size guard rather than a page size.
- Places are deduped by location, and the `sceneBase` fallback sorts coordinates
  numerically instead of as strings, where `"10,0"` preceded `"9,0"`.
- The thunk takes a `condition`, so a remount cannot start a second run that
  rebuilds from staler state and wins the race.
- A small shared `retry` helper backs the two discovery paths.

The second commit is docs only: `docs/testing-standards.md` becomes the single
testing doc (how to write a test plus every testing gotcha), CLAUDE.md keeps the
pointer, and the runtime traps that were filed under a "Testing" heading move to
`## Gotchas`.

## Testing

- [x] Unit — 504 creator-hub tests pass (main 109, preload 63, renderer 296, shared 36); full monorepo 1438 with inspector and asset-packs.
- [x] Both new specs proven to fail against the original code: `management/utils.spec.ts` failed 7/8 and `land.spec.ts` failed 5/7, including `promise resolved "[]" instead of rejecting` — the silent shrink itself.
- [x] Manage-page bleed — the list is identical whether `management` is `idle`, `loading`, `succeeded` with a `searchQuery`, or `succeeded` with `publishFilter: UNPUBLISHED`.
- [x] Edge cases — world with >100 scenes; failed scene lookup distinguishable from "no scenes"; non-`ok` and timed-out pointer chunks retried then reported; two scenes sharing a coordinate; `sceneBase` picking the numerically lowest parcel.
- [x] Race — overlapping dispatches produce exactly one fetch.
- [x] Regression — typecheck clean across all workspaces; lint and prettier clean.
- [ ] Manual in the packaged app with a multi-world wallet: Manage (with a search term) → Analytics, and Manage → Analytics before Manage finishes loading. Both should show the same full list, stable across reloads.

## Impact

Creators see every deployed scene on Analytics rather than a varying subset. A
discovery failure now surfaces as an error naming what could not be read,
instead of a short list that looks complete — the more useful answer, and
consistent with how the metrics half already behaved.

Worth watching: Analytics now fetches worlds and LAND on each visit rather than
reusing the Manage page's data. That is more requests for a wallet with many
worlds, bounded by the new in-flight `condition`.

## Screenshots

N/A — no visual change; the same list renders, with the missing rows present.
