### PR TITLE
fix: poll the rootCID that was actually deployed after a catalyst retry

### DIFF
--- a/packages/creator-hub/renderer/src/modules/store/deployment/slice.spec.ts
+++ b/packages/creator-hub/renderer/src/modules/store/deployment/slice.spec.ts
@@ -44,12 +44,13 @@ vi.mock('./utils', async () => {
     getDeploymentUrl: vi.fn((port: number) => `http://localhost:${port}/api`),
     deploy: vi.fn().mockResolvedValue(undefined),
     checkDeploymentStatus: vi.fn(),
+    fetchDeploymentStatus: vi.fn().mockResolvedValue({}),
     fetchFiles: vi.fn().mockResolvedValue([]),
     fetchInfo: vi.fn().mockResolvedValue({}),
   };
 });
 
-import { deploy, checkDeploymentStatus, fetchInfo } from './utils';
+import { deploy, checkDeploymentStatus, fetchDeploymentStatus, fetchInfo } from './utils';
 
 describe('deployment slice', () => {
   let store: ReturnType<typeof createTestStore>;
@@ -430,6 +431,48 @@ describe('deployment slice', () => {
 
         const deployment = store.getState().deployment.deployments[TEST_PATH];
         expect(deployment?.createdAt).toBe(initialCreatedAt);
+      });
+    });
+
+    describe('when a retry rebuilds the scene under a new rootCID', () => {
+      const REBUILT_SCENE_INFO = { ...TEST_SCENE_INFO, rootCID: 'QmRebuilt456' };
+
+      beforeEach(async () => {
+        vi.useFakeTimers();
+        store = await initDeploymentStore();
+        // Retrying against another catalyst respawns the CLI server, which rebuilds the
+        // scene and produces a different rootCID than the one we started with.
+        vi.mocked(fetchInfo).mockResolvedValue(REBUILT_SCENE_INFO);
+        mockDeployWithRetryOnce();
+        mockCheckStatus();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('should poll the status of the rootCID that was actually deployed', async () => {
+        const resultPromise = store.dispatch(executeDeployment(TEST_PATH));
+        await advanceRetryTimers(1);
+        await resultPromise.unwrap();
+
+        // checkDeploymentStatus receives fetchStatus as its 3rd arg; invoking it reveals
+        // which entity the poller is asking the asset-bundle-registry about.
+        const fetchStatus = vi.mocked(checkDeploymentStatus).mock.calls[0][2];
+        await fetchStatus();
+
+        expect(vi.mocked(fetchDeploymentStatus)).toHaveBeenCalledWith(
+          expect.objectContaining({ rootCID: REBUILT_SCENE_INFO.rootCID }),
+          expect.anything(),
+        );
+      });
+
+      it('should return the rebuilt info rather than the initial one', async () => {
+        const resultPromise = store.dispatch(executeDeployment(TEST_PATH));
+        await advanceRetryTimers(1);
+        const result = await resultPromise.unwrap();
+
+        expect(result.info.rootCID).toBe(REBUILT_SCENE_INFO.rootCID);
       });
     });
 

--- a/packages/creator-hub/renderer/src/modules/store/deployment/slice.ts
+++ b/packages/creator-hub/renderer/src/modules/store/deployment/slice.ts
@@ -138,7 +138,10 @@ export const deploy = createAsyncThunk(
     while (retries > 0) {
       try {
         const authChain = Authenticator.signPayload(identity, currentInfo.rootCID);
-        return await deployFn(currentUrl, { address: wallet, authChain, chainId });
+        await deployFn(currentUrl, { address: wallet, authChain, chainId });
+        // Retrying against another catalyst rebuilds the scene and yields a new rootCID,
+        // so the caller must poll the status of the entity that actually got deployed.
+        return { info: currentInfo };
       } catch (error: any) {
         retries--;
 
@@ -191,6 +194,15 @@ export const deploy = createAsyncThunk(
         currentInfo = result.info;
       }
     }
+
+    // Unreachable in practice, but returning undefined here would fulfill the thunk and leave
+    // the caller polling a deployment that never happened.
+    return rejectWithValue(
+      new DeploymentError(
+        'CATALYST_SERVERS_EXHAUSTED',
+        getState().deployment.deployments[path]?.componentsStatus ?? getInitialDeploymentStatus(),
+      ),
+    );
   },
 );
 
@@ -205,7 +217,7 @@ export const executeDeployment = createAsyncThunk(
       );
     }
 
-    const { info, id: deploymentId, wallet } = deployment;
+    const { id: deploymentId, wallet } = deployment;
 
     const hasValidIdentity = AuthServerProvider.hasValidIdentity();
     const identity = localStorageGetIdentity(wallet);
@@ -221,7 +233,9 @@ export const executeDeployment = createAsyncThunk(
     }
 
     try {
-      await dispatch(deploy({ identity, deployment })).unwrap();
+      // Retries against alternative catalysts rebuild the scene, so the deployed entity may
+      // no longer be the one we started with. Poll the rootCID that actually got deployed.
+      const { info } = await dispatch(deploy({ identity, deployment })).unwrap();
 
       const fetchStatus = () => fetchDeploymentStatus(info, identity);
       let isCancelled = false;


### PR DESCRIPTION
## Problem

Publishing a scene to LAND could sit in "Publishing..." indefinitely — the upload step never ticked over to success, and no error was ever shown. The scene *was* actually live in-world the whole time.

Repro: publish to LAND when the first catalyst rejects the upload. In the observed case the initial `/deploy` returned `400 { message: "Could not upload content: <html>...404 Not Found..." }` from `peer.decentral.io`, then again from `peer-ap1.decentraland.org`, and finally succeeded on `peer.uadevops.com`.

## Cause

When a `/deploy` attempt fails, the `deploy` thunk selects another catalyst and dispatches `updateDeploymentTarget`, which respawns the CLI deploy server and rebuilds the scene. That rebuild is not byte-identical (autogenerated thumbnail, build outputs), so each retry yields a **different rootCID**:

| attempt | target | rootCID |
|---|---|---|
| 1 | (initial) | `bafkreib3uzdc…vfjqzy` |
| 2 | peer-ap1 | `bafkreidveasa…ov7ju` |
| 3 ✅ | peer.uadevops.com | `bafkreigie7tx…kliry` |

The thunk tracked the new info internally via `currentInfo`, but returned `deployFn`'s result — which is `void` — so it never reported which entity actually landed.

Meanwhile `executeDeployment` destructured `info` from the deployment *before* dispatching the deploy, and its `fetchStatus` closure captured that stale value. After the successful third attempt it polled the asset-bundle-registry for the **attempt-1** rootCID — an entity never deployed anywhere — and got a 404 forever.

Why it hung rather than failing: `checkDeploymentStatus` treats a throwing `fetchStatus` as a soft retry, so `componentsStatus` stayed at all-`idle`. `deriveOverallStatus` of all-idle is `'idle'`, never `'failed'`, so `isCancelled` never flipped and the abort path never fired. It burned all 360 retries × 10s — a full hour — before surfacing `MAX_RETRIES`.

## Fix

- `deploy` returns `{ info: currentInfo }` on success, so callers know which entity actually deployed.
- `executeDeployment` consumes that returned `info` for `fetchStatus` and the fulfilled payload. `info` is dropped from the pre-deploy destructure so the stale value is unreachable rather than merely unused.
- Closes a fall-through at the end of the retry loop: exiting the `while` without deploying returned `undefined` and *fulfilled* the thunk, sending the caller off to poll a deployment that never happened. It now rejects with `CATALYST_SERVERS_EXHAUSTED`.

The deploy thunk is the right seam — it is the only place that knows which catalyst attempt succeeded, and it already tracked the correct info; it just wasn't handing it back.

## Tests

Added a `when a retry rebuilds the scene under a new rootCID` block with two cases: one asserting the poller queries the deployed rootCID, one asserting the returned `info` is the rebuilt one.

The existing retry tests could not catch this — `fetchInfo` was mocked to return the same info on every call, so the CID never changed and the stale capture was indistinguishable from the correct one.

Verified these are genuine regression tests by reintroducing the bug: both fail with `expected 'QmTest123' to be 'QmRebuilt456'`, then pass once reverted.

Full creator-hub unit suite passes (185/185: main 28, preload 17, renderer 127, shared 13). Typecheck and ESLint clean.

Not addressed here: the upstream reason catalysts return `404 Not Found` on upload is server-side and outside this repo. This fix means a successful retry now completes correctly instead of hanging. Separately worth considering — a prolonged registry 404 still consumes the full 60-minute retry window before surfacing; escalating earlier would be a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)