### PR TITLE
chore: remove Legacy Web Editor card and update Names link in More tab

### DIFF
--- a/packages/creator-hub/renderer/src/components/MorePage/component.tsx
+++ b/packages/creator-hub/renderer/src/components/MorePage/component.tsx
@@ -7,7 +7,6 @@ import { misc } from '#preload';
 import { t } from '/@/modules/store/translation/utils';
 import { SUBMIT_EVENT_URL } from '/@/modules/utils';
 
-import EditorPng from '/assets/images/editor.png';
 import CollectionsPng from '/assets/images/collections.png';
 import NamesPng from '/assets/images/names.png';
 import LandPng from '/assets/images/land.png';
@@ -18,6 +17,7 @@ import { Navbar, NavbarItem } from '../Navbar';
 import './styles.css';
 
 const BUILDER_URL = 'https://decentraland.org/builder';
+const NAMES_URL = 'https://decentraland.org/shop/items?category=names';
 
 const HorizontalCardWithImage: React.FC<{
   className?: string;
@@ -92,21 +92,6 @@ export function MorePage() {
             lg={4}
           >
             <HorizontalCardWithImage
-              className="FlipImage"
-              title={t('more.cards.create.legacy_web_editor.title')}
-              description={t('more.cards.create.legacy_web_editor.description')}
-              action={() => misc.openExternal(`${BUILDER_URL}/scenes`)}
-              image={EditorPng}
-            />
-          </Grid>
-          <Grid
-            item
-            xs={12}
-            sm={6}
-            md={6}
-            lg={4}
-          >
-            <HorizontalCardWithImage
               title={t('more.cards.create.collections.title')}
               description={t('more.cards.create.collections.description')}
               action={() => misc.openExternal(`${BUILDER_URL}/collections`)}
@@ -135,7 +120,7 @@ export function MorePage() {
             <HorizontalCardWithImage
               title={t('more.cards.manage.names.title')}
               description={t('more.cards.manage.names.description')}
-              action={() => misc.openExternal(`${BUILDER_URL}/names`)}
+              action={() => misc.openExternal(NAMES_URL)}
               image={NamesPng}
             />
           </Grid>

--- a/packages/creator-hub/renderer/src/components/MorePage/styles.css
+++ b/packages/creator-hub/renderer/src/components/MorePage/styles.css
@@ -32,10 +32,6 @@
   object-fit: contain;
 }
 
-.MorePage .HorizontalCardWithImage.FlipImage .CardImage img {
-  transform: scaleX(-1);
-}
-
 .MorePage .HorizontalCardWithImage .CardContent {
   display: flex;
   flex-direction: column;

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/en.json
@@ -791,10 +791,6 @@
           "title": "Submit Event",
           "description": "Host your own event on Decentraland."
         },
-        "legacy_web_editor": {
-          "title": "Legacy Web Editor",
-          "description": "Access the old web editor to continue working on your scenes."
-        },
         "collections": {
           "title": "Collections",
           "description": "Create, review and publish your collections of Wearables and Emotes."

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/es.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/es.json
@@ -791,10 +791,6 @@
           "title": "Enviar Evento",
           "description": "Organiza tu propio evento en Decentraland."
         },
-        "legacy_web_editor": {
-          "title": "Editor Web Clásico",
-          "description": "Accede al editor web antiguo para continuar trabajando en tus escenas."
-        },
         "collections": {
           "title": "Colecciones",
           "description": "Crea, revisa y publica tus colecciones de Vestimentas y Animaciones."

--- a/packages/creator-hub/renderer/src/modules/store/translation/locales/zh.json
+++ b/packages/creator-hub/renderer/src/modules/store/translation/locales/zh.json
@@ -791,10 +791,6 @@
           "title": "提交事件",
           "description": "在 Decentraland 上舉辦您自己的活動。"
         },
-        "legacy_web_editor": {
-          "title": "旧版网页编辑器",
-          "description": "访问旧版网页编辑器继续编辑你的场景。"
-        },
         "collections": {
           "title": "收藏",
           "description": "创建、审核并发布你的可穿戴设备和表情收藏。"


### PR DESCRIPTION
## What

Updates the "More" tab in the Creator Hub:

- **Removes the Legacy Web Editor card** — no longer relevant. Also removes its now-unused `EditorPng` import, the `FlipImage` CSS rule only that card used, and the `legacy_web_editor` translation entries from all three locales (en/es/zh). The `editor.png` asset stays since the Editor and Sign In pages still use it.
- **Updates the Names card link** to point to the marketplace shop: https://decentraland.org/shop/items?category=names (previously `decentraland.org/builder/names`).

The Create section now shows two cards (Submit Event, Collections); Manage keeps Names and Land.

## Testing

- `npm run typecheck` passes for main/preload/renderer.
- No tests reference the removed card or translation keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)