### PR TITLE
fix: publish to World confirm button stuck disabled in Bevy editor

### DIFF
--- a/packages/creator-hub/renderer/src/components/Modals/PublishProject/steps/PublishToWorld/component.tsx
+++ b/packages/creator-hub/renderer/src/components/Modals/PublishProject/steps/PublishToWorld/component.tsx
@@ -327,8 +327,12 @@ function SelectWorld({
     }
   }, [project, name, isMultiSceneEnabled, worldSettings.scenes, onPublish, onSelectLocation]);
 
-  // TODO: handle failed state...
-  const projectIsReady = project.status === 'succeeded';
+  // Only an in-flight thumbnail save blocks publishing (so the deploy doesn't
+  // race the file write). `status` stays undefined when no thumbnail was ever
+  // captured — the Bevy renderer's screenshot is best-effort and may never
+  // dispatch the save — and a failed save is likewise no reason to block:
+  // the thumbnail is decorative, the deploy works without it.
+  const projectIsReady = project.status !== 'loading';
 
   return (
     <div className="SelectWorld">


### PR DESCRIPTION
## Problem

When editing a scene with the **Bevy editor**, publishing to a World is impossible: after selecting a world name from the dropdown, the confirm button stays grayed out forever. The same scene publishes fine from the Babylon editor.

## Root cause

When Publish is clicked, the editor fire-and-forgets a "save scene thumbnail" flow: it requests a screenshot from the renderer over the scene RPC, and **only if a screenshot comes back** does it dispatch `workspace/saveAndGetThumbnail` — the thunk whose lifecycle sets `project.status` to `loading` → `succeeded`/`failed`.

The World step's confirm button required `project.status === 'succeeded'`:

- **Babylon**: the canvas screenshot succeeds quickly → status becomes `succeeded` → button enables.
- **Bevy**: the screenshot is best-effort (it goes through the engine's `/screenshot` console command, and the host explicitly treats a rejection as "no thumbnail, non-fatal"). When it fails, the save thunk is never dispatched, `project.status` stays `undefined` forever, and the button never enables — with no error surfaced anywhere.

The `status === 'succeeded'` gate is a leftover: it originally guarded a thumbnail preview image inside the publish modal (loader until the screenshot arrived, #279). That preview was removed in the multi-scene redesign (#1089), but the gate stayed attached to the button — silently turning a decorative thumbnail failure into a publish blocker. It even carried a `// TODO: handle failed state...`.

## Fix

Only block the button while a thumbnail save is actually **in flight** (`status === 'loading'`), so the deploy doesn't race the thumbnail file write. Both `undefined` (thumbnail never attempted — the normal Bevy case) and `failed` now allow publishing, since the deploy works fine without a fresh thumbnail.

Babylon behavior is unchanged: the button just briefly disables during the save, then enables.

## Notes

- The world may still show a stale/missing thumbnail after publishing from the Bevy editor when the engine bundle doesn't answer `/screenshot` — that's a separate, cosmetic issue; publishing is no longer held hostage by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
